### PR TITLE
mod-api-key: simplify exported fields and extend ApikeyTag with TagLevel

### DIFF
--- a/design-docs/api-define/InnerAPI接口定义/mod-api-key.md
+++ b/design-docs/api-define/InnerAPI接口定义/mod-api-key.md
@@ -91,9 +91,7 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/mod-api-key?version=000
             "AI_product-abcdef123456": {
                 "key": "AI_product-abcdef123456",
                 "key_id": "ak-test-key-001",
-                "enabled": 1,
-                "status": 1,
-                "update_time": 1716883200,
+                "enabled": true,
                 "expired_time": -1,
                 "unlimited_quota": false,
                 "allow_models": "gpt-4,gpt-3.5-turbo",
@@ -101,7 +99,7 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/mod-api-key?version=000
                 "subnet": "192.168.0.0/16,10.0.0.0/8",
                 "quota_plans": ["ak-test-key-001", "dept-engineering"],
                 "Tags": [
-                    {"TagName": "department", "TagValue": "dept-engineering"}
+                    {"TagName": "department", "TagValue": "dept-engineering", "TagLevel": 3}
                 ]
             }
         }
@@ -115,16 +113,14 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/mod-api-key?version=000
 |------|------|------|----------|
 | key | string | API-Key 值 | 系统生成的 Key 字符串 |
 | key_id | string | API-Key 标识 ID | 用于唯一标识该 API-Key，对应 API-Key 的唯一标识 |
-| enabled | int | 是否启用 | `1`: 启用, `2`: 禁用 |
-| status | int | Key 状态 | `1`: 启用, `2`: 禁用, `3`: 已过期, `4`: 配额耗尽 |
-| update_time | int64 | 创建时间 | Unix 时间戳（秒） |
+| enabled | bool | 是否启用 | `true`: 启用，`false`: 禁用 |
 | expired_time | int64 | 过期时间 | `-1`: 永不过期；其他为 Unix 时间戳（秒） |
 | unlimited_quota | bool | 是否无限配额 | `true`: 不检查配额；`false`: 检查配额 |
 | allow_models | string | 允许访问的模型 | 逗号分隔，空或 `""` 表示不限制 |
 | block_models | string | 禁止访问的模型 | 逗号分隔，空或 `""` 表示无不允许模型 |
 | subnet | string | 允许的客户端子网 | 逗号分隔的 CIDR 列表，空或 `""` 表示不限制 |
 | quota_plans | []string | 关联的配额计划 ID 列表 | 引用顶层 `QuotaPlans` 中的定义，包含 API-Key 自身和 Entity 层级的所有配额计划 |
-| Tags | []ApikeyTag | Entity 层级标签列表 | 包含 `TagName` 和 `TagValue` 字段 |
+| Tags | []ApikeyTag | Entity 层级标签列表 | 包含 `TagName`、`TagValue` 和 `TagLevel` 字段 |
 
 **ApikeyTag 结构（Entity 层级标签，按字段名导出）**
 
@@ -132,6 +128,7 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/mod-api-key?version=000
 |------|------|------|------|
 | TagName | string | Entity 类型 | `department`, `team`, `project` |
 | TagValue | string | Entity 名称 | `dept-engineering`, `team-core` |
+| TagLevel | int | 标签级别，取值为 1~5 的整数 | `3` |
 
 ### 3.4 QuotaPlans 结构（配额计划定义）
 
@@ -146,10 +143,8 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/mod-api-key?version=000
                 "Unlimited": false,
                 "PassNoQuota": false,
                 "RedisKey": "QUOTA_ak-test-key-001",
-                "CreateTime": 1716883200,
                 "ExpiredTime": -1,
                 "Quota": 100000000,
-                "ResetMode": 1,
                 "Unit": "RMB"
             }
         ]
@@ -165,26 +160,11 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/mod-api-key?version=000
 | Unlimited | bool | 是否无限配额 | `true`/`false` |
 | PassNoQuota | bool | 配额不足时是否放行 | `true`: 放行；`false`: 拒绝 |
 | RedisKey | string | Redis 中存储配额余额的 Key | 格式 `QUOTA_{id}` |
-| CreateTime | int64 | 创建时间 | Unix 时间戳（秒） |
 | ExpiredTime | int64 | 过期时间 | `-1`: 永不过期 |
 | Quota | int64 | 配额总量 | 初始配额值；`Unit=RMB` 时为定点整数，精度 `1e-8` 元 |
-| ResetMode | int | 重置模式 | `0`: 非周期性；`1`: 周期性（weekly/monthly） |
 | Unit | string | 配额单位，`RMB` 同时隐含货币类型 | `total_token` / `RMB` |
 
-## 4. 状态码说明
-
-| 状态码 | 含义 | 说明 |
-|--------|------|------|
-| 1 | 启用 | API-Key 正常可用 |
-| 2 | 禁用 | API-Key 已被禁用 |
-| 3 | 已过期 | API-Key 已过期 |
-| 4 | 配额耗尽 | API-Key 配额已用完 |
-
-同时，`enabled` 字段独立表示是否启用：
-- `1` = 启用
-- `2` = 禁用
-
-## 5. 成功返回示例
+## 4. 成功返回示例
 
 ```json
 {
@@ -215,20 +195,16 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/mod-api-key?version=000
                     "Unlimited": false,
                     "PassNoQuota": false,
                     "RedisKey": "QUOTA_ak-test-key-001",
-                    "CreateTime": 1716883200,
                     "ExpiredTime": -1,
-                    "Quota": 100000000,
-                    "ResetMode": 1
+                    "Quota": 100000000
                 },
                 {
                     "Id": "dept-engineering",
                     "Unlimited": false,
                     "PassNoQuota": false,
                     "RedisKey": "QUOTA_dept-engineering",
-                    "CreateTime": 1716000000,
                     "ExpiredTime": -1,
-                    "Quota": 500000000,
-                    "ResetMode": 0
+                    "Quota": 500000000
                 }
             ]
         },
@@ -237,9 +213,7 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/mod-api-key?version=000
                 "AI_product-abcdef123456": {
                     "key": "AI_product-abcdef123456",
                     "key_id": "ak-test-key-001",
-                    "enabled": 1,
-                    "status": 1,
-                    "update_time": 1716883200,
+                    "enabled": true,
                     "expired_time": -1,
                     "unlimited_quota": false,
                     "allow_models": "gpt-4,gpt-3.5-turbo",
@@ -247,15 +221,13 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/mod-api-key?version=000
                     "subnet": "192.168.0.0/16,10.0.0.0/8",
                     "quota_plans": ["ak-test-key-001", "dept-engineering"],
                     "Tags": [
-                        {"TagName": "department", "TagValue": "dept-engineering"}
+                        {"TagName": "department", "TagValue": "dept-engineering", "TagLevel": 3}
                     ]
                 },
                 "AI_product-ghijkl789012": {
                     "key": "AI_product-ghijkl789012",
                     "key_id": "ak-prod-key-002",
-                    "enabled": 1,
-                    "status": 1,
-                    "update_time": 1716883200,
+                    "enabled": true,
                     "expired_time": -1,
                     "unlimited_quota": true,
                     "allow_models": "",
@@ -271,7 +243,7 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/mod-api-key?version=000
 }
 ```
 
-## 6. 配置未变化返回示例
+## 5. 配置未变化返回示例
 
 ```json
 {

--- a/design-docs/modifications/2026-08-21-mod-api-key-field-simplification/design-changes.md
+++ b/design-docs/modifications/2026-08-21-mod-api-key-field-simplification/design-changes.md
@@ -1,0 +1,442 @@
+# ai-gateway-api mod-api-key 字段精简与 TagLevel 扩展
+
+## 1. 背景
+
+BFE 的 `token_rule.data` 配置已完成字段精简：
+
+- **QuotaPlan**：删除 `CreateTime`、`ResetMode`。
+- **Token**：删除 `status`、`update_time`；`enabled` 类型从 `int` 调整为 `bool`。
+- **ApikeyTag**：新增 `TagLevel` 字段，取值为 1~5 的整数。
+
+`ai-gateway-api` 作为 `/configs/mod-api-key` 接口的实现方，需要同步调整导出数据结构和生成逻辑，确保响应与 BFE 配置文档保持一致。
+
+---
+
+## 2. 目标
+
+1. `/configs/mod-api-key` 接口返回的 Token 配置中删除 `status`、`update_time`。
+2. `/configs/mod-api-key` 接口返回的 Token 配置中 `enabled` 字段类型从 `int` 改为 `bool`。
+3. `/configs/mod-api-key` 接口返回的 QuotaPlan 配置中删除 `CreateTime`、`ResetMode`。
+4. `/configs/mod-api-key` 接口返回的 Tags 中新增 `TagLevel` 字段。
+5. 保持现有 API-Key 启用/禁用、过期判断逻辑不变。
+6. 单元测试、集成测试与设计文档同步更新。
+
+---
+
+## 3. 方案概述
+
+### 3.1 TokenFile 结构变更
+
+**文件：** `ai-gateway-api/model/imods/exporter.go`
+
+当前结构：
+
+```go
+type TokenFile struct {
+    Key            string  `json:"key"`
+    KeyID          string  `json:"key_id"`
+    Enabled        int     `json:"enabled"`
+    Status         int     `json:"status"`
+    UpdateTime     int64   `json:"update_time"`
+    ExpiredTime    int64   `json:"expired_time"`
+    UnlimitedQuota bool    `json:"unlimited_quota"`
+    Models         *string `json:"allow_models"`
+    BlockModels    *string `json:"block_models"`
+    Subnet         *string `json:"subnet"`
+    Tags           []ApikeyTag
+    QuotaPlans     []string `json:"quota_plans"`
+    models         []string
+    blockModels    []string
+    subnet         []*net.IPNet
+}
+```
+
+改造后结构：
+
+```go
+type TokenFile struct {
+    Key            string  `json:"key"`
+    KeyID          string  `json:"key_id"`
+    Enabled        bool    `json:"enabled"`
+    ExpiredTime    int64   `json:"expired_time"`
+    UnlimitedQuota bool    `json:"unlimited_quota"`
+    Models         *string `json:"allow_models"`
+    BlockModels    *string `json:"block_models"`
+    Subnet         *string `json:"subnet"`
+    Tags           []ApikeyTag
+    QuotaPlans     []string `json:"quota_plans"`
+    models         []string
+    blockModels    []string
+    subnet         []*net.IPNet
+}
+```
+
+### 3.2 Token 生成逻辑变更
+
+**文件：** `ai-gateway-api/model/imods/exporter.go`
+
+当前 `APIKeyRuleGenerator` 中构造 `TokenFile` 时同时计算 `Enabled` 和 `Status`：
+
+```go
+status := TokenStatusDisabled
+var remainQuota float64
+if one.Enable != nil && *one.Enable {
+    isUnlimited := one.UnlimitedQuota != nil && *one.UnlimitedQuota
+    if !isUnlimited {
+        status = TokenStatusEnabled
+        remainingQuota, err := api_key.GetRemainingQuota(ctx, rlm.quotaCache, one)
+        ...
+        if remainingQuota != nil {
+            remainQuota = *remainingQuota
+            if expiredTime != int64(UnlimitedQuota) && time.Now().Local().Unix() >= expiredTime {
+                status = TokenStatusExpired
+            } else if remainQuota <= 0 {
+                status = TokenStatusExhausted
+            }
+        }
+    } else {
+        status = TokenStatusEnabled
+    }
+}
+
+tokenFile := &TokenFile{
+    Key:            *one.Key,
+    KeyID:          *one.ID,
+    Enabled:        2,
+    Status:         status,
+    ExpiredTime:    expiredTime,
+    UpdateTime:     one.KeyCreateAt.Unix(),
+    UnlimitedQuota: one.UnlimitedQuota != nil && *one.UnlimitedQuota,
+}
+if one.Enable != nil && *one.Enable {
+    tokenFile.Enabled = 1
+}
+```
+
+改造后逻辑：
+
+```go
+enabled := one.Enable != nil && *one.Enable
+
+// 当 allow_models 交集为空时，强制禁用
+if len(finalAllowModels) == 0 {
+    modelsStr := ""
+    tokenFile.Models = &modelsStr
+    enabled = false
+}
+
+tokenFile := &TokenFile{
+    Key:            *one.Key,
+    KeyID:          *one.ID,
+    Enabled:        enabled,
+    ExpiredTime:    expiredTime,
+    UnlimitedQuota: one.UnlimitedQuota != nil && *one.UnlimitedQuota,
+}
+```
+
+> 说明：
+> - `Expired` 状态由 BFE 根据 `expired_time` 实时判断，无需在导出时计算 `status`。
+> - `Exhausted` 状态由 BFE 认证阶段根据 Redis 配额余额实时判断，无需在导出时计算 `status`。
+> - `UpdateTime` 不再导出。
+
+### 3.3 QuotaPlan 结构变更
+
+**文件：** `ai-gateway-api/model/imods/exporter.go`
+
+当前结构：
+
+```go
+type QuotaPlan struct {
+    Id          string
+    Unlimited   bool
+    PassNoQuota bool
+    RedisKey    string
+    CreateTime  int64
+    ExpiredTime int64
+    Quota       int64
+    ResetMode   int
+    Unit        string
+}
+```
+
+改造后结构：
+
+```go
+type QuotaPlan struct {
+    Id          string
+    Unlimited   bool
+    PassNoQuota bool
+    RedisKey    string
+    ExpiredTime int64
+    Quota       int64
+    Unit        string
+}
+```
+
+`convertQuotaPlanToExport` 函数同步删除 `ResetMode` 与 `CreateTime` 赋值逻辑：
+
+```go
+func convertQuotaPlanToExport(qp *quota.QuotaPlanParam, id string, redisKeyID string) *QuotaPlan {
+    result := &QuotaPlan{
+        Id:          id,
+        RedisKey:    fmt.Sprintf("QUOTA_%s", redisKeyID),
+        Unlimited:   qp.Unlimited != nil && *qp.Unlimited,
+        PassNoQuota: qp.PassWhenNoEnoughQuota != nil && *qp.PassWhenNoEnoughQuota,
+        ExpiredTime: -1,
+    }
+    if qp.Quota != nil {
+        result.Quota = golibquota.PtrToRedisValue(qp.Quota, qp.Unit)
+    }
+    if qp.Unit != nil {
+        result.Unit = *qp.Unit
+    }
+    return result
+}
+```
+
+### 3.4 ApikeyTag 结构变更
+
+**文件：** `ai-gateway-api/model/imods/exporter.go`
+
+当前结构：
+
+```go
+type ApikeyTag struct {
+    TagName  string
+    TagValue string
+}
+```
+
+改造后结构：
+
+```go
+type ApikeyTag struct {
+    TagName  string
+    TagValue string
+    TagLevel int
+}
+```
+
+#### 3.4.1 当前 `ApikeyTag` 的填充方式
+
+`ApikeyTag` 在 `APIKeyRuleGenerator` 中通过 `fetchQuotaPlansWithEntityHierarchy` → `fetchEntityQuotaPlanHierarchy` 递归填充，当前仅使用 Entity 的 `Type` 和 `Name`：
+
+```go
+func (rlm *APIKeyRuleManager) fetchEntityQuotaPlanHierarchy(ctx context.Context, entity *entity.EntityParam, productName string, collectedQuotaPlans map[string][]*QuotaPlan) ([]string, []ApikeyTag, error) {
+    quotaPlanIDs := make([]string, 0)
+    tags := make([]ApikeyTag, 0)
+
+    if entity.EntityID != nil && entity.Type != nil && entity.Name != nil {
+        tags = append(tags, ApikeyTag{
+            TagName:  *entity.Type,
+            TagValue: *entity.Name,
+        })
+    }
+
+    // ... 处理 quota plan 和父级 entity
+
+    return quotaPlanIDs, tags, nil
+}
+```
+
+即：`Tags` 的数据来源是 API-Key 关联的 Entity 及其父级 Entity 链上的 `Type` + `Name`。
+
+#### 3.4.2 `TagLevel` 的数据来源
+
+`TagLevel` 应取值为 Entity 所属 **EntityType 的 `Level`**。`ai-gateway-api` 中已有 `EntityType` 模型，包含 `Level` 字段：
+
+```go
+// ai-gateway-api/model/entity/entity_type.go
+type EntityTypeParam struct {
+    TypeName    *string `json:"type_name"`
+    Description *string `json:"description"`
+    Level       *int    `json:"level"`
+    CreateTime  *int64  `json:"create_time,omitempty"`
+    UpdateTime  *int64  `json:"update_time,omitempty"`
+}
+```
+
+因此，填充 `ApikeyTag.TagLevel` 时，应根据 `entity.Type` 查询对应的 `EntityType`，再取其 `Level`。
+
+#### 3.4.3 `TagLevel` 填充实现
+
+**步骤 1：为 `APIKeyRuleManager` 引入 `EntityTypeStorager`**
+
+`ai-gateway-api/model/imods/mod_api_key_rule.go`：
+
+```go
+type APIKeyRuleManager struct {
+    txn                   itxn.TxnStorager
+    versionControlManager *iversion_control.VersionControlManager
+    apiKeyStorager        api_key.APIKeyStorager
+    aiRouteStorager       iai_route.AIRouteRuleStorager
+    quotaPlanStorager     quota.QuotaPlanStorager
+    entityStorager        entity.EntityStorager
+    entityTypeStorager    entity.EntityTypeStorager // 新增
+    quotaCache            quotacache.QuotaCache
+}
+
+func NewAPIKeyRuleManager(txn itxn.TxnStorager,
+    versionControlManager *iversion_control.VersionControlManager,
+    apiKeyStorager api_key.APIKeyStorager,
+    aiRouteStorager iai_route.AIRouteRuleStorager,
+    quotaPlanStorager quota.QuotaPlanStorager,
+    entityStorager entity.EntityStorager,
+    entityTypeStorager entity.EntityTypeStorager, // 新增
+    quotaCache quotacache.QuotaCache) *APIKeyRuleManager {
+    return &APIKeyRuleManager{
+        // ...
+        entityTypeStorager: entityTypeStorager,
+        // ...
+    }
+}
+```
+
+**步骤 2：容器初始化注入 `EntityTypeStorager`**
+
+`ai-gateway-api/stateful/container/rdb/components.go` 在构造 `APIKeyRuleManager` 时传入 `container.EntityTypeStorager`。
+
+**步骤 3：在 `fetchEntityQuotaPlanHierarchy` 中查询并填充 `TagLevel`**
+
+```go
+func (rlm *APIKeyRuleManager) fetchEntityQuotaPlanHierarchy(ctx context.Context, entity *entity.EntityParam, productName string, collectedQuotaPlans map[string][]*QuotaPlan) ([]string, []ApikeyTag, error) {
+    quotaPlanIDs := make([]string, 0)
+    tags := make([]ApikeyTag, 0)
+
+    if entity.EntityID != nil && entity.Type != nil && entity.Name != nil {
+        tag := ApikeyTag{
+            TagName:  *entity.Type,
+            TagValue: *entity.Name,
+        }
+
+        // 查询 entity type 对应的 level
+        // 按业务约束，每个 Entity 的 Type 必然对应一个存在且 Level 有效的 EntityType
+        entityType, err := rlm.entityTypeStorager.FetchEntityType(ctx, &entity.EntityTypeFilter{TypeName: entity.Type})
+        if err != nil {
+            return nil, nil, err
+        }
+        if entityType == nil || entityType.Level == nil {
+            return nil, nil, fmt.Errorf("entity type %s not found or level invalid", *entity.Type)
+        }
+        tag.TagLevel = *entityType.Level
+
+        tags = append(tags, tag)
+    }
+
+    // ... 处理 quota plan 和父级 entity
+
+    return quotaPlanIDs, tags, nil
+}
+```
+
+> 说明：
+> - `TagLevel` 取值为 1~5 的整数，对应 `entity_types` 表中 `level` 字段。
+> - 按业务约束，每个 Entity 的 Type 必然对应存在且 `Level` 有效的 EntityType；若查询不到或 Level 为空，按异常处理并返回错误。
+> - 父级 Entity 的 TagLevel 同样按其自身 Type 对应的 EntityType.Level 填充。
+
+### 3.5 状态常量清理
+
+**文件：** `ai-gateway-api/model/imods/exporter.go`
+
+当前定义：
+
+```go
+const (
+    TokenStatusEnabled   = 1
+    TokenStatusDisabled  = 2
+    TokenStatusExpired   = 3
+    TokenStatusExhausted = 4
+)
+```
+
+由于 `status` 字段删除，这些常量应同步删除。若其他模块引用了这些常量，需一并清理。
+
+---
+
+## 4. 涉及文件清单
+
+| 文件 | 修改内容 |
+|------|----------|
+| `ai-gateway-api/model/imods/exporter.go` | `TokenFile` 删除 `Status`、`UpdateTime`，`Enabled` 改为 `bool`；`QuotaPlan` 删除 `CreateTime`、`ResetMode`；`ApikeyTag` 新增 `TagLevel`；删除 `TokenStatus*` 常量；调整生成逻辑 |
+| `ai-gateway-api/model/imods/mod_api_key_rule.go` | `APIKeyRuleManager` 新增 `entityTypeStorager`，`NewAPIKeyRuleManager` 新增参数 |
+| `ai-gateway-api/model/imods/exporter_test.go` | 删除 `Status`、`UpdateTime`、`CreateTime`、`ResetMode` 相关断言；`Enabled` 改为 `bool` 断言；补充 `TagLevel` 断言；mock `EntityTypeStorager` |
+| `ai-gateway-api/model/imods/mod_api_key_rule_test.go` | 删除 `QuotaPlan.ResetMode`/`CreateTime` 相关断言；适配 `NewAPIKeyRuleManager` 新签名 |
+| `ai-gateway-api/stateful/container/rdb/components.go` | 构造 `APIKeyRuleManager` 时传入 `EntityTypeStorager` |
+| `ai-gateway-api/endpoints/innerapi_v1/mod_api_key/export_test.go` | endpoint 层测试断言 `enabled` 为 `bool`，不再断言 `status`/`update_time` |
+| `ai-gateway-api/test/integration/tests/innerapi/mod_api_key/mod_api_key_test.go` | 集成测试同步调整字段断言 |
+| `ai-gateway-api/design-docs/api-define/InnerAPI接口定义/mod-api-key.md` | 已同步更新字段说明与示例 JSON |
+| `ai-gateway-api/design-docs/modifications/2026-08-21-mod-api-key-field-simplification/design-changes.md` | 本设计变更文档（即本文档） |
+
+---
+
+## 5. 测试计划
+
+### 5.1 单元测试
+
+**文件：** `ai-gateway-api/model/imods/exporter_test.go`
+
+1. 删除所有对 `TokenFile.Status` 的断言。
+2. 删除所有对 `TokenFile.UpdateTime` 的断言。
+3. 将 `Enabled` 断言从 `assert.Equal(t, 1, token.Enabled)` 改为 `assert.True(t, token.Enabled)`。
+4. 将禁用场景断言从 `assert.Equal(t, 2, token.Enabled)` 改为 `assert.False(t, token.Enabled)`。
+5. 删除 `QuotaPlan.ResetMode` 与 `CreateTime` 断言。
+6. 补充 `ApikeyTag.TagLevel` 断言。
+
+### 5.2 Endpoint 测试
+
+**文件：** `ai-gateway-api/endpoints/innerapi_v1/mod_api_key/export_test.go`
+
+1. 断言反序列化后的 token `enabled` 为 `bool` 类型。
+2. 断言响应中不再包含 `status`、`update_time`。
+3. 断言 QuotaPlan 中不再包含 `CreateTime`、`ResetMode`。
+4. 断言 Tags 中包含 `TagLevel`。
+
+### 5.3 集成测试
+
+**文件：** `ai-gateway-api/test/integration/tests/innerapi/mod_api_key/mod_api_key_test.go`
+
+1. 调用 `/inner-api/v1/configs/mod-api-key` 后，断言 token 字段与文档一致。
+2. 断言 QuotaPlan 字段与文档一致。
+
+### 5.4 验证命令
+
+```bash
+cd ai-gateway-api
+
+go test ./model/imods/...
+go test ./endpoints/innerapi_v1/mod_api_key/...
+go test ./test/integration/tests/innerapi/mod_api_key/...
+```
+
+---
+
+## 6. 兼容性说明
+
+- `/configs/mod-api-key` 响应删除 `status`、`update_time`、`CreateTime`、`ResetMode`，BFE 侧已删除对这些字段的依赖。
+- `/configs/mod-api-key` 响应中 `enabled` 类型从 `int` 改为 `bool`，BFE 侧 `TokenFile.Enabled` 需同步改为 `bool`。
+- `/configs/mod-api-key` 响应中 Tags 新增 `TagLevel`，BFE 侧 `ApikeyTag` 需同步新增该字段。
+- 数据库 schema 不变；`ResetMode`/`CreateTime`/`status`/`update_time` 相关数据库字段可继续保留，仅不再导出。
+
+---
+
+## 7. 风险与缓解
+
+| 风险 | 缓解措施 |
+|------|---------|
+| `enabled` 从 `int` 改为 `bool` 可能导致 BFE 旧版本解析失败 | 确保 BFE 与 ai-gateway-api 同步升级；旧配置中 JSON 的 `true`/`false` 对 Go `bool` 可正确解析，但 BFE 旧代码若仍按 `int` 解析会报错 |
+| `status` 删除后，BFE 侧状态判断逻辑未迁移完成 | 参考 BFE 修改方案 `bfe/docs/zh_cn/modifications/2026-08-21-token-rule-data-field-simplification/design-changes.md` 完成 `enabled`/`expired_time`/实时配额检查迁移 |
+| `TagLevel` 需引入 EntityType 查询 | 为 `APIKeyRuleManager` 注入 `EntityTypeStorager`，在导出时按需查询；按业务约束 EntityType 及其 Level 必然存在，异常时返回错误 |
+| 外部系统仍依赖 `status`/`update_time` | 全局搜索 `/configs/mod-api-key` 消费者，同步通知改造 |
+
+---
+
+## 8. 关键代码索引
+
+| 文件 | 行号范围 | 说明 |
+|---|---|---|
+| `ai-gateway-api/model/imods/exporter.go` | 37-42 | `TokenStatus*` 常量定义 |
+| `ai-gateway-api/model/imods/exporter.go` | 57-60 | `ApikeyTag` 结构定义 |
+| `ai-gateway-api/model/imods/exporter.go` | 66-76 | `QuotaPlan` 结构定义 |
+| `ai-gateway-api/model/imods/exporter.go` | 78-94 | `TokenFile` 结构定义 |
+| `ai-gateway-api/model/imods/exporter.go` | 235-273 | Token `status`/`enabled` 生成逻辑 |
+| `ai-gateway-api/model/imods/exporter.go` | 576-603 | `convertQuotaPlanToExport` 函数 |

--- a/design-docs/sys-design/details/API-Key与Entity关联及模型继承.md
+++ b/design-docs/sys-design/details/API-Key与Entity关联及模型继承.md
@@ -212,6 +212,8 @@ func (rlm *APIKeyRuleManager) fetchEntityQuotaPlanHierarchy(
 
 无限配额计划虽然不参与导出，但仍会影响 Entity 层级的标签收集。
 
+在收集标签时，会根据 `entity.Type` 查询 `EntityType`，取其 `Level` 填充到 `ApikeyTag.TagLevel`；若对应 EntityType 不存在或 Level 无效，则导出失败并返回错误。
+
 ### 6.3 导出格式
 
 每个配额计划导出为 BFE 的 `QuotaPlan`：
@@ -222,10 +224,9 @@ type QuotaPlan struct {
     Unlimited bool
     PassNoQuota bool
     RedisKey string
-    CreateTime int64
     ExpiredTime int64 // -1 表示永不过期
     Quota int64
-    ResetMode int // 0 非周期，1 周期
+    Unit string
 }
 ```
 
@@ -242,10 +243,11 @@ type QuotaPlan struct {
 type ApikeyTag struct {
     TagName string // 如 entity.type
     TagValue string // 如 entity.name
+    TagLevel int    // 对应 EntityType.Level，取值为 1~5 的整数
 }
 ```
 
-每个 Entity 会生成一个 `TagName = Entity.Type`、`TagValue = Entity.Name` 的标签。
+每个 Entity 会生成一个 `TagName = Entity.Type`、`TagValue = Entity.Name` 的标签，并依据该 Entity Type 对应的 `EntityType.Level` 填充 `TagLevel`。
 
 ---
 
@@ -381,7 +383,7 @@ for _, apiKey := range apiKeys {
 | API-Key 未挂载 Entity | 仅使用自身配置，不继承任何 Entity 策略 |
 | Entity 未设置 allow_models | 不参与交集计算，视为不限制 |
 | Entity allow_models 含 `*` | 跳过该层级的交集计算 |
-| API-Key 与 Entity allow_models 交集为空 | 导出时禁用该 Token（`Enabled=2`） |
+| API-Key 与 Entity allow_models 交集为空 | 导出时禁用该 Token（`Enabled=false`） |
 | Entity 层级成环 | 创建/更新时通过层级校验阻止 |
 | 父 Entity 被删除 | 需先删除所有子 Entity |
 | 多个配额计划 | API-Key 同时受多个 Redis Key 控制，BFE 侧需支持多配额校验 |

--- a/design-docs/sys-design/details/InnerAPI配置导出与版本控制.md
+++ b/design-docs/sys-design/details/InnerAPI配置导出与版本控制.md
@@ -222,10 +222,10 @@ type ModAPIKeyRuleConf struct {
 
 1. 构造 AI 路由对应的 API-Key 规则（`buildAIRouteAPIKeyRules`）；
 2. 遍历所有 `api_keys`，为每个 key 生成 `TokenFile`；
-3. **预加载每个 API-Key 关联的 `QuotaPlan`**（raw storager 不会自动填充关联对象，而 `GetRemainingQuota` 需要 `QuotaPlan.Quota` 判断 token 是否耗尽）；
-4. 计算 token 状态（`enabled/disabled/expired/exhausted`）；
-5. 合并 Entity 层级的 `allow_models`（交集）与 `block_models`（并集）；
-6. 收集 API-Key 自身及 Entity 层级向上的配额计划，**跳过 `unlimited=true` 的配额计划**；
+3. 根据 API-Key 的 `enabled` 字段及 Entity 层级的 `allow_models` 交集结果，确定导出的 `enabled`（布尔值）；`expired`/`exhausted` 状态由 BFE 根据 `expired_time` 和实时 Redis 配额余额自行判断，不再由导出层计算；
+4. 合并 Entity 层级的 `allow_models`（交集）与 `block_models`（并集）；
+5. 收集 API-Key 自身及 Entity 层级向上的配额计划，**跳过 `unlimited=true` 的配额计划**；
+6. 为每个 Entity 标签补充 `TagLevel`（取自对应 `EntityType.Level`）；
 7. 输出 `QuotaPlans`、`Tokens`、`Config`。
 
 > 详见《API-Key 与 Entity 关联及模型继承.md》。

--- a/endpoints/innerapi_v1/mod_api_key/export_test.go
+++ b/endpoints/innerapi_v1/mod_api_key/export_test.go
@@ -126,6 +126,28 @@ func (f *fakeEntityStoragerForRule) DeleteEntity(ctx context.Context, filter *en
 	return nil
 }
 
+type fakeEntityTypeStoragerForRule struct{}
+
+func (f *fakeEntityTypeStoragerForRule) CreateEntityType(ctx context.Context, param *entity.EntityTypeParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeEntityTypeStoragerForRule) FetchEntityType(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error) {
+	return nil, nil
+}
+
+func (f *fakeEntityTypeStoragerForRule) FetchEntityTypeList(ctx context.Context, filter *entity.EntityTypeFilter) ([]*entity.EntityTypeParam, error) {
+	return nil, nil
+}
+
+func (f *fakeEntityTypeStoragerForRule) UpdateEntityType(ctx context.Context, filter *entity.EntityTypeFilter, param *entity.EntityTypeParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeEntityTypeStoragerForRule) DeleteEntityType(ctx context.Context, filter *entity.EntityTypeFilter) error {
+	return nil
+}
+
 func setupAPIKeyRuleManager(version string) func() {
 	origConfig := stateful.DefaultConfig
 	stateful.DefaultConfig = &stateful.Config{
@@ -141,7 +163,8 @@ func setupAPIKeyRuleManager(version string) func() {
 		&fakeAPIKeyStoragerForRule{},
 		&fakeAIRouteRuleStoragerForRule{},
 		&fakeQuotaPlanStoragerForRule{},
-		&fakeEntityStoragerForRule{}, nil)
+		&fakeEntityStoragerForRule{},
+		&fakeEntityTypeStoragerForRule{}, nil)
 	return func() {
 		container.APIKeyRuleManager = old
 		stateful.DefaultConfig = origConfig

--- a/model/imods/exporter.go
+++ b/model/imods/exporter.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
 
 	golibquota "github.com/bfenetworks/go-lib/quota"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/api_key"
@@ -27,19 +26,11 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iai_route"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iversion_control"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/quota"
-	"github.com/rainway-ai-gateway/ai-gateway-api/model/shared"
 	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
 )
 
 // ConfigTopicProductAPIKeyRule is the configuration topic for API key rules
 const ConfigTopicProductAPIKeyRule = "mod_api_key_rule"
-
-const (
-	TokenStatusEnabled   = 1
-	TokenStatusDisabled  = 2
-	TokenStatusExpired   = 3
-	TokenStatusExhausted = 4
-)
 
 // ModAPIKeyRuleConf defines the configuration structure for API key rules module
 type ModAPIKeyRuleConf struct {
@@ -57,6 +48,7 @@ type TokenRuleFile struct {
 type ApikeyTag struct {
 	TagName  string //eg entity.type
 	TagValue string //eg entity.name
+	TagLevel int
 }
 
 type ActionFile struct {
@@ -68,19 +60,15 @@ type QuotaPlan struct {
 	Unlimited   bool
 	PassNoQuota bool
 	RedisKey    string
-	CreateTime  int64
 	ExpiredTime int64 // -1 means never expired
 	Quota       int64 // 配额总量
-	ResetMode   int   // 0 – 非周期性；1 – 周期性的配额包
 	Unit        string
 }
 
 type TokenFile struct {
 	Key            string  `json:"key"`
 	KeyID          string  `json:"key_id"`
-	Enabled        int     `json:"enabled"`
-	Status         int     `json:"status"`
-	UpdateTime     int64   `json:"update_time"`
+	Enabled        bool    `json:"enabled"`
 	ExpiredTime    int64   `json:"expired_time"` // -1 means never expired
 	UnlimitedQuota bool    `json:"unlimited_quota"`
 	Models         *string `json:"allow_models"` // allowed models
@@ -199,27 +187,6 @@ func (rlm *APIKeyRuleManager) APIKeyRuleGenerator(ctx context.Context) (*iversio
 		return nil, err
 	}
 
-	// Populate QuotaPlan for status calculation. The raw storager does not load
-	// associated objects, but GetRemainingQuota needs QuotaPlan.Quota to decide
-	// whether the token is exhausted.
-	for _, one := range apiKeyList {
-		if one.QuotaPlanID != nil && rlm.quotaPlanStorager != nil {
-			quotaPlan, err := rlm.quotaPlanStorager.FetchQuotaPlan(ctx, &quota.QuotaPlanFilter{ID: one.QuotaPlanID})
-			if err != nil {
-				return nil, err
-			}
-			if quotaPlan != nil {
-				one.QuotaPlan = &shared.QuotaPlanParam{
-					Unlimited:             quotaPlan.Unlimited,
-					PassWhenNoEnoughQuota: quotaPlan.PassWhenNoEnoughQuota,
-					Quota:                 quotaPlan.Quota,
-					Unit:                  quotaPlan.Unit,
-					ResetPeriod:           quotaPlan.ResetPeriod,
-				}
-			}
-		}
-	}
-
 	apiKey2Config := make(map[string]map[string]*TokenFile)
 	for _, one := range apiKeyList {
 		if _, ok := apiKey2Config[*one.ProductName]; !ok {
@@ -232,43 +199,16 @@ func (rlm *APIKeyRuleManager) APIKeyRuleGenerator(ctx context.Context) (*iversio
 			expiredTime = *one.ExpiredTime
 		}
 
-		status := TokenStatusDisabled
-		var remainQuota float64
-		if one.Enable != nil && *one.Enable {
-			isUnlimited := one.UnlimitedQuota != nil && *one.UnlimitedQuota
-			if !isUnlimited {
-				status = TokenStatusEnabled
-				remainingQuota, err := api_key.GetRemainingQuota(ctx, rlm.quotaCache, one)
-				if err != nil {
-					return nil, err
-				}
-
-				if remainingQuota != nil {
-					remainQuota = *remainingQuota
-					if expiredTime != int64(UnlimitedQuota) && time.Now().Local().Unix() >= expiredTime {
-						status = TokenStatusExpired
-					} else if remainQuota <= 0 {
-						status = TokenStatusExhausted
-					}
-				}
-			} else {
-				status = TokenStatusEnabled
-			}
-		}
+		enabled := one.Enable != nil && *one.Enable
 
 		items := apiKey2Config[*one.ProductName]
 
 		tokenFile := &TokenFile{
 			Key:            *one.Key,
 			KeyID:          *one.ID,
-			Enabled:        2,
-			Status:         status,
+			Enabled:        enabled,
 			ExpiredTime:    expiredTime,
-			UpdateTime:     one.KeyCreateAt.Unix(),
 			UnlimitedQuota: one.UnlimitedQuota != nil && *one.UnlimitedQuota,
-		}
-		if one.Enable != nil && *one.Enable {
-			tokenFile.Enabled = 1
 		}
 
 		// Collect allow_models and block_models from entity hierarchy
@@ -310,12 +250,14 @@ func (rlm *APIKeyRuleManager) APIKeyRuleGenerator(ctx context.Context) (*iversio
 				// Rule 3: intersection empty → disable the token, models empty
 				modelsStr := ""
 				tokenFile.Models = &modelsStr
-				tokenFile.Enabled = 2
+				enabled = false
 			} else {
 				modelsStr := strings.Join(finalAllowModels, ",")
 				tokenFile.Models = &modelsStr
 			}
 		}
+
+		tokenFile.Enabled = enabled
 
 		// Merge block_models from entity hierarchy (union of all)
 		if len(entityBlockModels) > 0 {
@@ -432,10 +374,25 @@ func (rlm *APIKeyRuleManager) fetchEntityQuotaPlanHierarchy(ctx context.Context,
 	tags := make([]ApikeyTag, 0)
 
 	if entity.EntityID != nil && entity.Type != nil && entity.Name != nil {
-		tags = append(tags, ApikeyTag{
+		tag := ApikeyTag{
 			TagName:  *entity.Type,
 			TagValue: *entity.Name,
-		})
+		}
+
+		// Query entity type level for TagLevel.
+		// By business constraint, every entity type must exist and have a valid level.
+		if rlm.entityTypeStorager != nil {
+			entityType, err := rlm.entityTypeStorager.FetchEntityType(ctx, &entpkg.EntityTypeFilter{TypeName: entity.Type})
+			if err != nil {
+				return nil, nil, err
+			}
+			if entityType == nil || entityType.Level == nil {
+				return nil, nil, fmt.Errorf("entity type %s not found or level invalid", *entity.Type)
+			}
+			tag.TagLevel = *entityType.Level
+		}
+
+		tags = append(tags, tag)
 	}
 
 	if entity.QuotaPlanID != nil && rlm.quotaPlanStorager != nil {
@@ -586,18 +543,6 @@ func convertQuotaPlanToExport(qp *quota.QuotaPlanParam, id string, redisKeyID st
 	}
 	if qp.Unit != nil {
 		result.Unit = *qp.Unit
-	}
-	if qp.ResetPeriod != nil {
-		if *qp.ResetPeriod == "weekly" || *qp.ResetPeriod == "monthly" {
-			result.ResetMode = 1
-		} else {
-			result.ResetMode = 0
-		}
-	} else {
-		result.ResetMode = 0
-	}
-	if qp.CreateTime != nil {
-		result.CreateTime = *qp.CreateTime
 	}
 
 	return result

--- a/model/imods/exporter_test.go
+++ b/model/imods/exporter_test.go
@@ -41,7 +41,8 @@ func newTestAPIKeyRuleManager() *APIKeyRuleManager {
 		&fakeAPIKeyStorager{},
 		&fakeAIRouteRuleStorager{},
 		&fakeQuotaPlanStorager{},
-		&fakeEntityStorager{}, nil)
+		&fakeEntityStorager{},
+		&fakeEntityTypeStorager{}, nil)
 }
 
 func TestAPIKeyRuleManager_ConfigExport(t *testing.T) {
@@ -80,7 +81,8 @@ func TestAPIKeyRuleManager_ConfigExport(t *testing.T) {
 		apiKeyStore,
 		aiRouteStore,
 		&fakeQuotaPlanStorager{},
-		&fakeEntityStorager{}, nil)
+		&fakeEntityStorager{},
+		&fakeEntityTypeStorager{}, nil)
 
 	conf, err := m.ConfigExport(ctx, "")
 	require.NoError(t, err)
@@ -180,13 +182,23 @@ func TestAPIKeyRuleManager_ConfigExport_Concurrent(t *testing.T) {
 		},
 	}
 
+	entityTypeStore := &fakeEntityTypeStorager{
+		fetchFn: func(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error) {
+			if filter.TypeName != nil && *filter.TypeName == "team" {
+				return &entity.EntityTypeParam{TypeName: lib.PString("team"), Level: lib.PInt(2)}, nil
+			}
+			return nil, nil
+		},
+	}
+
 	m := NewAPIKeyRuleManager(
 		&fakeTxn{},
 		iversion_control.NewVersionControllerManager(&fakeTxn{}, versionStore),
 		apiKeyStore,
 		aiRouteStore,
 		quotaPlanStore,
-		entityStore, nil)
+		entityStore,
+		entityTypeStore, nil)
 
 	// Increase concurrency to maximize the chance of triggering the race.
 	prevMaxProcs := runtime.GOMAXPROCS(runtime.NumCPU())
@@ -341,13 +353,26 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator(t *testing.T) {
 		},
 	}
 
+	entityTypeStore := &fakeEntityTypeStorager{
+		fetchFn: func(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error) {
+			if filter.TypeName != nil && *filter.TypeName == "team" {
+				return &entity.EntityTypeParam{
+					TypeName: lib.PString("team"),
+					Level:    lib.PInt(2),
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+
 	m := NewAPIKeyRuleManager(
 		&fakeTxn{},
 		iversion_control.NewVersionControllerManager(&fakeTxn{}, &fakeVersionControlStorager{}),
 		apiKeyStore,
 		aiRouteStore,
 		quotaPlanStore,
-		entityStore, nil)
+		entityStore,
+		entityTypeStore, nil)
 
 	data, err := m.APIKeyRuleGenerator(ctx)
 	require.NoError(t, err)
@@ -359,13 +384,13 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator(t *testing.T) {
 	assert.NotNil(t, conf.Tokens["AI_product"]["ak-key-1"])
 	token := conf.Tokens["AI_product"]["ak-key-1"]
 	assert.Equal(t, "key-1", token.KeyID)
-	assert.Equal(t, TokenStatusEnabled, token.Status)
-	assert.Equal(t, 1, token.Enabled)
+	assert.True(t, token.Enabled)
 	assert.Equal(t, "gpt-4", *token.Models)
 	assert.Equal(t, "gpt-2", *token.BlockModels)
 	assert.Equal(t, "10.0.0.0/8", *token.Subnet)
 	assert.NotEmpty(t, token.QuotaPlans)
 	assert.NotEmpty(t, token.Tags)
+	assert.Equal(t, 2, token.Tags[0].TagLevel)
 }
 
 func TestAPIKeyRuleManager_APIKeyRuleGenerator_Unlimited(t *testing.T) {
@@ -402,7 +427,7 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_Unlimited(t *testing.T) {
 	require.NoError(t, err)
 	conf := data.DataWithoutVersion.(*ModAPIKeyRuleConf)
 	token := conf.Tokens["AI_product"]["ak-key-1"]
-	assert.Equal(t, TokenStatusEnabled, token.Status)
+	assert.True(t, token.Enabled)
 	assert.True(t, token.UnlimitedQuota)
 }
 
@@ -455,7 +480,7 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_FalseUnlimitedWithEmptyQuotaPlans
 	require.NoError(t, err)
 	conf := data.DataWithoutVersion.(*ModAPIKeyRuleConf)
 	token := conf.Tokens["AI_product"]["ak-key-1"]
-	assert.Equal(t, TokenStatusEnabled, token.Status)
+	assert.True(t, token.Enabled)
 	assert.Empty(t, token.QuotaPlans)
 	assert.True(t, token.UnlimitedQuota)
 }
@@ -493,7 +518,7 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_MinimalParamsWithNoQuotaPlan(t *t
 	require.NoError(t, err)
 	conf := data.DataWithoutVersion.(*ModAPIKeyRuleConf)
 	token := conf.Tokens["AI_product"]["ak-key-1"]
-	assert.Equal(t, TokenStatusEnabled, token.Status)
+	assert.True(t, token.Enabled)
 	assert.Empty(t, token.QuotaPlans)
 	assert.True(t, token.UnlimitedQuota)
 }
@@ -548,7 +573,7 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_FalseUnlimitedWithNonUnlimitedQuo
 	require.NoError(t, err)
 	conf := data.DataWithoutVersion.(*ModAPIKeyRuleConf)
 	token := conf.Tokens["AI_product"]["ak-key-1"]
-	assert.Equal(t, TokenStatusEnabled, token.Status)
+	assert.True(t, token.Enabled)
 	assert.False(t, token.UnlimitedQuota)
 	assert.NotEmpty(t, token.QuotaPlans)
 }
@@ -591,7 +616,8 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_Expired(t *testing.T) {
 	require.NoError(t, err)
 	conf := data.DataWithoutVersion.(*ModAPIKeyRuleConf)
 	token := conf.Tokens["AI_product"]["ak-key-1"]
-	assert.Equal(t, TokenStatusExpired, token.Status)
+	assert.True(t, token.Enabled)
+	assert.Equal(t, pastExpire, token.ExpiredTime)
 }
 
 func TestAPIKeyRuleManager_APIKeyRuleGenerator_Exhausted(t *testing.T) {
@@ -633,7 +659,8 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_Exhausted(t *testing.T) {
 	require.NoError(t, err)
 	conf := data.DataWithoutVersion.(*ModAPIKeyRuleConf)
 	token := conf.Tokens["AI_product"]["ak-key-1"]
-	assert.Equal(t, TokenStatusExhausted, token.Status)
+	assert.True(t, token.Enabled)
+	assert.Equal(t, futureExpire, token.ExpiredTime)
 }
 
 func TestAPIKeyRuleManager_APIKeyRuleGenerator_Disabled(t *testing.T) {
@@ -668,8 +695,7 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_Disabled(t *testing.T) {
 	require.NoError(t, err)
 	conf := data.DataWithoutVersion.(*ModAPIKeyRuleConf)
 	token := conf.Tokens["AI_product"]["ak-key-1"]
-	assert.Equal(t, TokenStatusDisabled, token.Status)
-	assert.Equal(t, 2, token.Enabled)
+	assert.False(t, token.Enabled)
 }
 
 func TestAPIKeyRuleManager_APIKeyRuleGenerator_ModelIntersectionEmpty(t *testing.T) {
@@ -719,7 +745,7 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_ModelIntersectionEmpty(t *testing
 	conf := data.DataWithoutVersion.(*ModAPIKeyRuleConf)
 	token := conf.Tokens["AI_product"]["ak-key-1"]
 	assert.Equal(t, "", *token.Models)
-	assert.Equal(t, 2, token.Enabled)
+	assert.False(t, token.Enabled)
 }
 
 func TestAPIKeyRuleManager_APIKeyRuleGenerator_EntityHierarchy(t *testing.T) {
@@ -789,11 +815,24 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_EntityHierarchy(t *testing.T) {
 		},
 	}
 
+	entityTypeStore := &fakeEntityTypeStorager{
+		fetchFn: func(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error) {
+			if filter.TypeName != nil && *filter.TypeName == "team" {
+				return &entity.EntityTypeParam{TypeName: lib.PString("team"), Level: lib.PInt(2)}, nil
+			}
+			if filter.TypeName != nil && *filter.TypeName == "org" {
+				return &entity.EntityTypeParam{TypeName: lib.PString("org"), Level: lib.PInt(1)}, nil
+			}
+			return nil, nil
+		},
+	}
+
 	m := newTestAPIKeyRuleManager()
 	m.apiKeyStorager = apiKeyStore
 	m.aiRouteStorager = aiRouteStore
 	m.quotaPlanStorager = quotaPlanStore
 	m.entityStorager = entityStore
+	m.entityTypeStorager = entityTypeStore
 
 	data, err := m.APIKeyRuleGenerator(ctx)
 	require.NoError(t, err)
@@ -801,6 +840,8 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_EntityHierarchy(t *testing.T) {
 	token := conf.Tokens["AI_product"]["ak-key-1"]
 	assert.Equal(t, "gpt-4", *token.Models)
 	assert.Len(t, token.Tags, 2)
+	assert.Equal(t, 2, token.Tags[0].TagLevel)
+	assert.Equal(t, 1, token.Tags[1].TagLevel)
 	assert.Contains(t, token.QuotaPlans, "entity-1")
 }
 
@@ -844,9 +885,19 @@ func TestAPIKeyRuleManager_FetchQuotaPlansWithEntityHierarchy(t *testing.T) {
 		},
 	}
 
+	entityTypeStore := &fakeEntityTypeStorager{
+		fetchFn: func(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error) {
+			if filter.TypeName != nil && *filter.TypeName == "team" {
+				return &entity.EntityTypeParam{TypeName: lib.PString("team"), Level: lib.PInt(2)}, nil
+			}
+			return nil, nil
+		},
+	}
+
 	m := newTestAPIKeyRuleManager()
 	m.quotaPlanStorager = quotaPlanStore
 	m.entityStorager = entityStore
+	m.entityTypeStorager = entityTypeStore
 	collectedQuotaPlans := make(map[string][]*QuotaPlan)
 
 	ids, tags, err := m.fetchQuotaPlansWithEntityHierarchy(ctx, apiKey, "AI_product", collectedQuotaPlans)
@@ -854,6 +905,7 @@ func TestAPIKeyRuleManager_FetchQuotaPlansWithEntityHierarchy(t *testing.T) {
 	assert.Len(t, ids, 1)
 	assert.Len(t, tags, 1)
 	assert.Equal(t, "team-a", tags[0].TagValue)
+	assert.Equal(t, 2, tags[0].TagLevel)
 }
 
 func TestAPIKeyRuleManager_FetchEntityModelHierarchy(t *testing.T) {

--- a/model/imods/mocks_test.go
+++ b/model/imods/mocks_test.go
@@ -278,6 +278,52 @@ func (s *fakeEntityStorager) DeleteEntity(ctx context.Context, filter *entity.En
 
 var _ entity.EntityStorager = (*fakeEntityStorager)(nil)
 
+// fakeEntityTypeStorager implements entity.EntityTypeStorager.
+type fakeEntityTypeStorager struct {
+	createFn func(ctx context.Context, param *entity.EntityTypeParam) (int64, error)
+	fetchFn  func(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error)
+	listFn   func(ctx context.Context, filter *entity.EntityTypeFilter) ([]*entity.EntityTypeParam, error)
+	updateFn func(ctx context.Context, filter *entity.EntityTypeFilter, param *entity.EntityTypeParam) (int64, error)
+	deleteFn func(ctx context.Context, filter *entity.EntityTypeFilter) error
+}
+
+func (s *fakeEntityTypeStorager) CreateEntityType(ctx context.Context, param *entity.EntityTypeParam) (int64, error) {
+	if s.createFn != nil {
+		return s.createFn(ctx, param)
+	}
+	return 0, nil
+}
+
+func (s *fakeEntityTypeStorager) FetchEntityType(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error) {
+	if s.fetchFn != nil {
+		return s.fetchFn(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (s *fakeEntityTypeStorager) FetchEntityTypeList(ctx context.Context, filter *entity.EntityTypeFilter) ([]*entity.EntityTypeParam, error) {
+	if s.listFn != nil {
+		return s.listFn(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (s *fakeEntityTypeStorager) UpdateEntityType(ctx context.Context, filter *entity.EntityTypeFilter, param *entity.EntityTypeParam) (int64, error) {
+	if s.updateFn != nil {
+		return s.updateFn(ctx, filter, param)
+	}
+	return 0, nil
+}
+
+func (s *fakeEntityTypeStorager) DeleteEntityType(ctx context.Context, filter *entity.EntityTypeFilter) error {
+	if s.deleteFn != nil {
+		return s.deleteFn(ctx, filter)
+	}
+	return nil
+}
+
+var _ entity.EntityTypeStorager = (*fakeEntityTypeStorager)(nil)
+
 // fakeVersionControlStorager implements iversion_control.VersionControlStorager.
 type fakeVersionControlStorager struct {
 	upsertFn func(ctx context.Context, css *iversion_control.ExportData) (string, error)

--- a/model/imods/mod_api_key_rule.go
+++ b/model/imods/mod_api_key_rule.go
@@ -31,6 +31,7 @@ type APIKeyRuleManager struct {
 	aiRouteStorager       iai_route.AIRouteRuleStorager
 	quotaPlanStorager     quota.QuotaPlanStorager
 	entityStorager        entity.EntityStorager
+	entityTypeStorager    entity.EntityTypeStorager
 	quotaCache            quotacache.QuotaCache
 }
 
@@ -70,6 +71,7 @@ func NewAPIKeyRuleManager(txn itxn.TxnStorager,
 	aiRouteStorager iai_route.AIRouteRuleStorager,
 	quotaPlanStorager quota.QuotaPlanStorager,
 	entityStorager entity.EntityStorager,
+	entityTypeStorager entity.EntityTypeStorager,
 	quotaCache quotacache.QuotaCache) *APIKeyRuleManager {
 	return &APIKeyRuleManager{
 		txn:                   txn,
@@ -78,6 +80,7 @@ func NewAPIKeyRuleManager(txn itxn.TxnStorager,
 		aiRouteStorager:       aiRouteStorager,
 		quotaPlanStorager:     quotaPlanStorager,
 		entityStorager:        entityStorager,
+		entityTypeStorager:    entityTypeStorager,
 		quotaCache:            quotaCache,
 	}
 }

--- a/model/imods/mod_api_key_rule_test.go
+++ b/model/imods/mod_api_key_rule_test.go
@@ -31,7 +31,8 @@ func TestNewAPIKeyRuleManager(t *testing.T) {
 		&fakeAPIKeyStorager{},
 		&fakeAIRouteRuleStorager{},
 		&fakeQuotaPlanStorager{},
-		&fakeEntityStorager{}, nil)
+		&fakeEntityStorager{},
+		&fakeEntityTypeStorager{}, nil)
 	assert.NotNil(t, m)
 	assert.NotNil(t, m.txn)
 	assert.NotNil(t, m.versionControlManager)
@@ -80,15 +81,11 @@ func TestConvertQuotaPlanToExport(t *testing.T) {
 	unlimited := false
 	passNoQuota := true
 	quotaVal := float64(1000)
-	period := "monthly"
-	createTime := int64(1234567890)
 
 	qp := convertQuotaPlanToExport(&quota.QuotaPlanParam{
 		Unlimited:             &unlimited,
 		PassWhenNoEnoughQuota: &passNoQuota,
 		Quota:                 &quotaVal,
-		ResetPeriod:           &period,
-		CreateTime:            &createTime,
 	}, "id-1", "redis-1")
 
 	assert.Equal(t, "id-1", qp.Id)
@@ -96,25 +93,7 @@ func TestConvertQuotaPlanToExport(t *testing.T) {
 	assert.False(t, qp.Unlimited)
 	assert.True(t, qp.PassNoQuota)
 	assert.Equal(t, int64(1000), qp.Quota)
-	assert.Equal(t, 1, qp.ResetMode)
-	assert.Equal(t, int64(1234567890), qp.CreateTime)
 	assert.Equal(t, int64(-1), qp.ExpiredTime)
-}
-
-func TestConvertQuotaPlanToExport_Weekly(t *testing.T) {
-	period := "weekly"
-	qp := convertQuotaPlanToExport(&quota.QuotaPlanParam{
-		ResetPeriod: &period,
-	}, "id-1", "redis-1")
-	assert.Equal(t, 1, qp.ResetMode)
-}
-
-func TestConvertQuotaPlanToExport_OtherPeriod(t *testing.T) {
-	period := "daily"
-	qp := convertQuotaPlanToExport(&quota.QuotaPlanParam{
-		ResetPeriod: &period,
-	}, "id-1", "redis-1")
-	assert.Equal(t, 0, qp.ResetMode)
 }
 
 func TestConvertQuotaPlanToExport_Unlimited(t *testing.T) {
@@ -166,7 +145,8 @@ func TestBuildAIRouteAPIKeyRules(t *testing.T) {
 		&fakeAPIKeyStorager{},
 		aiRouteStore,
 		&fakeQuotaPlanStorager{},
-		&fakeEntityStorager{}, nil)
+		&fakeEntityStorager{},
+		&fakeEntityTypeStorager{}, nil)
 
 	product2config, err := m.buildAIRouteAPIKeyRules(ctx)
 	assert.NoError(t, err)
@@ -193,7 +173,8 @@ func TestBuildAIRouteAPIKeyRules_Error(t *testing.T) {
 		&fakeAPIKeyStorager{},
 		aiRouteStore,
 		&fakeQuotaPlanStorager{},
-		&fakeEntityStorager{}, nil)
+		&fakeEntityStorager{},
+		&fakeEntityTypeStorager{}, nil)
 
 	product2config, err := m.buildAIRouteAPIKeyRules(ctx)
 	assert.Error(t, err)

--- a/stateful/container/rdb/components.go
+++ b/stateful/container/rdb/components.go
@@ -224,6 +224,7 @@ func Init() error {
 		container.AIRouteRuleStorager,
 		container.QuotaPlanStorager,
 		container.EntityStorager,
+		container.EntityTypeStorager,
 		container.QuotaCacheSingleton,
 	)
 

--- a/test/integration/tests/innerapi/mod_api_key/mod_api_key_test.go
+++ b/test/integration/tests/innerapi/mod_api_key/mod_api_key_test.go
@@ -49,7 +49,7 @@ func TestInnerAPI_ModApiKey(t *testing.T) {
 		testutil.AssertDataFieldNotEmpty(t, resp, "QuotaPlans")
 		testutil.AssertDataFieldNotEmpty(t, resp, "tokens")
 
-		// 验证导出的 token 包含 key_id 且不包含 name
+		// 验证导出的 token 包含 key_id 且不包含 name/status/update_time，enabled 为 bool
 		var data map[string]interface{}
 		if err := testutil.UnmarshalData(resp, &data); err != nil {
 			t.Fatalf("parse data failed: %v", err)
@@ -75,6 +75,43 @@ func TestInnerAPI_ModApiKey(t *testing.T) {
 			}
 			if _, ok := tokenMap["name"]; ok {
 				t.Errorf("token %s should not contain name", key)
+			}
+			if _, ok := tokenMap["status"]; ok {
+				t.Errorf("token %s should not contain status", key)
+			}
+			if _, ok := tokenMap["update_time"]; ok {
+				t.Errorf("token %s should not contain update_time", key)
+			}
+			enabled, ok := tokenMap["enabled"].(bool)
+			if !ok {
+				t.Errorf("token %s enabled should be bool", key)
+			}
+			if !enabled {
+				t.Errorf("token %s should be enabled", key)
+			}
+		}
+
+		// 验证 QuotaPlans 不包含 CreateTime、ResetMode
+		quotaPlans, ok := data["QuotaPlans"].(map[string]interface{})
+		if !ok {
+			t.Fatal("QuotaPlans is not an object")
+		}
+		for product, plans := range quotaPlans {
+			planList, ok := plans.([]interface{})
+			if !ok {
+				t.Fatalf("QuotaPlans.%s is not an array", product)
+			}
+			for i, plan := range planList {
+				planMap, ok := plan.(map[string]interface{})
+				if !ok {
+					t.Fatalf("QuotaPlans.%s[%d] is not an object", product, i)
+				}
+				if _, ok := planMap["CreateTime"]; ok {
+					t.Errorf("QuotaPlans.%s[%d] should not contain CreateTime", product, i)
+				}
+				if _, ok := planMap["ResetMode"]; ok {
+					t.Errorf("QuotaPlans.%s[%d] should not contain ResetMode", product, i)
+				}
 			}
 		}
 	})

--- a/test/integration/tests/schema/innerapi/innerapi_schema_test.go
+++ b/test/integration/tests/schema/innerapi/innerapi_schema_test.go
@@ -1,6 +1,7 @@
 package innerapi
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -171,11 +172,128 @@ func testModAPIKeySchema(t *testing.T) {
 	testutil.AssertSuccess(t, innerResp)
 	if innerResp.Data != nil && string(innerResp.Data) != "null" {
 		testutil.AssertSchema(t, innerResp, ModAPIKeySchema)
+		assertModAPIKeyFieldDetails(t, innerResp.Data)
 	}
 
 	t.Cleanup(func() {
 		testutil.DeleteAPIKey(apiKeyID)
 	})
+}
+
+// assertModAPIKeyFieldDetails 校验 /configs/mod-api-key 响应中 tokens 和 QuotaPlans 的字段细节：
+// token 的 enabled 为 bool，不包含 status/update_time；QuotaPlan 不包含 CreateTime/ResetMode；Tags 包含 TagLevel。
+func assertModAPIKeyFieldDetails(t *testing.T, data []byte) {
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal mod-api-key data: %v", err)
+	}
+
+	tokens, ok := payload["tokens"].(map[string]interface{})
+	if !ok {
+		t.Fatal("tokens is not an object")
+	}
+	for product, productTokens := range tokens {
+		productTokenMap, ok := productTokens.(map[string]interface{})
+		if !ok {
+			t.Fatalf("tokens.%s is not an object", product)
+		}
+		for key, token := range productTokenMap {
+			tokenMap, ok := token.(map[string]interface{})
+			if !ok {
+				t.Fatalf("tokens.%s.%s is not an object", product, key)
+			}
+			if _, ok := tokenMap["status"]; ok {
+				t.Errorf("tokens.%s.%s should not contain status", product, key)
+			}
+			if _, ok := tokenMap["update_time"]; ok {
+				t.Errorf("tokens.%s.%s should not contain update_time", product, key)
+			}
+			if enabled, ok := tokenMap["enabled"].(bool); !ok {
+				t.Errorf("tokens.%s.%s.enabled should be bool", product, key)
+			} else if !enabled {
+				t.Errorf("tokens.%s.%s.enabled should be true", product, key)
+			}
+			if keyID, ok := tokenMap["key_id"].(string); !ok || keyID == "" {
+				t.Errorf("tokens.%s.%s.key_id should be non-empty string", product, key)
+			}
+			if expiredTime, ok := tokenMap["expired_time"].(float64); !ok {
+				t.Errorf("tokens.%s.%s.expired_time should be number", product, key)
+			} else if expiredTime != -1 {
+				// ok, can be -1 or a timestamp
+			}
+			if _, ok := tokenMap["unlimited_quota"].(bool); !ok {
+				t.Errorf("tokens.%s.%s.unlimited_quota should be bool", product, key)
+			}
+			if models, ok := tokenMap["allow_models"].(string); ok && models == "*" {
+				t.Errorf("tokens.%s.%s.allow_models should not be '*', got %q", product, key, models)
+			}
+			if quotaPlans, ok := tokenMap["quota_plans"].([]interface{}); ok {
+				for i, qp := range quotaPlans {
+					if _, ok := qp.(string); !ok {
+						t.Errorf("tokens.%s.%s.quota_plans[%d] should be string", product, key, i)
+					}
+				}
+			}
+			if tags, ok := tokenMap["Tags"].([]interface{}); ok {
+				for i, tag := range tags {
+					tagMap, ok := tag.(map[string]interface{})
+					if !ok {
+						t.Fatalf("tokens.%s.%s.Tags[%d] is not an object", product, key, i)
+					}
+					if _, ok := tagMap["TagName"].(string); !ok {
+						t.Errorf("tokens.%s.%s.Tags[%d].TagName should be string", product, key, i)
+					}
+					if _, ok := tagMap["TagValue"].(string); !ok {
+						t.Errorf("tokens.%s.%s.Tags[%d].TagValue should be string", product, key, i)
+					}
+					if _, ok := tagMap["TagLevel"].(float64); !ok {
+						t.Errorf("tokens.%s.%s.Tags[%d].TagLevel should be int", product, key, i)
+					}
+				}
+			}
+		}
+	}
+
+	quotaPlans, ok := payload["QuotaPlans"].(map[string]interface{})
+	if !ok {
+		t.Fatal("QuotaPlans is not an object")
+	}
+	for product, plans := range quotaPlans {
+		planList, ok := plans.([]interface{})
+		if !ok {
+			t.Fatalf("QuotaPlans.%s is not an array", product)
+		}
+		for i, plan := range planList {
+			planMap, ok := plan.(map[string]interface{})
+			if !ok {
+				t.Fatalf("QuotaPlans.%s[%d] is not an object", product, i)
+			}
+			if _, ok := planMap["CreateTime"]; ok {
+				t.Errorf("QuotaPlans.%s[%d] should not contain CreateTime", product, i)
+			}
+			if _, ok := planMap["ResetMode"]; ok {
+				t.Errorf("QuotaPlans.%s[%d] should not contain ResetMode", product, i)
+			}
+			if id, ok := planMap["Id"].(string); !ok || id == "" {
+				t.Errorf("QuotaPlans.%s[%d].Id should be non-empty string", product, i)
+			}
+			if _, ok := planMap["Unlimited"].(bool); !ok {
+				t.Errorf("QuotaPlans.%s[%d].Unlimited should be bool", product, i)
+			}
+			if _, ok := planMap["PassNoQuota"].(bool); !ok {
+				t.Errorf("QuotaPlans.%s[%d].PassNoQuota should be bool", product, i)
+			}
+			if redisKey, ok := planMap["RedisKey"].(string); !ok || redisKey == "" {
+				t.Errorf("QuotaPlans.%s[%d].RedisKey should be non-empty string", product, i)
+			}
+			if _, ok := planMap["ExpiredTime"].(float64); !ok {
+				t.Errorf("QuotaPlans.%s[%d].ExpiredTime should be number", product, i)
+			}
+			if _, ok := planMap["Quota"].(float64); !ok {
+				t.Errorf("QuotaPlans.%s[%d].Quota should be number", product, i)
+			}
+		}
+	}
 }
 
 func testModBodyProcessSchema(t *testing.T) {


### PR DESCRIPTION
- TokenFile: remove Status/UpdateTime, change Enabled from int to bool
- QuotaPlan: remove CreateTime/ResetMode
- ApikeyTag: add TagLevel from EntityType.Level
- APIKeyRuleManager: inject EntityTypeStorager for TagLevel lookup
- Update unit/endpoint/integration/schema tests and design docs