### PR TITLE
feat(ai-gateway-api): provider/model prefix routing support

### DIFF
--- a/design-docs/api-define/InnerAPI接口定义/server-data-conf.md
+++ b/design-docs/api-define/InnerAPI接口定义/server-data-conf.md
@@ -155,6 +155,8 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/tls_conf/server_data_co
                         "RetryBackoffInitial": 500,
                         "RetryBackoffMax": 5000
                     },
+                    "MatchPrefix": "deepseek/",
+                    "StripPrefix": true,
                     "ModelTable": {
                         "Models": [
                             {
@@ -197,6 +199,8 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/tls_conf/server_data_co
 | KeyPolicy.MaxRetries | int | 请求内总额外重试次数 |
 | KeyPolicy.RetryBackoffInitial | int | 初始退避时间，单位毫秒 |
 | KeyPolicy.RetryBackoffMax | int | 最大退避时间，单位毫秒 |
+| MatchPrefix | string | 需要匹配的 provider/model 前缀；对应 OpenAPI `llm_config.match_prefix` |
+| StripPrefix | bool | 是否裁剪 `MatchPrefix` 前缀；对应 OpenAPI `llm_config.strip_prefix` |
 | ModelTable | object | 该 cluster 的成本定价表；无 `Currency` 字段 |
 | ModelTable.Models | array | 模型定价条目列表 |
 | ModelTable.Models[].Provider | string | Provider 名 |

--- a/design-docs/api-define/OpenAPI接口定义/clusters.md
+++ b/design-docs/api-define/OpenAPI接口定义/clusters.md
@@ -77,7 +77,9 @@
             "retry_backoff_max": 5000
         },
         "provider_type": "deepseek",
-        "provider": "deepseek"
+        "provider": "deepseek",
+        "match_prefix": "deepseek/",
+        "strip_prefix": true
     }
 }
 ```
@@ -155,6 +157,8 @@
 | key_policy| object |  Key 路由策略 | N | 多 Key 时的选择策略、重试与退避配置 | 非必填；默认见下方 表：Key 路由策略；`strategy` 本版仅支持 `weighted_random` |
 | provider_type| string |  AI模型提供商类型 | N | 取值如：deepseek、openai、qwen 等。数据来自 `/model-provider-types` | 非必填；若传入，须为 `/model-provider-types` 中已存在的类型 |
 | provider| string |  该 cluster 在 `model_prices` 中对应的 provider | N | 用于 InnerAPI 自动填充 `AIConf.ModelTable`；为空时 `ModelTable` 为空列表 | 非必填；默认空字符串；OpenAPI 可读写 |
+| match_prefix| string |  需要匹配的 provider/model 前缀 | N | 例如 `openrouter/`；用于 OpenRouter 等聚合 provider 场景；必须以 `/` 结尾 | 非必填；`strip_prefix=true` 时必填 |
+| strip_prefix| bool |  是否裁剪 `match_prefix` 指定前缀 | N | `true` 时转发给下游前会从请求 `model` 字段中去掉该前缀；`false` 时仅用于路由标识，不裁剪 | 非必填；默认 `false` |
 
 > **说明**：`model_endpoint.headers` 中的 `${API_KEY}` 占位符，当 `keys` 非空时由当前选中的 Key 替换；当 `keys` 为空时，不允许出现该占位符，否则在校验阶段返回 `422`。
 >
@@ -213,6 +217,9 @@
 - `llm_config.model_endpoint.headers` 中若包含 `${API_KEY}` 占位符，则 `keys` 不能为空，否则返回 `422`。
 - `llm_config.provider_type` 若传入，须为 `/model-provider-types` 中已存在的类型。
 - `llm_config.provider` 若传入，表示该 cluster 在 `model_prices` 中对应的 provider；为空时 InnerAPI 下发的 `AIConf.ModelTable` 为空列表。
+- `llm_config.match_prefix` / `strip_prefix`：
+  - `strip_prefix=true` 时，`match_prefix` 必填且非空；
+  - `match_prefix` 若传入，必须以 `/` 结尾。
 - `llm_config.model_table` 不在 OpenAPI `/clusters` 端点中展示，调用方传入时忽略或返回 `422`；该字段由 InnerAPI 根据 `provider` 自动填充后下发给 BFE。
 - `basic`、`sticky_sessions`、`passive_health_check` 若未传则使用 AI 网关场景默认值。
 - `basic.protocol` 有效值为 `http`、`https`。

--- a/design-docs/sys-design/details/InnerAPI配置导出与版本控制.md
+++ b/design-docs/sys-design/details/InnerAPI配置导出与版本控制.md
@@ -128,9 +128,9 @@ type RouteRuleExportData struct {
 
 其中 `RouteTable` 包含产品级高级路由规则（来自 `route_advance_rules`），`ClusterConf` 包含集群转发参数。
 
-> 说明：当管理面 Cluster 配置了 `llm_config` 时，导出后的 `ClusterConf.Config.<cluster_name>.AIConf` 会包含模型映射、认证密钥与模型定价表，供 BFE 侧 AI 转发模块使用。`AIConf` 由 `llm_config.models`/`model_mappings`/`keys`/`key_policy`/`provider` 转换而来，字段位置为 `ClusterConf.Config.<cluster_name>.AIConf`。
+> 说明：当管理面 Cluster 配置了 `llm_config` 时，导出后的 `ClusterConf.Config.<cluster_name>.AIConf` 会包含模型映射、认证密钥、模型定价表以及前缀路由裁剪开关，供 BFE 侧 AI 转发模块使用。`AIConf` 由 `llm_config.models`/`model_mappings`/`keys`/`key_policy`/`provider`/`match_prefix`/`strip_prefix` 转换而来，字段位置为 `ClusterConf.Config.<cluster_name>.AIConf`。
 >
-> `AIConf.Provider` 对应 OpenAPI `llm_config.provider`，用于关联 `model_prices` 表；`AIConf.ModelTable` 由 InnerAPI 根据 `Provider` 查询 `model_prices` 自动填充，不在 OpenAPI `/clusters` 端点中展示。`model_prices` 变更后不会同步触发 InnerAPI 推送，BFE/Conf Agent 按自身周期拉取配置并热加载。
+> `AIConf.Provider` 对应 OpenAPI `llm_config.provider`，用于关联 `model_prices` 表；`AIConf.ModelTable` 由 InnerAPI 根据 `Provider` 查询 `model_prices` 自动填充，不在 OpenAPI `/clusters` 端点中展示。`AIConf.MatchPrefix`/`StripPrefix` 对应 OpenAPI `llm_config.match_prefix`/`strip_prefix`，由 BFE 在转发前决定是否裁剪请求 `model` 字段前缀。`model_prices` 变更后不会同步触发 InnerAPI 推送，BFE/Conf Agent 按自身周期拉取配置并热加载。
 
 ### 4.2 GSLB（`/configs/gslb_data/gslb`）
 

--- a/design-docs/sys-design/details/路由规则管理.md
+++ b/design-docs/sys-design/details/路由规则管理.md
@@ -75,6 +75,7 @@ func BuildAIRouteCond(ctx context.Context, basicInfo *BasicInfo) string
 | Header 精确 | `req_header_value_in("X-Model", "gpt-4", true)` |
 | Header 后缀 | `req_header_value_suffix_in("X-Model", "-4", true)` |
 | 请求体 JSON | `req_body_json_in("model", "gpt-4", true)` |
+| 请求体 JSON 前缀 | `req_body_json_prefix_in("model", "openrouter/", false)` |
 
 多个条件通过 `&&` 组合。
 

--- a/design-docs/sys-design/总体设计文档.md
+++ b/design-docs/sys-design/总体设计文档.md
@@ -38,11 +38,11 @@ AI 网关整体由以下核心组件构成：
 - **AI 网关实例池管理（`/alb-pool`）**：获取和更新默认 AI 网关实例池。
 - **认证授权管理（`/auth`）**：用户、Session Key、Token；Token Scope 仅保留 `System`/`Support`，移除产品线授权。
 - **证书管理（`/certificates`）**：证书创建、列表、详情、设置默认证书、删除；创建/更新时仅需上传证书与密钥内容，`expired_date` 由服务端从证书中解析，不再要求上传文件名。
-- **集群管理（`/clusters`）**：集群一键创建、查询、更新、删除；支持 `llm_config`（含 `models`、`model_mappings`、`keys` 多 API-Key 数组、`key_policy` Key 路由策略、`provider` 等）用于 AI 模型转发；集群就绪状态、子集群、调度矩阵等内部概念不再对外暴露；`llm_config.provider` 用于 InnerAPI 自动填充 `AIConf.ModelTable`。
+- **集群管理（`/clusters`）**：集群一键创建、查询、更新、删除；支持 `llm_config`（含 `models`、`model_mappings`、`keys` 多 API-Key 数组、`key_policy` Key 路由策略、`provider`、`match_prefix`/`strip_prefix` 前缀路由裁剪开关等）用于 AI 模型转发；集群就绪状态、子集群、调度矩阵等内部概念不再对外暴露；`llm_config.provider` 用于 InnerAPI 自动填充 `AIConf.ModelTable`。
 - **模型定价管理（`/model-prices`）**：导入 `model-list.yaml`、单条 CRUD、分页查询；为 RMB 配额与 BFE 成本核算提供统一模型定价数据源。
 - **模型提供商类型（`/model-provider-types`）**：查询系统支持的 AI 模型提供商类型。
 - **工具接口（`/tools/get-models-from-provider`）**：从指定提供商代理拉取模型列表。
-- **配置导出（InnerAPI）**：向 BFE/Conf Agent 导出 TLS/Server/路由、GSLB、证书、附加文件、API-Key、请求体处理、限流策略、AI 路由等配置；`server_data_conf` 中 `ClusterConf.Config.<cluster_name>.AIConf` 新增 `Provider` 与 `ModelTable`。
+- **配置导出（InnerAPI）**：向 BFE/Conf Agent 导出 TLS/Server/路由、GSLB、证书、附加文件、API-Key、请求体处理、限流策略、AI 路由等配置；`server_data_conf` 中 `ClusterConf.Config.<cluster_name>.AIConf` 新增 `Provider`、`ModelTable`、`MatchPrefix` 与 `StripPrefix`。
 
 ---
 
@@ -285,7 +285,7 @@ ai-gateway-api/
 |--------|----------|
 | `model/iauth` | 用户/Token 认证、产品线授权、Feature-Action 权限定义 |
 | `model/ibasic` | Product、BFECluster、ExtraFile 业务逻辑 |
-| `model/icluster_conf` | Cluster、SubCluster、Pool、API-Key 业务逻辑；`LLMConfig` 新增 `provider`，导出 `AIConf` 时填充 `Provider` 与 `ModelTable` |
+| `model/icluster_conf` | Cluster、SubCluster、Pool、API-Key 业务逻辑；`LLMConfig` 新增 `provider`、`match_prefix`、`strip_prefix`，导出 `AIConf` 时填充 `Provider`、`ModelTable`、`MatchPrefix` 与 `StripPrefix` |
 | `model/imodel_price` | `ModelPrice` 模型定价管理：`model-list.yaml` 导入、单条 CRUD、分页查询、按 provider 查询 |
 | `model/iroute_conf` | 基础/高级路由规则、Domain 业务逻辑 |
 | `model/iai_route` | AI 路由规则模型与校验 |

--- a/design-docs/sys-design/模型层设计文档.md
+++ b/design-docs/sys-design/模型层设计文档.md
@@ -548,7 +548,9 @@ Cluster 对外模型与存储模型解耦，不再暴露 `ready`、`sub_clusters
             "retry_backoff_initial": 500,
             "retry_backoff_max": 5000
         },
-        "provider_type": "deepseek"
+        "provider_type": "deepseek",
+        "match_prefix": "openrouter/",
+        "strip_prefix": true
     }
 }
 ```
@@ -574,6 +576,7 @@ Cluster 对外模型与存储模型解耦，不再暴露 `ready`、`sub_clusters
 | `llm_config.model_endpoint` | 改为选填，默认 `https`/`/v1/models` |
 | `llm_config.model_mappings[].key/value` | 重命名为 `source_model` / `target_model` |
 | `llm_config.key` | **删除**；替换为 `llm_config.keys`（多 API-Key 数组）+ `llm_config.key_policy`（Key 路由策略） |
+| `llm_config.match_prefix` / `strip_prefix` | 新增：用于 OpenRouter 等聚合 provider 场景，按前缀匹配并决定是否裁剪请求 `model` 字段前缀 |
 
 创建集群时，`basic`、`sticky_sessions`、`passive_health_check` 改为可选；`llm_config` 改为必填。
 
@@ -603,6 +606,8 @@ type LLMConfig struct {
     KeyPolicy      *KeyPolicy       `json:"key_policy"`    // 新增
     ProviderType   *string          `json:"provider_type"`
     Provider       *string          `json:"provider"`      // 新增：对应 model_prices.provider，用于 InnerAPI 自动填充 AIConf.ModelTable
+    MatchPrefix    *string          `json:"match_prefix"`  // 新增：需要匹配的 provider/model 前缀，必须以 "/" 结尾
+    StripPrefix    *bool            `json:"strip_prefix"`  // 新增：是否裁剪 MatchPrefix
 }
 ```
 
@@ -612,7 +617,9 @@ type LLMConfig struct {
 - 若 `keys` 非空，所有元素 `name` 必填且在同一数组内唯一，`key` 必填非空，`weight` ∈ `[0,100]`，且所有 `weight` 之和必须等于 `100`；
 - `key_policy` 若传入，`strategy` 仅允许 `weighted_random`，`max_retries`、`retry_backoff_initial`、`retry_backoff_max` 均须 `>=0`，且 `retry_backoff_max >= retry_backoff_initial`；
 - `model_endpoint.headers` 中若包含 `${API_KEY}` 占位符，则 `keys` 不能为空，否则返回 `422`；
-- `provider` 非必填，默认空字符串；为空时 InnerAPI 下发的 `AIConf.ModelTable` 为空列表。
+- `provider` 非必填，默认空字符串；为空时 InnerAPI 下发的 `AIConf.ModelTable` 为空列表；
+- `match_prefix` 非必填，若传入且非空则必须以 `/` 结尾；
+- `strip_prefix` 为 `true` 时，`match_prefix` 必填且非空。
 
 #### Cluster 配置导出（AIConf）
 
@@ -653,6 +660,8 @@ type AIConf struct {
     Provider     string          // 新增：对应 LLMConfig.Provider
     Keys         []AIKey         // 新增
     KeyPolicy    *AIKeyPolicy    // 新增
+    MatchPrefix  string          // 新增：对应 LLMConfig.MatchPrefix
+    StripPrefix  bool            // 新增：对应 LLMConfig.StripPrefix
     ModelTable   *ModelTable     // 新增：按 Provider 从 model_prices 查询填充
 }
 ```

--- a/endpoints/openapi_v1/product_cluster/checker_test.go
+++ b/endpoints/openapi_v1/product_cluster/checker_test.go
@@ -61,6 +61,31 @@ func TestCheckLLMConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "strip prefix without match prefix",
+			config: &icluster_conf.LLMConfig{
+				Models:      []string{"gpt-4"},
+				StripPrefix: lib.PBool(true),
+			},
+			wantErr: true,
+		},
+		{
+			name: "match prefix missing trailing slash",
+			config: &icluster_conf.LLMConfig{
+				Models:      []string{"gpt-4"},
+				MatchPrefix: lib.PString("openrouter"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid prefix config",
+			config: &icluster_conf.LLMConfig{
+				Models:      []string{"gpt-4"},
+				MatchPrefix: lib.PString("openrouter/"),
+				StripPrefix: lib.PBool(true),
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/endpoints/openapi_v1/product_cluster/create.go
+++ b/endpoints/openapi_v1/product_cluster/create.go
@@ -383,6 +383,8 @@ func normalizeLLMConfig(llm *icluster_conf.LLMConfig) *icluster_conf.LLMConfig {
 		KeyPolicy:     llm.KeyPolicy,
 		ProviderType:  llm.ProviderType,
 		Provider:      llm.Provider,
+		MatchPrefix:   llm.MatchPrefix,
+		StripPrefix:   llm.StripPrefix,
 	}
 	if rst.Keys == nil {
 		rst.Keys = []icluster_conf.APIKey{}

--- a/endpoints/openapi_v1/product_cluster/create_test.go
+++ b/endpoints/openapi_v1/product_cluster/create_test.go
@@ -170,3 +170,21 @@ func TestUpsertParamValidate_StickySessions(t *testing.T) {
 		assert.NoError(t, p.Validate())
 	})
 }
+
+func TestNormalizeLLMConfig(t *testing.T) {
+	t.Run("nil returns nil", func(t *testing.T) {
+		assert.Nil(t, normalizeLLMConfig(nil))
+	})
+
+	t.Run("copies prefix fields", func(t *testing.T) {
+		in := &icluster_conf.LLMConfig{
+			Models:      []string{"gpt-4"},
+			MatchPrefix: lib.PString("openrouter/"),
+			StripPrefix: lib.PBool(true),
+		}
+		got := normalizeLLMConfig(in)
+		require.NotNil(t, got)
+		assert.Equal(t, "openrouter/", *got.MatchPrefix)
+		assert.Equal(t, true, *got.StripPrefix)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/DATA-DOG/go-sqlmock v1.4.0
 	github.com/baidu/go-lib v0.0.0-20210316014414-55daa983069e
-	github.com/bfenetworks/bfe v1.8.5-0.20260815015414-8339b1f92f56
+	github.com/bfenetworks/bfe v1.8.5-0.20260815094932-927738429881
 	github.com/bfenetworks/go-lib v0.0.2
 	github.com/codegangsta/negroni v1.0.0
 	github.com/didi/gendry v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/baidu/go-lib v0.0.0-20210316014414-55daa983069e h1:AFtIzBRgufWYEdQLFt
 github.com/baidu/go-lib v0.0.0-20210316014414-55daa983069e/go.mod h1:FneHDqz3wLeDGdWfRyW4CzBbCwaqesLGIFb09N80/ww=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bfenetworks/bfe v1.8.5-0.20260815015414-8339b1f92f56 h1:/2SL1j02EI+eM8tVnEwK7FE+plCIPWin4kkv1gsYdho=
-github.com/bfenetworks/bfe v1.8.5-0.20260815015414-8339b1f92f56/go.mod h1:R4CJtbaLSG9DM68ftxO3tze9mh+1EPJJkLZdyjJChNo=
+github.com/bfenetworks/bfe v1.8.5-0.20260815094932-927738429881 h1:EdmtGC1yocZz3oYRwxdK4j0QKA3ADQwhianbjGW0RR4=
+github.com/bfenetworks/bfe v1.8.5-0.20260815094932-927738429881/go.mod h1:R4CJtbaLSG9DM68ftxO3tze9mh+1EPJJkLZdyjJChNo=
 github.com/bfenetworks/go-lib v0.0.2 h1:ZjWas7Icd3svzVdegSSM1kMYSrnZHRvoCx6SQ458pqg=
 github.com/bfenetworks/go-lib v0.0.2/go.mod h1:DNiKiff30CaX7uOUGJpP85VyTn+JSFoY9gfG2AxmPgM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/lib/validate/validate.go
+++ b/lib/validate/validate.go
@@ -678,6 +678,16 @@ func LLMConfig(c *icluster_conf.LLMConfig) error {
 		}
 	}
 
+	// Validate prefix stripping configuration
+	if c.StripPrefix != nil && *c.StripPrefix {
+		if c.MatchPrefix == nil || *c.MatchPrefix == "" {
+			return xerror.WrapParamErrorWithMsg("llm_config.match_prefix is required when strip_prefix is true")
+		}
+	}
+	if c.MatchPrefix != nil && *c.MatchPrefix != "" && !strings.HasSuffix(*c.MatchPrefix, "/") {
+		return xerror.WrapParamErrorWithMsg("llm_config.match_prefix must end with '/'")
+	}
+
 	return nil
 }
 

--- a/lib/validate/validate_test.go
+++ b/lib/validate/validate_test.go
@@ -229,6 +229,22 @@ func TestLLMConfig(t *testing.T) {
 		Strategy: lib.PString("invalid"),
 	}
 	assert.Error(t, LLMConfig(&c7))
+
+	// strip_prefix=true without match_prefix
+	c8 := *c
+	c8.StripPrefix = lib.PBool(true)
+	assert.Error(t, LLMConfig(&c8))
+
+	// match_prefix not ending with '/'
+	c9 := *c
+	c9.MatchPrefix = lib.PString("openrouter")
+	assert.Error(t, LLMConfig(&c9))
+
+	// valid prefix configuration
+	c10 := *c
+	c10.MatchPrefix = lib.PString("openrouter/")
+	c10.StripPrefix = lib.PBool(true)
+	assert.NoError(t, LLMConfig(&c10))
 }
 
 func TestInstancePool(t *testing.T) {

--- a/model/icluster_conf/cluster.go
+++ b/model/icluster_conf/cluster.go
@@ -205,6 +205,13 @@ type LLMConfig struct {
 	KeyPolicy     *KeyPolicy `json:"key_policy"`     // key routing policy
 	ProviderType  *string    `json:"provider_type"`
 	Provider      *string    `json:"provider"`       // provider name in model_prices
+
+	// MatchPrefix defines the provider/model prefix this cluster matches.
+	// Must end with '/' to avoid matching model names themselves.
+	MatchPrefix *string `json:"match_prefix"`
+	// StripPrefix controls whether to strip MatchPrefix from the request model
+	// field before forwarding to the backend.
+	StripPrefix *bool `json:"strip_prefix"`
 }
 
 type Mapping struct {
@@ -922,6 +929,12 @@ func newAIConf(llmConfig *LLMConfig, modelTable *cluster_conf.ModelTable) *clust
 	}
 	if modelTable != nil {
 		aiConf.ModelTable = modelTable
+	}
+	if llmConfig.MatchPrefix != nil {
+		aiConf.MatchPrefix = *llmConfig.MatchPrefix
+	}
+	if llmConfig.StripPrefix != nil {
+		aiConf.StripPrefix = *llmConfig.StripPrefix
 	}
 
 	for _, k := range llmConfig.Keys {

--- a/model/icluster_conf/cluster_test.go
+++ b/model/icluster_conf/cluster_test.go
@@ -145,6 +145,8 @@ func newTestClusterLLM() *Cluster {
 			RetryBackoffMax:     lib.PInt(5000),
 		},
 		ProviderType: lib.PString("openai"),
+		MatchPrefix:  lib.PString("openrouter/"),
+		StripPrefix:  lib.PBool(true),
 	}
 	return c
 }
@@ -813,6 +815,8 @@ func TestNewBfeClusterConf(t *testing.T) {
 		assert.Equal(t, 5000, cConf.AIConf.KeyPolicy.RetryBackoffMax)
 		require.NotNil(t, cConf.AIConf.ModelMapping)
 		assert.Equal(t, "new", (*cConf.AIConf.ModelMapping)["old"])
+		assert.Equal(t, "openrouter/", cConf.AIConf.MatchPrefix)
+		assert.True(t, cConf.AIConf.StripPrefix)
 	})
 
 	t.Run("disabled sticky sessions with empty hash_header falls back to CLIENT_IP_ONLY", func(t *testing.T) {

--- a/test/docs/README.md
+++ b/test/docs/README.md
@@ -1,6 +1,6 @@
 # AI Gateway API 集成测试设计方案
 
-**更新日期**：2026-08-09
+**更新日期**：2026-08-15
 **文档类型**：测试设计方案
 **目标读者**：后端开发工程师、测试工程师
 
@@ -35,6 +35,8 @@
 | OpenAPI - Tools | `/open-api/v1/tools` | 工具接口（如从提供商拉取模型列表） |
 | OpenAPI - Expression Verify | `/open-api/v1/expression/verify` | 路由表达式校验 |
 | InnerAPI | `/inner-api/v1/configs` | 配置导出接口 |
+
+> **v0.4 更新**：新增 Provider/Model 前缀路由裁剪集成测试，覆盖 OpenAPI `/clusters` 对 `llm_config.match_prefix` / `strip_prefix` 的传入校验，以及 InnerAPI `/configs/tls_conf/server_data_conf` 对 `AIConf.MatchPrefix` / `StripPrefix` 的导出验证。详见 [8.1 相关文档](#81-相关文档)。
 
 ### 1.3 设计原则
 
@@ -749,6 +751,8 @@ integration/tests/{module}/
 | 文档 | 路径 | 说明 |
 |------|------|------|
 | 测试使用说明 | `test/integration/README.md` | 集成测试详细使用说明 |
+| Cluster 模块用例设计 | `test/integration/tests/clusters/design.md` | 含 `llm_config.match_prefix` / `strip_prefix` 创建/更新校验用例 |
+| InnerAPI TlsConf 用例设计 | `test/integration/tests/innerapi/tls_conf/design.md` | 含 `AIConf.MatchPrefix` / `StripPrefix` 导出验证用例 |
 | OpenAPI 接口文档 | `design-docs/api-define/OpenAPI接口定义/README.md` | 各模块接口定义索引 |
 | InnerAPI 接口文档 | `design-docs/api-define/InnerAPI接口定义/README.md` | InnerAPI 接口详细设计索引 |
 | 系统设计文档 | `design-docs/sys-design/` | 系统总体与详细设计 |

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -12,7 +12,8 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/baidu/go-lib v0.0.0-20210316014414-55daa983069e // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bfenetworks/bfe v1.8.1-0.20260427052401-8d3a8cd44d98 // indirect
+	github.com/bfenetworks/bfe v1.8.5-0.20260815015414-8339b1f92f56 // indirect
+	github.com/bfenetworks/go-lib v0.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/test/integration/go.sum
+++ b/test/integration/go.sum
@@ -1,11 +1,15 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.4.0 h1:yxQ63CFIA8Sxkh0vqIofuNrsXl/LZ42TpeTLV4Nb5HM=
+github.com/DATA-DOG/go-sqlmock v1.4.0/go.mod h1:3TucWNLPFOLcHhha1CPp7Kis1UG2h/AqGROPyOeZzsM=
 github.com/baidu/go-lib v0.0.0-20210316014414-55daa983069e h1:AFtIzBRgufWYEdQLFtymsBHFexUulILN3A/5E6376WA=
 github.com/baidu/go-lib v0.0.0-20210316014414-55daa983069e/go.mod h1:FneHDqz3wLeDGdWfRyW4CzBbCwaqesLGIFb09N80/ww=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bfenetworks/bfe v1.8.1-0.20260427052401-8d3a8cd44d98 h1:UzGdA8T+HLLYUfDwpMHWoJHz2CAP6vg5pKlG5v1ZJmI=
-github.com/bfenetworks/bfe v1.8.1-0.20260427052401-8d3a8cd44d98/go.mod h1:7bvAh4MXJI6kOGOjni63qygMURIuD1hZgAitASK3H2s=
+github.com/bfenetworks/bfe v1.8.5-0.20260815015414-8339b1f92f56 h1:/2SL1j02EI+eM8tVnEwK7FE+plCIPWin4kkv1gsYdho=
+github.com/bfenetworks/bfe v1.8.5-0.20260815015414-8339b1f92f56/go.mod h1:R4CJtbaLSG9DM68ftxO3tze9mh+1EPJJkLZdyjJChNo=
+github.com/bfenetworks/go-lib v0.0.2 h1:ZjWas7Icd3svzVdegSSM1kMYSrnZHRvoCx6SQ458pqg=
+github.com/bfenetworks/go-lib v0.0.2/go.mod h1:DNiKiff30CaX7uOUGJpP85VyTn+JSFoY9gfG2AxmPgM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/test/integration/tests/clusters/create/create_test.go
+++ b/test/integration/tests/clusters/create/create_test.go
@@ -475,6 +475,151 @@ func TestClusters_Create(t *testing.T) {
 			},
 			wantCode: 422,
 		},
+		{
+			name: "CL-1-020 合法前缀配置（strip_prefix=true）",
+			body: map[string]interface{}{
+				"name": testutil.UniqueClusterName(),
+				"instance_pool": []interface{}{
+					map[string]interface{}{
+						"name":   "backend-1",
+						"addr":   "10.0.0.1",
+						"weight": 100,
+						"port":   8080,
+					},
+				},
+				"llm_config": map[string]interface{}{
+					"models":        []string{"openrouter/anthropic/claude-sonnet-4"},
+					"match_prefix":  "openrouter/",
+					"strip_prefix":  true,
+					"provider_type": "openrouter",
+				},
+			},
+			wantCode: 200,
+			check: func(t *testing.T, resp *testutil.APIResponse) {
+				var data map[string]interface{}
+				json.Unmarshal(resp.Data, &data)
+				llm, _ := data["llm_config"].(map[string]interface{})
+				assert.Equal(t, "openrouter/", llm["match_prefix"])
+				assert.Equal(t, true, llm["strip_prefix"])
+			},
+		},
+		{
+			name: "CL-1-021 strip_prefix=true 但 match_prefix 为空",
+			body: map[string]interface{}{
+				"name": testutil.UniqueClusterName(),
+				"instance_pool": []interface{}{
+					map[string]interface{}{
+						"name":   "backend-1",
+						"addr":   "10.0.0.1",
+						"weight": 100,
+						"port":   8080,
+					},
+				},
+				"llm_config": map[string]interface{}{
+					"models":        []string{"m"},
+					"strip_prefix":  true,
+					"provider_type": "deepseek",
+				},
+			},
+			wantCode: 422,
+		},
+		{
+			name: "CL-1-022 match_prefix 缺少尾部斜杠",
+			body: map[string]interface{}{
+				"name": testutil.UniqueClusterName(),
+				"instance_pool": []interface{}{
+					map[string]interface{}{
+						"name":   "backend-1",
+						"addr":   "10.0.0.1",
+						"weight": 100,
+						"port":   8080,
+					},
+				},
+				"llm_config": map[string]interface{}{
+					"models":        []string{"m"},
+					"match_prefix":  "openrouter",
+					"provider_type": "deepseek",
+				},
+			},
+			wantCode: 422,
+		},
+		{
+			name: "CL-1-023 仅 match_prefix、strip_prefix=false",
+			body: map[string]interface{}{
+				"name": testutil.UniqueClusterName(),
+				"instance_pool": []interface{}{
+					map[string]interface{}{
+						"name":   "backend-1",
+						"addr":   "10.0.0.1",
+						"weight": 100,
+						"port":   8080,
+					},
+				},
+				"llm_config": map[string]interface{}{
+					"models":        []string{"openrouter/anthropic/claude-sonnet-4"},
+					"match_prefix":  "openrouter/",
+					"strip_prefix":  false,
+					"provider_type": "openrouter",
+				},
+			},
+			wantCode: 200,
+			check: func(t *testing.T, resp *testutil.APIResponse) {
+				var data map[string]interface{}
+				json.Unmarshal(resp.Data, &data)
+				llm, _ := data["llm_config"].(map[string]interface{})
+				assert.Equal(t, "openrouter/", llm["match_prefix"])
+				assert.Equal(t, false, llm["strip_prefix"])
+			},
+		},
+		{
+			name: "CL-1-024 未配置 match_prefix / strip_prefix",
+			body: map[string]interface{}{
+				"name": testutil.UniqueClusterName(),
+				"instance_pool": []interface{}{
+					map[string]interface{}{
+						"name":   "backend-1",
+						"addr":   "10.0.0.1",
+						"weight": 100,
+						"port":   8080,
+					},
+				},
+				"llm_config": map[string]interface{}{
+					"models":        []string{"deepseek-chat"},
+					"provider_type": "deepseek",
+				},
+			},
+			wantCode: 200,
+			check: func(t *testing.T, resp *testutil.APIResponse) {
+				var data map[string]interface{}
+				json.Unmarshal(resp.Data, &data)
+				llm, _ := data["llm_config"].(map[string]interface{})
+				v, ok := llm["match_prefix"]
+				if ok && v != nil {
+					assert.Equal(t, "", v, "match_prefix should be empty if present")
+				}
+			},
+		},
+		{
+			name: "CL-1-025 非法 strip_prefix 类型",
+			body: map[string]interface{}{
+				"name": testutil.UniqueClusterName(),
+				"instance_pool": []interface{}{
+					map[string]interface{}{
+						"name":   "backend-1",
+						"addr":   "10.0.0.1",
+						"weight": 100,
+						"port":   8080,
+					},
+				},
+				"llm_config": map[string]interface{}{
+					"models":        []string{"m"},
+					"match_prefix":  "openrouter/",
+					"strip_prefix":  "true",
+					"provider_type": "deepseek",
+				},
+			},
+			wantCode: 422,
+		},
 	}
 
 	// 预先创建重复集群

--- a/test/integration/tests/clusters/design.md
+++ b/test/integration/tests/clusters/design.md
@@ -9,6 +9,10 @@ v0.0.7 起，`llm_config` 支持多 API-Key：
 - `keys` 非必填，默认值为空数组 `[]`；若传入，则所有元素的 `name`/`key`/`weight` 必填，同一数组内 `name` 唯一，且所有 `weight` 之和必须等于 100。
 - `key_policy` 非必填；`strategy` 当前仅支持 `weighted_random`；`max_retries`、`retry_backoff_initial`、`retry_backoff_max` 必须 ≥0，且 `retry_backoff_max` ≥ `retry_backoff_initial`。
 - 当 `model_endpoint.headers` 中包含 `${API_KEY}` 占位符时，`keys` 不能为空，否则返回 422。
+- v0.4 起，`llm_config` 新增 `match_prefix` / `strip_prefix`：
+  - `match_prefix` 非必填，用于声明该 cluster 匹配的前缀（如 `openrouter/`），若传入且非空则必须以 `/` 结尾；
+  - `strip_prefix` 非必填，默认 `false`；为 `true` 时 `match_prefix` 必填且非空；
+  - 两个字段透传到 InnerAPI 导出的 `AIConf.MatchPrefix` / `StripPrefix`，由 BFE 在转发前执行前缀裁剪。
 
 另外，删除集群时会检查 `route_rules` 表中的全局、Entity、API-Key 路由规则：若任意规则的 `targets` 或 `fallbacks` 引用了该集群，则删除被拒绝。
 
@@ -26,12 +30,12 @@ v0.0.7 起，`llm_config` 支持多 API-Key：
 
 | 接口 | 测试用例数 |
 |------|-----------|
-| 创建集群 | 19 |
+| 创建集群 | 25 |
 | 查询集群列表 | 1 |
 | 查询集群详情 | 1 |
-| 更新集群 | 7 |
+| 更新集群 | 8 |
 | 删除集群 | 8 |
-| **合计** | **36** |
+| **合计** | **43** |
 
 ## 4. 认证方式
 
@@ -91,6 +95,8 @@ clusters/
 | llm_config.keys | []object | N | 多 API-Key 列表 | 非必填，默认 `[]`；非空时须满足下方“API-Key 结构” |
 | llm_config.key_policy | object | N | Key 路由策略 | 非必填；`strategy` 仅支持 `weighted_random`；退避参数 ≥0 且 max ≥ initial |
 | llm_config.provider_type | string | Y | AI 模型提供商类型 | 必填 |
+| llm_config.match_prefix | string | N | provider/model 前缀 | 若传入且非空，必须以 `/` 结尾 |
+| llm_config.strip_prefix | bool | N | 是否裁剪 `match_prefix` | 默认 `false`；为 `true` 时 `match_prefix` 必填且非空 |
 
 ##### API-Key 结构（`llm_config.keys` 元素）
 
@@ -146,6 +152,12 @@ clusters/
 | CL-1-017 | model_endpoint.headers 含 ${API_KEY} 但 keys 为空 | 合法性条件 | 验证 ErrNum=422 |
 | CL-1-018 | key_policy 非法 strategy | 合法性条件 | 验证 ErrNum=422 |
 | CL-1-019 | key_policy 退避参数非法 | 合法性条件 | 验证 ErrNum=422 |
+| CL-1-020 | 合法前缀配置（strip_prefix=true） | 正常参数 | 验证 `match_prefix`/`strip_prefix` 返回正确 |
+| CL-1-021 | strip_prefix=true 但 match_prefix 为空 | 合法性条件 | 验证 ErrNum=422 |
+| CL-1-022 | match_prefix 缺少尾部斜杠 | 合法性条件 | 验证 ErrNum=422 |
+| CL-1-023 | 仅 match_prefix、strip_prefix=false | 正常参数 | 验证仅用于路由标识 |
+| CL-1-024 | 未配置 match_prefix / strip_prefix | 正常参数 | 验证默认值/字段不存在 |
+| CL-1-025 | 非法 strip_prefix 类型 | 异常参数 | 验证 ErrNum=422 |
 
 ### 6.4 测试场景详细设计
 
@@ -1158,6 +1170,270 @@ clusters/
 **ErrMsg**：包含 "retry_backoff_max" 或 "retry_backoff_initial" 的错误信息  
 **Data**：null
 
+----
+
+#### 6.4.20 CL-1-020：合法前缀配置（strip_prefix=true）（正常参数）
+
+##### 设计思路
+
+验证 `llm_config.match_prefix` / `strip_prefix` 合法组合可成功创建集群，且响应字段回显正确。
+
+##### 前提数据准备
+
+无
+
+##### 执行步骤
+
+1. 发送 POST 请求，`match_prefix="openrouter/"`，`strip_prefix=true`。
+2. 验证返回 200。
+3. 验证响应 `llm_config.match_prefix == "openrouter/"`、`llm_config.strip_prefix == true`。
+
+##### 请求参数
+
+```json
+{
+    "name": "cluster_prefix_valid",
+    "instance_pool": [
+        {
+            "hostname": "backend-1",
+            "ip": "10.0.0.1",
+            "weight": 100,
+            "ports": {"Default": 8080}
+        }
+    ],
+    "llm_config": {
+        "models": ["openrouter/anthropic/claude-sonnet-4"],
+        "match_prefix": "openrouter/",
+        "strip_prefix": true,
+        "provider_type": "openrouter"
+    }
+}
+```
+
+##### 预期返回结果
+
+**ErrNum**：200  
+**Data**：`llm_config.match_prefix == "openrouter/"`，`llm_config.strip_prefix == true`
+
+----
+
+#### 6.4.21 CL-1-021：strip_prefix=true 但 match_prefix 为空（合法性条件）
+
+##### 设计思路
+
+验证 `strip_prefix=true` 时，`match_prefix` 必须非空，否则返回 422。
+
+##### 前提数据准备
+
+无
+
+##### 执行步骤
+
+1. 发送 POST 请求，`strip_prefix=true`，不传入 `match_prefix`。
+2. 验证返回 422。
+
+##### 请求参数
+
+```json
+{
+    "name": "cluster_prefix_missing",
+    "instance_pool": [
+        {
+            "hostname": "backend-1",
+            "ip": "10.0.0.1",
+            "weight": 100,
+            "ports": {"Default": 8080}
+        }
+    ],
+    "llm_config": {
+        "models": ["m"],
+        "strip_prefix": true,
+        "provider_type": "deepseek"
+    }
+}
+```
+
+##### 预期返回结果
+
+**ErrNum**：422  
+**ErrMsg**：包含 "match_prefix is required when strip_prefix is true"  
+**Data**：null
+
+----
+
+#### 6.4.22 CL-1-022：match_prefix 缺少尾部斜杠（合法性条件）
+
+##### 设计思路
+
+验证非空 `match_prefix` 必须以 `/` 结尾，否则返回 422。
+
+##### 前提数据准备
+
+无
+
+##### 执行步骤
+
+1. 发送 POST 请求，`match_prefix="openrouter"`。
+2. 验证返回 422。
+
+##### 请求参数
+
+```json
+{
+    "name": "cluster_prefix_no_slash",
+    "instance_pool": [
+        {
+            "hostname": "backend-1",
+            "ip": "10.0.0.1",
+            "weight": 100,
+            "ports": {"Default": 8080}
+        }
+    ],
+    "llm_config": {
+        "models": ["m"],
+        "match_prefix": "openrouter",
+        "provider_type": "deepseek"
+    }
+}
+```
+
+##### 预期返回结果
+
+**ErrNum**：422  
+**ErrMsg**：包含 "match_prefix must end with '/'"  
+**Data**：null
+
+----
+
+#### 6.4.23 CL-1-023：仅 match_prefix、strip_prefix=false（正常参数）
+
+##### 设计思路
+
+验证 `strip_prefix=false` 时，`match_prefix` 可用于路由标识但不裁剪前缀，创建成功且字段回显正确。
+
+##### 前提数据准备
+
+无
+
+##### 执行步骤
+
+1. 发送 POST 请求，`match_prefix="openrouter/"`，`strip_prefix=false`。
+2. 验证返回 200，字段回显正确。
+
+##### 请求参数
+
+```json
+{
+    "name": "cluster_prefix_no_strip",
+    "instance_pool": [
+        {
+            "hostname": "backend-1",
+            "ip": "10.0.0.1",
+            "weight": 100,
+            "ports": {"Default": 8080}
+        }
+    ],
+    "llm_config": {
+        "models": ["openrouter/anthropic/claude-sonnet-4"],
+        "match_prefix": "openrouter/",
+        "strip_prefix": false,
+        "provider_type": "openrouter"
+    }
+}
+```
+
+##### 预期返回结果
+
+**ErrNum**：200  
+**Data**：`llm_config.match_prefix == "openrouter/"`，`llm_config.strip_prefix == false`
+
+----
+
+#### 6.4.24 CL-1-024：未配置 match_prefix / strip_prefix（正常参数）
+
+##### 设计思路
+
+验证不配置这两个字段时，集群创建成功，响应中不存在相关字段或为默认值。
+
+##### 前提数据准备
+
+无
+
+##### 执行步骤
+
+1. 发送最小参数创建集群请求，不携带 `match_prefix` / `strip_prefix`。
+2. 验证返回 200，响应中不包含 `match_prefix` 或 `strip_prefix` 字段（或 `strip_prefix` 为 false）。
+
+##### 请求参数
+
+```json
+{
+    "name": "cluster_no_prefix",
+    "instance_pool": [
+        {
+            "hostname": "backend-1",
+            "ip": "10.0.0.1",
+            "weight": 100,
+            "ports": {"Default": 8080}
+        }
+    ],
+    "llm_config": {
+        "models": ["deepseek-chat"],
+        "provider_type": "deepseek"
+    }
+}
+```
+
+##### 预期返回结果
+
+**ErrNum**：200  
+**Data**：`llm_config.match_prefix` 不存在、为 `null` 或为空字符串；`strip_prefix` 不存在或为 `false`
+
+----
+
+#### 6.4.25 CL-1-025：非法 strip_prefix 类型（异常参数）
+
+##### 设计思路
+
+验证 `strip_prefix` 必须为 bool 类型，传入字符串等非法类型时返回 422。
+
+##### 前提数据准备
+
+无
+
+##### 执行步骤
+
+1. 发送 POST 请求，`strip_prefix="true"`。
+2. 验证返回 422。
+
+##### 请求参数
+
+```json
+{
+    "name": "cluster_prefix_bad_type",
+    "instance_pool": [
+        {
+            "hostname": "backend-1",
+            "ip": "10.0.0.1",
+            "weight": 100,
+            "ports": {"Default": 8080}
+        }
+    ],
+    "llm_config": {
+        "models": ["m"],
+        "match_prefix": "openrouter/",
+        "strip_prefix": "true",
+        "provider_type": "deepseek"
+    }
+}
+```
+
+##### 预期返回结果
+
+**ErrNum**：422  
+**ErrMsg**：包含 "strip_prefix" 或类型错误信息  
+**Data**：null
+
 ---
 
 ## 7. 查询集群列表
@@ -1338,6 +1614,7 @@ URI：`cluster_full`
 | CL-4-005 | 更新非法 instance_pool（非法 IP） | 合法性条件 | 验证 ErrNum=422 |
 | CL-4-006 | 更新 keys（全量替换） | 正常参数 | 验证 PATCH 后 keys 被完整替换 |
 | CL-4-007 | 更新 key_policy | 正常参数 | 验证 PATCH 后 key_policy 更新生效 |
+| CL-4-008 | 更新 match_prefix / strip_prefix | 正常参数 | 验证 PATCH 后前缀配置更新生效，InnerAPI 导出一致 |
 
 ### 9.4 测试场景详细设计
 
@@ -1645,6 +1922,62 @@ URI：`cluster_update_policy`
 | llm_config.keys | 与更新前一致 | Equals |
 | llm_config.key_policy.retry_backoff_initial | 200 | Equals |
 | llm_config.key_policy.retry_backoff_max | 2000 | Equals |
+
+----
+
+#### 9.4.8 CL-4-008：更新 match_prefix / strip_prefix（正常参数）
+
+##### 设计思路
+
+验证通过 PATCH 更新 `llm_config.match_prefix` / `strip_prefix` 后，OpenAPI 查询与 InnerAPI 导出均生效。
+
+##### 前提数据准备
+
+已创建集群 `cluster_update_prefix`，初始配置：
+```json
+{
+    "llm_config": {
+        "models": ["openrouter/anthropic/claude-sonnet-4"],
+        "match_prefix": "openrouter/",
+        "strip_prefix": true,
+        "provider_type": "openrouter"
+    }
+}
+```
+
+##### 执行步骤
+
+1. 发送 PATCH 请求，将 `match_prefix` 改为 `"deepseek/"`，`strip_prefix` 改为 `false`。
+2. 验证返回 200，响应中字段已更新。
+3. 发送 GET 请求查询集群，验证字段一致。
+4. 发送 GET 请求到 `/inner-api/v1/configs/tls_conf/server_data_conf`，验证 `AIConf.MatchPrefix == "deepseek/"`、`AIConf.StripPrefix == false`。
+
+##### 请求参数
+
+URI：`cluster_update_prefix`
+
+```json
+{
+    "llm_config": {
+        "models": ["deepseek-chat"],
+        "match_prefix": "deepseek/",
+        "strip_prefix": false,
+        "provider_type": "deepseek"
+    }
+}
+```
+
+##### 预期返回结果
+
+**ErrNum**：200  
+**ErrMsg**：success
+
+**Data 字段校验**：
+
+| 字段 | 预期值 | 校验方式 |
+|------|--------|---------|
+| llm_config.match_prefix | "deepseek/" | Equals |
+| llm_config.strip_prefix | false | Equals |
 
 ---
 

--- a/test/integration/tests/clusters/update/update_test.go
+++ b/test/integration/tests/clusters/update/update_test.go
@@ -1,9 +1,11 @@
 package clusters_test
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/infinity-ai-gateway/ai-gateway-api/integration/testutil"
 )
 
@@ -196,6 +198,73 @@ func TestClusters_Update(t *testing.T) {
 		}
 		testutil.AssertSuccess(t, resp)
 		testutil.AssertDataFieldEquals(t, resp, "name", clusterUpdatePolicy)
+	})
+
+	t.Run("CL-4-008 更新 match_prefix / strip_prefix", func(t *testing.T) {
+		clusterUpdatePrefix := testutil.UniqueClusterName()
+		_, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name": clusterUpdatePrefix,
+			"instance_pool": []interface{}{
+				map[string]interface{}{
+					"name":   "backend-1",
+					"addr":   "10.0.0.1",
+					"weight": 100,
+					"port":   8080,
+				},
+			},
+			"llm_config": map[string]interface{}{
+				"models":        []string{"openrouter/anthropic/claude-sonnet-4"},
+				"match_prefix":  "openrouter/",
+				"strip_prefix":  true,
+				"provider_type": "openrouter",
+			},
+		})
+		if err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		defer testutil.DeleteCluster(clusterUpdatePrefix)
+
+		resp, err := testutil.GetClient().Patch("/open-api/v1/clusters/"+clusterUpdatePrefix, map[string]interface{}{
+			"llm_config": map[string]interface{}{
+				"models":        []string{"deepseek-chat"},
+				"match_prefix":  "deepseek/",
+				"strip_prefix":  false,
+				"provider_type": "deepseek",
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		resp, err = testutil.GetClient().Get("/open-api/v1/clusters/" + clusterUpdatePrefix)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+		var data map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			t.Fatalf("unmarshal failed: %v", err)
+		}
+		llm, _ := data["llm_config"].(map[string]interface{})
+		assert.Equal(t, "deepseek/", llm["match_prefix"])
+		assert.Equal(t, false, llm["strip_prefix"])
+
+		resp, err = testutil.GetClient().Get("/inner-api/v1/configs/tls_conf/server_data_conf")
+		if err != nil {
+			t.Fatalf("inner api request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+		var innerData map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &innerData); err != nil {
+			t.Fatalf("unmarshal inner data failed: %v", err)
+		}
+		clusterConf, _ := innerData["ClusterConf"].(map[string]interface{})
+		config, _ := clusterConf["Config"].(map[string]interface{})
+		cluster, _ := config[clusterUpdatePrefix].(map[string]interface{})
+		aiconf, _ := cluster["AIConf"].(map[string]interface{})
+		assert.Equal(t, "deepseek/", aiconf["MatchPrefix"])
+		assert.Equal(t, false, aiconf["StripPrefix"])
 	})
 
 	t.Cleanup(func() {

--- a/test/integration/tests/innerapi/tls_conf/design.md
+++ b/test/integration/tests/innerapi/tls_conf/design.md
@@ -1,0 +1,84 @@
+# InnerAPI TlsConf 导出测试设计文档
+
+## 1. 模块概述
+
+`/inner-api/v1/configs/tls_conf/server_data_conf` 是 InnerAPI 的核心导出接口之一，负责将 AI 网关管理面的集群、路由、证书等配置聚合为 BFE 可识别的 `server_data_conf`。其中 `ClusterConf.Config.<cluster_name>.AIConf` 承载 AI 转发所需的模型映射、API-Key、Key 路由策略、模型定价表以及本次新增的 `MatchPrefix` / `StripPrefix` 前缀路由裁剪开关。
+
+本文档覆盖 `AIConf.MatchPrefix` / `StripPrefix` 在 InnerAPI 导出结果中的正确性验证。
+
+## 2. 接口列表
+
+| 编号 | 接口名称 | 方法 | 路径 | 说明 |
+|------|----------|------|------|------|
+| IN-TLS-1 | 导出 Server Data Conf | GET | `/inner-api/v1/configs/tls_conf/server_data_conf` | 导出 TLS/Server/Cluster 等配置 |
+
+## 3. 测试用例统计
+
+| 场景 | 测试用例数 |
+|------|-----------|
+| AIConf 含 MatchPrefix/StripPrefix | 3（编号 IN-TLS-1-004 ~ IN-TLS-1-006，与现有 IN-1-001 ~ IN-1-003 区分） |
+| **合计** | **3** |
+
+## 4. 前置条件
+
+- 测试环境配置 `SkipTokenValidate=true`。
+- 通过 OpenAPI `/open-api/v1/clusters` 预先创建测试集群。
+- 若验证 `ModelTable` 共存场景，需通过 `/open-api/v1/model-prices/import` 导入模型定价并设置 `llm_config.provider`。
+
+## 5. 目录结构
+
+```
+innerapi/tls_conf/
+├── design.md          # 本文档
+└── tls_conf_test.go   # 现有 InnerAPI TlsConf 测试（含 AIConf 多 Key、ModelTable 等用例）
+```
+
+> 新增 `MatchPrefix` / `StripPrefix` 验证用例直接补充到 `tls_conf_test.go` 中，保持同一模块测试文件集中。
+
+## 6. 导出 AIConf 中 MatchPrefix / StripPrefix 验证
+
+### 6.1 接口信息
+
+| 项目 | 值 |
+|------|-----|
+| 模块 | InnerAPI - TlsConf |
+| 接口名称 | 导出 Server Data Conf |
+| 方法 | GET |
+| 路径 | `/inner-api/v1/configs/tls_conf/server_data_conf` |
+
+### 6.2 测试用例
+
+#### IN-TLS-1-004 AIConf 包含 MatchPrefix / StripPrefix
+
+- **前置**：通过 OpenAPI 创建集群，请求体中 `llm_config` 配置：
+  ```json
+  {
+    "match_prefix": "openrouter/",
+    "strip_prefix": true
+  }
+  ```
+- **请求**：`GET /inner-api/v1/configs/tls_conf/server_data_conf`
+- **预期**：
+  - `ErrNum == 200`；
+  - `ClusterConf.Config.<cluster>.AIConf.MatchPrefix == "openrouter/"`；
+  - `ClusterConf.Config.<cluster>.AIConf.StripPrefix == true`。
+
+#### IN-TLS-1-005 未配置前缀时 AIConf 为默认值
+
+- **前置**：创建集群时不传 `match_prefix` / `strip_prefix`。
+- **请求**：`GET /inner-api/v1/configs/tls_conf/server_data_conf`
+- **预期**：
+  - `AIConf.MatchPrefix` 不存在或为空字符串（BFE `AIConf.MatchPrefix` 使用 `omitempty`）；
+  - `AIConf.StripPrefix == false`。
+
+#### IN-TLS-1-006 仅 match_prefix、strip_prefix=false 时的导出
+
+- **前置**：创建集群时配置 `match_prefix="openrouter/"`、`strip_prefix=false`。
+- **请求**：`GET /inner-api/v1/configs/tls_conf/server_data_conf`
+- **预期**：
+  - `AIConf.MatchPrefix == "openrouter/"`；
+  - `AIConf.StripPrefix == false`。
+
+## 7. 数据清理
+
+每个用例在 `t.Cleanup` 或 `defer` 中调用 `testutil.DeleteCluster(clusterName)`，确保测试集群被清理。

--- a/test/integration/tests/innerapi/tls_conf/tls_conf_test.go
+++ b/test/integration/tests/innerapi/tls_conf/tls_conf_test.go
@@ -220,7 +220,138 @@ models:
 		assert.Contains(t, modelNames, "gpt-4o-mini")
 	})
 
+	t.Run("IN-TLS-1-004 AIConf 包含 MatchPrefix / StripPrefix", func(t *testing.T) {
+		clusterName := testutil.UniqueClusterName()
+		_, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name": clusterName,
+			"instance_pool": []interface{}{
+				map[string]interface{}{
+					"name":   "backend-1",
+					"addr":   "10.0.0.1",
+					"weight": 100,
+					"port":   8080,
+				},
+			},
+			"llm_config": map[string]interface{}{
+				"models":        []string{"openrouter/anthropic/claude-sonnet-4"},
+				"match_prefix":  "openrouter/",
+				"strip_prefix":  true,
+				"provider_type": "openrouter",
+			},
+		})
+		if err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		defer testutil.DeleteCluster(clusterName)
+
+		resp, err := testutil.GetClient().Get("/inner-api/v1/configs/tls_conf/server_data_conf")
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		aiconf := extractAIConf(t, resp, clusterName)
+		assert.Equal(t, "openrouter/", aiconf["MatchPrefix"])
+		assert.Equal(t, true, aiconf["StripPrefix"])
+	})
+
+	t.Run("IN-TLS-1-005 未配置前缀时 AIConf 为默认值", func(t *testing.T) {
+		clusterName := testutil.UniqueClusterName()
+		_, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name": clusterName,
+			"instance_pool": []interface{}{
+				map[string]interface{}{
+					"name":   "backend-1",
+					"addr":   "10.0.0.1",
+					"weight": 100,
+					"port":   8080,
+				},
+			},
+			"llm_config": map[string]interface{}{
+				"models":        []string{"deepseek-chat"},
+				"provider_type": "deepseek",
+			},
+		})
+		if err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		defer testutil.DeleteCluster(clusterName)
+
+		resp, err := testutil.GetClient().Get("/inner-api/v1/configs/tls_conf/server_data_conf")
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		aiconf := extractAIConf(t, resp, clusterName)
+		v, ok := aiconf["MatchPrefix"]
+		if ok && v != nil {
+			assert.Equal(t, "", v, "MatchPrefix should be empty if present")
+		}
+		assert.Equal(t, false, aiconf["StripPrefix"])
+	})
+
+	t.Run("IN-TLS-1-006 仅 match_prefix、strip_prefix=false 时的导出", func(t *testing.T) {
+		clusterName := testutil.UniqueClusterName()
+		_, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name": clusterName,
+			"instance_pool": []interface{}{
+				map[string]interface{}{
+					"name":   "backend-1",
+					"addr":   "10.0.0.1",
+					"weight": 100,
+					"port":   8080,
+				},
+			},
+			"llm_config": map[string]interface{}{
+				"models":        []string{"openrouter/anthropic/claude-sonnet-4"},
+				"match_prefix":  "openrouter/",
+				"strip_prefix":  false,
+				"provider_type": "openrouter",
+			},
+		})
+		if err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		defer testutil.DeleteCluster(clusterName)
+
+		resp, err := testutil.GetClient().Get("/inner-api/v1/configs/tls_conf/server_data_conf")
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		aiconf := extractAIConf(t, resp, clusterName)
+		assert.Equal(t, "openrouter/", aiconf["MatchPrefix"])
+		assert.Equal(t, false, aiconf["StripPrefix"])
+	})
+
 	t.Cleanup(func() {
 		testutil.DeleteCertificate(certName)
 	})
+}
+
+func extractAIConf(t *testing.T, resp *testutil.APIResponse, clusterName string) map[string]interface{} {
+	t.Helper()
+	var data map[string]interface{}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	clusterConf, ok := data["ClusterConf"].(map[string]interface{})
+	if !assert.True(t, ok, "ClusterConf should be an object") {
+		return nil
+	}
+	config, ok := clusterConf["Config"].(map[string]interface{})
+	if !assert.True(t, ok, "ClusterConf.Config should be an object") {
+		return nil
+	}
+	cluster, ok := config[clusterName].(map[string]interface{})
+	if !assert.True(t, ok, "target cluster should exist in ClusterConf.Config") {
+		return nil
+	}
+	aiconf, ok := cluster["AIConf"].(map[string]interface{})
+	if !assert.True(t, ok, "AIConf should be an object") {
+		return nil
+	}
+	return aiconf
 }


### PR DESCRIPTION
- Add match_prefix/strip_prefix fields to cluster LLMConfig
- Validate match_prefix ends with '/' and strip_prefix requires match_prefix
- Export AIConf.MatchPrefix/StripPrefix via InnerAPI server_data_conf
- Update OpenAPI/InnerAPI design docs for prefix routing
- Add unit and integration tests for prefix field CRUD and export
- Update dependency to bfenetworks/bfe v1.8.5 branch (pseudo-version)