### PR TITLE
perf(imods): batch preload entity/quota/entity-type for mod-api-key e…

### DIFF
--- a/design-docs/modifications/2026-08-24-mod-api-key-export-performance/design-changes.md
+++ b/design-docs/modifications/2026-08-24-mod-api-key-export-performance/design-changes.md
@@ -1,0 +1,399 @@
+# mod-api-key 配置导出性能优化
+
+## 1. 背景
+
+线上用户通过 Open API 批量写入 690 个 API Key 后，BFE 数据面出现部分 Key 报 `INVALID_API_KEY` 的故障。排查发现 conf-agent 拉取 `/inner-api/v1/configs/mod-api-key` 时反复超时：
+
+```text
+context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+```
+
+根本原因是 `ai-gateway-api/model/imods/exporter.go` 中的 `APIKeyRuleGenerator` 对每个 API Key 都进行多次单条数据库查询（Entity 层级、QuotaPlan、EntityType），形成 N+1 查询。690 个 Key 会触发数千次 DB 查询，导致接口响应超过 conf-agent 的 1.5 秒超时，BFE 只能拿到不完整的 `token_rule.data`。
+
+相邻的 `ai-route` 导出逻辑（`ai-gateway-api/model/imods/ai_route_exporter.go`）已经采用“全量 Entity 预加载 + 内存 Map 回溯”的方式，mod-api-key 导出逻辑需要同步改造。
+
+---
+
+## 2. 目标
+
+1. 将 `/inner-api/v1/configs/mod-api-key` 接口的 DB 查询次数从 **O(N × 层级数)** 降到 **O(4)**。
+2. 保证 690 个 API Key、3 层 Entity 层级的场景下，单线程 `ConfigExport` 耗时 < 500 ms。
+3. 保持导出的 JSON 配置结构与现有 BFE 消费侧完全兼容。
+4. 补充单元测试与集成测试，覆盖批量 Key 场景。
+
+---
+
+## 3. 方案概述
+
+### 3.1 核心思路
+
+在 `APIKeyRuleGenerator` 中，先一次性全量加载三类数据到内存索引，再遍历 API Key：
+
+- 全量 API Key（已有 `FetchAPIKeyList`）
+- 全量 Entity（已有 `FetchEntityList`）
+- 全量 QuotaPlan（已有 `FetchQuotaPlanList`）
+- 全量 EntityType（需确认/新增 `FetchEntityTypeList`）
+
+后续所有 Entity 层级、QuotaPlan、EntityType 查询全部走内存 Map，不再递归调用单条 `FetchEntity`/`FetchQuotaPlan`/`FetchEntityType`。
+
+### 3.2 与 ai_route_exporter 的差异
+
+ai_route 场景只需要 Entity Map；mod-api-key 还需要 QuotaPlan Map 和 EntityType Map，用于计算每个 Token 的 `QuotaPlans` 和 `Tags`。
+
+---
+
+## 4. 具体改动
+
+### 4.1 `APIKeyRuleGenerator` 预加载数据
+
+**文件：** `ai-gateway-api/model/imods/exporter.go`
+
+当前 `APIKeyRuleGenerator` 直接遍历 API Key 列表，对每个 Key 调用递归查询：
+
+```go
+apiKeyList, err := rlm.apiKeyStorager.FetchAPIKeyList(ctx, &api_key.APIKeyFilter{})
+// ...
+for _, one := range apiKeyList {
+    if one.EntityID != nil && *one.EntityID != "" && rlm.entityStorager != nil {
+        entityAllowModels, entityBlockModels, err = rlm.fetchEntityModelHierarchy(ctx, *one.EntityID)
+        // ...
+    }
+    quotaPlanIDs, tags, err := rlm.fetchQuotaPlansWithEntityHierarchy(ctx, one, *one.ProductName, collectedQuotaPlans)
+    // ...
+}
+```
+
+改造后在循环前批量加载：
+
+```go
+func (rlm *APIKeyRuleManager) APIKeyRuleGenerator(ctx context.Context) (*iversion_control.ExportData, error) {
+    collectedQuotaPlans := make(map[string][]*QuotaPlan)
+
+    product2config, err := rlm.buildAIRouteAPIKeyRules(ctx)
+    if err != nil {
+        return nil, err
+    }
+
+    productName2Config := make(map[string][]*TokenRuleFile)
+    for productName, productConfig := range product2config {
+        if len(productConfig.Rules) > 0 {
+            productName2Config[productName] = convertAPIKeyRulesToBfeRules(productConfig.Rules)
+        }
+    }
+
+    // 1. 全量 API Key
+    apiKeyList, err := rlm.apiKeyStorager.FetchAPIKeyList(ctx, &api_key.APIKeyFilter{})
+    if err != nil {
+        return nil, err
+    }
+
+    // 2. 全量 Entity
+    entityMap, err := rlm.buildEntityMap(ctx)
+    if err != nil {
+        return nil, err
+    }
+
+    // 3. 全量 QuotaPlan
+    quotaPlanMap, err := rlm.buildQuotaPlanMap(ctx)
+    if err != nil {
+        return nil, err
+    }
+
+    // 4. 全量 EntityType
+    entityTypeMap, err := rlm.buildEntityTypeMap(ctx)
+    if err != nil {
+        return nil, err
+    }
+
+    apiKey2Config := make(map[string]map[string]*TokenFile)
+    for _, one := range apiKeyList {
+        // ... 使用 entityMap / quotaPlanMap / entityTypeMap 填充 TokenFile
+    }
+
+    // ...
+}
+```
+
+新增辅助函数：
+
+```go
+func (rlm *APIKeyRuleManager) buildEntityMap(ctx context.Context) (map[string]*entpkg.EntityParam, error) {
+    if rlm.entityStorager == nil {
+        return nil, nil
+    }
+    allEntities, err := rlm.entityStorager.FetchEntityList(ctx, &entpkg.EntityFilter{})
+    if err != nil {
+        return nil, err
+    }
+    entityMap := make(map[string]*entpkg.EntityParam, len(allEntities))
+    for _, e := range allEntities {
+        if e.EntityID != nil {
+            entityMap[*e.EntityID] = e
+        }
+    }
+    return entityMap, nil
+}
+
+func (rlm *APIKeyRuleManager) buildQuotaPlanMap(ctx context.Context) (map[int64]*quota.QuotaPlanParam, error) {
+    if rlm.quotaPlanStorager == nil {
+        return nil, nil
+    }
+    allPlans, err := rlm.quotaPlanStorager.FetchQuotaPlanList(ctx, &quota.QuotaPlanFilter{})
+    if err != nil {
+        return nil, err
+    }
+    planMap := make(map[int64]*quota.QuotaPlanParam, len(allPlans))
+    for _, qp := range allPlans {
+        if qp.ID != nil {
+            planMap[*qp.ID] = qp
+        }
+    }
+    return planMap, nil
+}
+
+func (rlm *APIKeyRuleManager) buildEntityTypeMap(ctx context.Context) (map[string]*entpkg.EntityTypeParam, error) {
+    if rlm.entityTypeStorager == nil {
+        return nil, nil
+    }
+    allTypes, err := rlm.entityTypeStorager.FetchEntityTypeList(ctx, &entpkg.EntityTypeFilter{})
+    if err != nil {
+        return nil, err
+    }
+    typeMap := make(map[string]*entpkg.EntityTypeParam, len(allTypes))
+    for _, et := range allTypes {
+        if et.TypeName != nil {
+            typeMap[*et.TypeName] = et
+        }
+    }
+    return typeMap, nil
+}
+```
+
+### 4.2 递归查询改为内存回溯
+
+**文件：** `ai-gateway-api/model/imods/exporter.go`
+
+在文件顶部新增层级深度保护常量，防止异常 `parent_id` 循环导致死循环：
+
+```go
+// maxEntityHierarchyDepth limits the number of ancestor levels walked when
+// resolving Entity hierarchy, protecting against accidental parent_id cycles.
+const maxEntityHierarchyDepth = 10
+```
+
+#### 4.2.1 `fetchEntityModelHierarchy`
+
+保留原函数名，增加 `entityMap` 参数，移除对 `collectEntityModels` 的递归调用：
+
+```go
+func (rlm *APIKeyRuleManager) fetchEntityModelHierarchy(ctx context.Context, entityMap map[string]*entpkg.EntityParam, entityID string) ([]string, []string, error) {
+    var allAllowModels [][]string
+    var allBlockModels []string
+
+    for depth := 0; depth < maxEntityHierarchyDepth; depth++ {
+        entity, ok := entityMap[entityID]
+        if !ok || entity == nil {
+            break
+        }
+        if len(entity.AllowModels) > 0 && !containsStar(entity.AllowModels) {
+            allAllowModels = append(allAllowModels, entity.AllowModels)
+        }
+        if len(entity.BlockModels) > 0 && !containsStar(entity.BlockModels) {
+            allBlockModels = append(allBlockModels, entity.BlockModels...)
+        }
+        if entity.ParentID == nil || *entity.ParentID == "" {
+            break
+        }
+        entityID = *entity.ParentID
+    }
+
+    return intersectAllowModels(allAllowModels), allBlockModels, nil
+}
+```
+
+#### 4.2.2 `fetchEntityQuotaPlanHierarchy`
+
+保留原函数名，增加 `entityMap`、`quotaPlanMap`、`entityTypeMap` 参数：
+
+```go
+func (rlm *APIKeyRuleManager) fetchEntityQuotaPlanHierarchy(ctx context.Context, entityMap map[string]*entpkg.EntityParam, quotaPlanMap map[int64]*quota.QuotaPlanParam, entityTypeMap map[string]*entpkg.EntityTypeParam, entityID string, productName string, collectedQuotaPlans map[string][]*QuotaPlan) ([]string, []ApikeyTag, error) {
+    var quotaPlanIDs []string
+    var tags []ApikeyTag
+
+    for depth := 0; depth < maxEntityHierarchyDepth; depth++ {
+        entity, ok := entityMap[entityID]
+        if !ok || entity == nil {
+            break
+        }
+
+        if entity.EntityID != nil && entity.Type != nil && entity.Name != nil {
+            tag := ApikeyTag{
+                TagName:  *entity.Type,
+                TagValue: *entity.Name,
+            }
+            if rlm.entityTypeStorager != nil {
+                entityType, ok := entityTypeMap[*entity.Type]
+                if !ok || entityType == nil || entityType.Level == nil {
+                    return nil, nil, fmt.Errorf("entity type %s not found or level invalid", *entity.Type)
+                }
+                tag.TagLevel = *entityType.Level
+            }
+            tags = append(tags, tag)
+        }
+
+        if entity.QuotaPlanID != nil && rlm.quotaPlanStorager != nil {
+            if quotaPlan, ok := quotaPlanMap[*entity.QuotaPlanID]; ok && quotaPlan != nil && entity.EntityID != nil {
+                if quotaPlan.Unlimited == nil || !*quotaPlan.Unlimited {
+                    qp := convertQuotaPlanToExport(quotaPlan, *entity.EntityID, *entity.EntityID)
+                    if !containsQuotaPlan(collectedQuotaPlans, productName, qp.Id) {
+                        if _, ok := collectedQuotaPlans[productName]; !ok {
+                            collectedQuotaPlans[productName] = make([]*QuotaPlan, 0)
+                        }
+                        collectedQuotaPlans[productName] = append(collectedQuotaPlans[productName], qp)
+                    }
+                    quotaPlanIDs = append(quotaPlanIDs, qp.Id)
+                }
+            }
+        }
+
+        if entity.ParentID == nil || *entity.ParentID == "" {
+            break
+        }
+        entityID = *entity.ParentID
+    }
+
+    return quotaPlanIDs, tags, nil
+}
+```
+
+#### 4.2.3 `fetchQuotaPlansWithEntityHierarchy` 适配
+
+保留原函数名，增加三个 Map 参数，API Key 自身 QuotaPlan 也走 `quotaPlanMap`：
+
+```go
+func (rlm *APIKeyRuleManager) fetchQuotaPlansWithEntityHierarchy(ctx context.Context, apiKey *api_key.APIKeyParam, productName string, collectedQuotaPlans map[string][]*QuotaPlan, entityMap map[string]*entpkg.EntityParam, quotaPlanMap map[int64]*quota.QuotaPlanParam, entityTypeMap map[string]*entpkg.EntityTypeParam) ([]string, []ApikeyTag, error) {
+    quotaPlanIDs := make([]string, 0)
+    tags := make([]ApikeyTag, 0)
+
+    if apiKey.QuotaPlanID != nil && rlm.quotaPlanStorager != nil {
+        if quotaPlan, ok := quotaPlanMap[*apiKey.QuotaPlanID]; ok && quotaPlan != nil && apiKey.Key != nil {
+            if quotaPlan.Unlimited == nil || !*quotaPlan.Unlimited {
+                qp := convertQuotaPlanToExport(quotaPlan, *apiKey.Key, *apiKey.Key)
+                if !containsQuotaPlan(collectedQuotaPlans, productName, qp.Id) {
+                    if _, ok := collectedQuotaPlans[productName]; !ok {
+                        collectedQuotaPlans[productName] = make([]*QuotaPlan, 0)
+                    }
+                    collectedQuotaPlans[productName] = append(collectedQuotaPlans[productName], qp)
+                }
+                quotaPlanIDs = append(quotaPlanIDs, qp.Id)
+            }
+        }
+    }
+
+    if apiKey.EntityID != nil && *apiKey.EntityID != "" && rlm.entityStorager != nil {
+        entityIDs, entityTags, err := rlm.fetchEntityQuotaPlanHierarchy(ctx, entityMap, quotaPlanMap, entityTypeMap, *apiKey.EntityID, productName, collectedQuotaPlans)
+        if err != nil {
+            return nil, nil, err
+        }
+        quotaPlanIDs = append(quotaPlanIDs, entityIDs...)
+        tags = append(tags, entityTags...)
+    }
+
+    return quotaPlanIDs, tags, nil
+}
+```
+
+### 4.3 EntityType 批量查询接口
+
+**文件：** `ai-gateway-api/model/entity/entity_type.go`
+
+确认 `EntityTypeStorager` 接口是否已有 `FetchEntityTypeList`：
+
+```go
+type EntityTypeStorager interface {
+    // ...
+    FetchEntityTypeList(ctx context.Context, filter *EntityTypeFilter) ([]*EntityTypeParam, error)
+}
+```
+
+若缺失，需新增接口方法并在 `storage/rdb/entity/entity_type.go` 中实现。
+
+---
+
+## 5. 涉及文件清单
+
+| 文件 | 修改内容 |
+|---|---|
+| `ai-gateway-api/model/imods/exporter.go` | `APIKeyRuleGenerator` 预加载 Entity/QuotaPlan/EntityType；`fetchEntityModelHierarchy`、`fetchQuotaPlansWithEntityHierarchy`、`fetchEntityQuotaPlanHierarchy` 改为基于内存 Map 的回溯。 |
+| `ai-gateway-api/model/imods/exporter_test.go` | mock `FetchEntityList`、`FetchQuotaPlanList`、`FetchEntityTypeList`；补充 690 Key 量级的性能/正确性测试。 |
+| `ai-gateway-api/model/imods/mocks_test.go` | 若缺少批量查询 mock，需补充。 |
+| `ai-gateway-api/model/entity/entity_type.go` | 确认/新增 `EntityTypeStorager.FetchEntityTypeList` 接口。 |
+| `ai-gateway-api/storage/rdb/entity/entity_type.go` | 若接口新增 `FetchEntityTypeList`，需实现 DAO。 |
+
+---
+
+## 6. 测试计划
+
+### 6.1 单元测试
+
+**文件：** `ai-gateway-api/model/imods/exporter_test.go`
+
+新增测试 `TestAPIKeyRuleManager_ConfigExport_Performance`：
+
+1. 构造 690 个 API Key，每个关联不同 Entity / QuotaPlan，Entity 层级 3 层。
+2. mock `FetchAPIKeyList`、`FetchEntityList`、`FetchQuotaPlanList`、`FetchEntityTypeList` 一次性返回。
+3. 断言：
+   - 导出结果包含全部 690 个 Token。
+   - QuotaPlans 收集正确，无重复。
+   - Entity 层级 Tags 正确。
+   - `ConfigExport` 耗时 < 500 ms。
+
+运行命令：
+
+```bash
+cd ai-gateway-api
+go test ./model/imods/... -run TestAPIKeyRuleManager_ConfigExport_Performance -v
+```
+
+### 6.2 集成测试
+
+**文件：** `ai-gateway-api/test/integration/tests/innerapi/mod_api_key/mod_api_key_test.go`
+
+1. 批量创建 700+ API Key。
+2. 调用 `/inner-api/v1/configs/mod-api-key`，断言返回 200 且包含全部 Key。
+3. 验证 BFE `token_rule.data` 文件大小与 Key 数量成正比。
+
+### 6.3 回归测试
+
+```bash
+cd ai-gateway-api
+make test-model
+make test-model-cover-gate
+```
+
+---
+
+## 7. 兼容性说明
+
+- `/configs/mod-api-key` 返回的 JSON 结构不变，BFE 消费侧无需修改。
+- 数据库 schema 不变，仅查询方式从单条递归改为批量 + 内存回溯。
+
+---
+
+## 8. 风险与缓解
+
+| 风险 | 缓解措施 |
+|---|---|
+| 批量加载全量 Entity/QuotaPlan/EntityType 导致瞬时内存 spike | 690 条记录全量加载内存占用极小（< 10 MB），可接受；后续若达十万级再考虑分页或缓存。 |
+| `FetchEntityTypeList` 接口/DAO 当前不存在 | 需确认 `EntityTypeStorager` 接口；如缺失，需新增 `FetchEntityTypeList` 并在 `storage/rdb/entity/entity_type.go` 实现。 |
+| 并发多个 conf-agent 同时拉取 | 结合版本控制：未变更时 `ExportConfig` 返回 `nil`，不会重复生成大数据包。 |
+| 内存 Map 中 Entity 父级循环引用导致死循环 | Entity 层级按业务约束为树形结构；回溯时增加最大深度保护（如 10 层）。 |
+
+---
+
+## 9. 建议实施顺序
+
+1. **本周**：确认 `EntityTypeStorager.FetchEntityTypeList` 接口与 DAO 实现是否齐全；不齐则补齐。
+2. **本周**：在 `ai-gateway-api/model/imods/exporter.go` 中实现 Entity/QuotaPlan/EntityType 批量预加载，重构递归查询为内存回溯。
+3. **本周**：补充 690 Key 量级的单元/集成测试，确保无回归。
+4. **观察一周**：确认 `/inner-api/v1/configs/mod-api-key` 接口耗时稳定 < 500 ms，conf-agent 不再出现超时。

--- a/design-docs/sys-design/details/InnerAPI配置导出与版本控制.md
+++ b/design-docs/sys-design/details/InnerAPI配置导出与版本控制.md
@@ -221,14 +221,17 @@ type ModAPIKeyRuleConf struct {
 生成流程：
 
 1. 构造 AI 路由对应的 API-Key 规则（`buildAIRouteAPIKeyRules`）；
-2. 遍历所有 `api_keys`，为每个 key 生成 `TokenFile`；
-3. 根据 API-Key 的 `enabled` 字段及 Entity 层级的 `allow_models` 交集结果，确定导出的 `enabled`（布尔值）；`expired`/`exhausted` 状态由 BFE 根据 `expired_time` 和实时 Redis 配额余额自行判断，不再由导出层计算；
-4. 合并 Entity 层级的 `allow_models`（交集）与 `block_models`（并集）；
-5. 收集 API-Key 自身及 Entity 层级向上的配额计划，**跳过 `unlimited=true` 的配额计划**；
-6. 为每个 Entity 标签补充 `TagLevel`（取自对应 `EntityType.Level`）；
-7. 输出 `QuotaPlans`、`Tokens`、`Config`。
+2. **批量预加载**：一次性加载全部 `api_keys`、`entities`、`quota_plans`、`entity_types` 到内存索引（Map），避免 N+1 查询；
+3. 遍历所有 `api_keys`，为每个 key 生成 `TokenFile`；
+4. 根据 API-Key 的 `enabled` 字段及 Entity 层级的 `allow_models` 交集结果，确定导出的 `enabled`（布尔值）；`expired`/`exhausted` 状态由 BFE 根据 `expired_time` 和实时 Redis 配额余额自行判断，不再由导出层计算；
+5. 合并 Entity 层级的 `allow_models`（交集）与 `block_models`（并集），通过内存 Map 沿 `parent_id` 回溯，不再递归查询数据库；
+6. 收集 API-Key 自身及 Entity 层级向上的配额计划，**跳过 `unlimited=true` 的配额计划**，同样通过内存 Map 查询；
+7. 为每个 Entity 标签补充 `TagLevel`（取自内存 Map 中对应 `EntityType.Level`）；
+8. 输出 `QuotaPlans`、`Tokens`、`Config`。
 
 > 详见《API-Key 与 Entity 关联及模型继承.md》。
+>
+> 性能优化记录：参见 `design-docs/modifications/2026-08-24-mod-api-key-export-performance/design-changes.md`。
 
 ### 4.7 mod-body-process（`/configs/mod-body-process`）
 
@@ -367,12 +370,13 @@ Authorization: Token <token>
 
 ---
 
-## 8. 性能优化建议
+## 8. 性能优化
 
-1. **缓存热点配置**：`mod-api-key`、`rate-limit-policy`、`ai-route` 每次导出都全量读取所有 API-Key / Entity，数据量大时建议加缓存。
-2. **异步签名计算**：复杂配置的 MD5 计算可异步化，避免阻塞请求。
-3. **按产品线分片**：当前所有配置按默认产品 `AI_product` 聚合，若未来多产品线并行，可按产品线拆分 Topic。
-4. **压缩传输**：InnerAPI 返回的 JSON 较大时，可启用 Gzip 压缩。
+1. **批量预加载 + 内存回溯**：`mod-api-key` 导出已实现一次性全量加载 `api_keys`、`entities`、`quota_plans`、`entity_types`，并在内存中沿 `parent_id` 回溯 Entity 层级，避免 N+1 查询。
+2. **缓存热点配置**：`rate-limit-policy`、`ai-route` 每次导出仍全量读取所有 API-Key / Entity，数据量大时建议参考 `mod-api-key` 进行批量预加载或加缓存。
+3. **异步签名计算**：复杂配置的 MD5 计算可异步化，避免阻塞请求。
+4. **按产品线分片**：当前所有配置按默认产品 `AI_product` 聚合，若未来多产品线并行，可按产品线拆分 Topic。
+5. **压缩传输**：InnerAPI 返回的 JSON 较大时，可启用 Gzip 压缩。
 
 ---
 

--- a/design-docs/sys-design/summary.md
+++ b/design-docs/sys-design/summary.md
@@ -21,7 +21,7 @@
 | 文档名称 | 相对路径 | 摘要说明 |
 |---------|---------|---------|
 | 认证授权机制 | [details/认证授权机制.md](./details/认证授权机制.md) | 描述 `model/iauth` 的认证授权设计，包括用户与 Token 共用 `users` 表、`Visitor` 统一抽象、Scope 作用域、Feature-Action 权限模型、四种认证方式以及中间件集成与数据库表设计。 |
-| InnerAPI 配置导出与版本控制 | [details/InnerAPI配置导出与版本控制.md](./details/InnerAPI配置导出与版本控制.md) | 描述面向 BFE/Conf Agent 的 InnerAPI 配置导出机制，包括 `VersionControlManager` 的 MD5 签名比对、版本号生成、`config_versions` 表持久化、9 类配置导出主题以及增量同步流程。 |
+| InnerAPI 配置导出与版本控制 | [details/InnerAPI配置导出与版本控制.md](./details/InnerAPI配置导出与版本控制.md) | 描述面向 BFE/Conf Agent 的 InnerAPI 配置导出机制，包括 `VersionControlManager` 的 MD5 签名比对、版本号生成、`config_versions` 表持久化、9 类配置导出主题、增量同步流程，以及 `mod-api-key` 的批量预加载 + 内存回溯性能优化。 |
 | API-Key 与 Entity 关联及模型继承 | [details/API-Key与Entity关联及模型继承.md](./details/API-Key与Entity关联及模型继承.md) | 描述 API-Key 与 Entity 的挂载关系、Entity 层级树约束、模型白名单交集与黑名单继承、配额计划层级合并、限流策略与路由规则的层级收集，以及导出到 BFE 时的最终生效规则。 |
 | 限流策略与导出 | [details/限流策略与导出.md](./details/限流策略与导出.md) | 描述限流策略的数据模型（TPM/RPM/并发数）、JSON 配置结构、CRUD 校验、API-Key/Entity 引用关系、按 Entity 层级向上合并导出到 BFE 的流程，以及 BFE 侧预期行为与边界情况。 |
 | 路由规则管理 | [details/路由规则管理.md](./details/路由规则管理.md) | 区分产品级 BFE 路由规则与 AI 路由规则，描述 `route_rules` 表的三级（Global/Entity/API-Key）管理、校验规则、与 API-Key/Entity 生命周期的一致性、导出到 BFE 的绑定顺序与文件格式。 |

--- a/model/imods/exporter.go
+++ b/model/imods/exporter.go
@@ -32,6 +32,10 @@ import (
 // ConfigTopicProductAPIKeyRule is the configuration topic for API key rules
 const ConfigTopicProductAPIKeyRule = "mod_api_key_rule"
 
+// maxEntityHierarchyDepth limits the number of ancestor levels walked when
+// resolving Entity hierarchy, protecting against accidental parent_id cycles.
+const maxEntityHierarchyDepth = 10
+
 // ModAPIKeyRuleConf defines the configuration structure for API key rules module
 type ModAPIKeyRuleConf struct {
 	Version    *string                          `json:"version"`
@@ -166,6 +170,69 @@ func (rlm *APIKeyRuleManager) buildAIRouteAPIKeyRules(ctx context.Context) (map[
 	return product2config, nil
 }
 
+// buildEntityMap loads all entities into a map indexed by EntityID.
+func (rlm *APIKeyRuleManager) buildEntityMap(ctx context.Context) (map[string]*entpkg.EntityParam, error) {
+	if rlm.entityStorager == nil {
+		return nil, nil
+	}
+
+	allEntities, err := rlm.entityStorager.FetchEntityList(ctx, &entpkg.EntityFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	entityMap := make(map[string]*entpkg.EntityParam, len(allEntities))
+	for _, e := range allEntities {
+		if e.EntityID != nil {
+			entityMap[*e.EntityID] = e
+		}
+	}
+
+	return entityMap, nil
+}
+
+// buildQuotaPlanMap loads all quota plans into a map indexed by ID.
+func (rlm *APIKeyRuleManager) buildQuotaPlanMap(ctx context.Context) (map[int64]*quota.QuotaPlanParam, error) {
+	if rlm.quotaPlanStorager == nil {
+		return nil, nil
+	}
+
+	allPlans, err := rlm.quotaPlanStorager.FetchQuotaPlanList(ctx, &quota.QuotaPlanFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	planMap := make(map[int64]*quota.QuotaPlanParam, len(allPlans))
+	for _, qp := range allPlans {
+		if qp.ID != nil {
+			planMap[*qp.ID] = qp
+		}
+	}
+
+	return planMap, nil
+}
+
+// buildEntityTypeMap loads all entity types into a map indexed by type name.
+func (rlm *APIKeyRuleManager) buildEntityTypeMap(ctx context.Context) (map[string]*entpkg.EntityTypeParam, error) {
+	if rlm.entityTypeStorager == nil {
+		return nil, nil
+	}
+
+	allTypes, err := rlm.entityTypeStorager.FetchEntityTypeList(ctx, &entpkg.EntityTypeFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	typeMap := make(map[string]*entpkg.EntityTypeParam, len(allTypes))
+	for _, et := range allTypes {
+		if et.TypeName != nil {
+			typeMap[*et.TypeName] = et
+		}
+	}
+
+	return typeMap, nil
+}
+
 // APIKeyRuleGenerator generates API key rules and token information for BFE configuration
 func (rlm *APIKeyRuleManager) APIKeyRuleGenerator(ctx context.Context) (*iversion_control.ExportData, error) {
 	collectedQuotaPlans := make(map[string][]*QuotaPlan)
@@ -183,6 +250,21 @@ func (rlm *APIKeyRuleManager) APIKeyRuleGenerator(ctx context.Context) (*iversio
 	}
 
 	apiKeyList, err := rlm.apiKeyStorager.FetchAPIKeyList(ctx, &api_key.APIKeyFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	entityMap, err := rlm.buildEntityMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	quotaPlanMap, err := rlm.buildQuotaPlanMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	entityTypeMap, err := rlm.buildEntityTypeMap(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +297,7 @@ func (rlm *APIKeyRuleManager) APIKeyRuleGenerator(ctx context.Context) (*iversio
 		var entityAllowModels []string
 		var entityBlockModels []string
 		if one.EntityID != nil && *one.EntityID != "" && rlm.entityStorager != nil {
-			entityAllowModels, entityBlockModels, err = rlm.fetchEntityModelHierarchy(ctx, *one.EntityID)
+			entityAllowModels, entityBlockModels, err = rlm.fetchEntityModelHierarchy(ctx, entityMap, *one.EntityID)
 			if err != nil {
 				return nil, fmt.Errorf("fetch entity model hierarchy error: %s", err.Error())
 			}
@@ -276,7 +358,7 @@ func (rlm *APIKeyRuleManager) APIKeyRuleGenerator(ctx context.Context) (*iversio
 			tokenFile.Subnet = &subnetStr
 		}
 
-		quotaPlanIDs, tags, err := rlm.fetchQuotaPlansWithEntityHierarchy(ctx, one, *one.ProductName, collectedQuotaPlans)
+		quotaPlanIDs, tags, err := rlm.fetchQuotaPlansWithEntityHierarchy(ctx, one, *one.ProductName, collectedQuotaPlans, entityMap, quotaPlanMap, entityTypeMap)
 		if err != nil {
 			return nil, fmt.Errorf("fetch quota plans error: %s", err.Error())
 		}
@@ -326,16 +408,12 @@ func convertAPIKeyRulesToBfeRules(oldRules []*APIKeyRule) []*TokenRuleFile {
 	return exportRules
 }
 
-func (rlm *APIKeyRuleManager) fetchQuotaPlansWithEntityHierarchy(ctx context.Context, apiKey *api_key.APIKeyParam, productName string, collectedQuotaPlans map[string][]*QuotaPlan) ([]string, []ApikeyTag, error) {
+func (rlm *APIKeyRuleManager) fetchQuotaPlansWithEntityHierarchy(ctx context.Context, apiKey *api_key.APIKeyParam, productName string, collectedQuotaPlans map[string][]*QuotaPlan, entityMap map[string]*entpkg.EntityParam, quotaPlanMap map[int64]*quota.QuotaPlanParam, entityTypeMap map[string]*entpkg.EntityTypeParam) ([]string, []ApikeyTag, error) {
 	quotaPlanIDs := make([]string, 0)
 	tags := make([]ApikeyTag, 0)
 
 	if apiKey.QuotaPlanID != nil && rlm.quotaPlanStorager != nil {
-		quotaPlan, err := rlm.quotaPlanStorager.FetchQuotaPlan(ctx, &quota.QuotaPlanFilter{ID: apiKey.QuotaPlanID})
-		if err != nil {
-			return nil, nil, err
-		}
-		if quotaPlan != nil {
+		if quotaPlan, ok := quotaPlanMap[*apiKey.QuotaPlanID]; ok && quotaPlan != nil && apiKey.Key != nil {
 			// Skip API-Key own unlimited quota plans: they do not need to be
 			// referenced in the token's quota_plans list.
 			if quotaPlan.Unlimited == nil || !*quotaPlan.Unlimited {
@@ -352,126 +430,101 @@ func (rlm *APIKeyRuleManager) fetchQuotaPlansWithEntityHierarchy(ctx context.Con
 	}
 
 	if apiKey.EntityID != nil && *apiKey.EntityID != "" && rlm.entityStorager != nil {
-		entity, err := rlm.entityStorager.FetchEntity(ctx, &entpkg.EntityFilter{EntityID: apiKey.EntityID})
+		entityQuotaPlanIDs, entityTags, err := rlm.fetchEntityQuotaPlanHierarchy(ctx, entityMap, quotaPlanMap, entityTypeMap, *apiKey.EntityID, productName, collectedQuotaPlans)
 		if err != nil {
 			return nil, nil, err
 		}
-		if entity != nil {
-			entityQuotaPlanIDs, entityTags, err := rlm.fetchEntityQuotaPlanHierarchy(ctx, entity, productName, collectedQuotaPlans)
-			if err != nil {
-				return nil, nil, err
-			}
-			quotaPlanIDs = append(quotaPlanIDs, entityQuotaPlanIDs...)
-			tags = append(tags, entityTags...)
-		}
+		quotaPlanIDs = append(quotaPlanIDs, entityQuotaPlanIDs...)
+		tags = append(tags, entityTags...)
 	}
 
 	return quotaPlanIDs, tags, nil
 }
 
-func (rlm *APIKeyRuleManager) fetchEntityQuotaPlanHierarchy(ctx context.Context, entity *entpkg.EntityParam, productName string, collectedQuotaPlans map[string][]*QuotaPlan) ([]string, []ApikeyTag, error) {
+func (rlm *APIKeyRuleManager) fetchEntityQuotaPlanHierarchy(ctx context.Context, entityMap map[string]*entpkg.EntityParam, quotaPlanMap map[int64]*quota.QuotaPlanParam, entityTypeMap map[string]*entpkg.EntityTypeParam, entityID string, productName string, collectedQuotaPlans map[string][]*QuotaPlan) ([]string, []ApikeyTag, error) {
 	quotaPlanIDs := make([]string, 0)
 	tags := make([]ApikeyTag, 0)
 
-	if entity.EntityID != nil && entity.Type != nil && entity.Name != nil {
-		tag := ApikeyTag{
-			TagName:  *entity.Type,
-			TagValue: *entity.Name,
+	for depth := 0; depth < maxEntityHierarchyDepth; depth++ {
+		entity, ok := entityMap[entityID]
+		if !ok || entity == nil {
+			break
 		}
 
-		// Query entity type level for TagLevel.
-		// By business constraint, every entity type must exist and have a valid level.
-		if rlm.entityTypeStorager != nil {
-			entityType, err := rlm.entityTypeStorager.FetchEntityType(ctx, &entpkg.EntityTypeFilter{TypeName: entity.Type})
-			if err != nil {
-				return nil, nil, err
+		if entity.EntityID != nil && entity.Type != nil && entity.Name != nil {
+			tag := ApikeyTag{
+				TagName:  *entity.Type,
+				TagValue: *entity.Name,
 			}
-			if entityType == nil || entityType.Level == nil {
-				return nil, nil, fmt.Errorf("entity type %s not found or level invalid", *entity.Type)
-			}
-			tag.TagLevel = *entityType.Level
-		}
 
-		tags = append(tags, tag)
-	}
-
-	if entity.QuotaPlanID != nil && rlm.quotaPlanStorager != nil {
-		quotaPlan, err := rlm.quotaPlanStorager.FetchQuotaPlan(ctx, &quota.QuotaPlanFilter{ID: entity.QuotaPlanID})
-		if err != nil {
-			return nil, nil, err
-		}
-		if quotaPlan != nil && entity.EntityID != nil {
-			// Skip unlimited entity quota plans: they do not enforce any quota
-			// and should not be referenced by the token.
-			if quotaPlan.Unlimited == nil || !*quotaPlan.Unlimited {
-				qp := convertQuotaPlanToExport(quotaPlan, *entity.EntityID, *entity.EntityID)
-				if !containsQuotaPlan(collectedQuotaPlans, productName, qp.Id) {
-					if _, ok := collectedQuotaPlans[productName]; !ok {
-						collectedQuotaPlans[productName] = make([]*QuotaPlan, 0)
-					}
-					collectedQuotaPlans[productName] = append(collectedQuotaPlans[productName], qp)
+			// Query entity type level for TagLevel.
+			// By business constraint, every entity type must exist and have a valid level.
+			if rlm.entityTypeStorager != nil {
+				entityType, ok := entityTypeMap[*entity.Type]
+				if !ok || entityType == nil || entityType.Level == nil {
+					return nil, nil, fmt.Errorf("entity type %s not found or level invalid", *entity.Type)
 				}
-				quotaPlanIDs = append(quotaPlanIDs, qp.Id)
+				tag.TagLevel = *entityType.Level
 			}
-		}
-	}
 
-	if entity.ParentID != nil && *entity.ParentID != "" && rlm.entityStorager != nil {
-		parentEntity, err := rlm.entityStorager.FetchEntity(ctx, &entpkg.EntityFilter{EntityID: entity.ParentID})
-		if err != nil {
-			return nil, nil, err
+			tags = append(tags, tag)
 		}
-		if parentEntity != nil {
-			parentQuotaPlanIDs, parentTags, err := rlm.fetchEntityQuotaPlanHierarchy(ctx, parentEntity, productName, collectedQuotaPlans)
-			if err != nil {
-				return nil, nil, err
+
+		if entity.QuotaPlanID != nil && rlm.quotaPlanStorager != nil {
+			if quotaPlan, ok := quotaPlanMap[*entity.QuotaPlanID]; ok && quotaPlan != nil && entity.EntityID != nil {
+				// Skip unlimited entity quota plans: they do not enforce any quota
+				// and should not be referenced by the token.
+				if quotaPlan.Unlimited == nil || !*quotaPlan.Unlimited {
+					qp := convertQuotaPlanToExport(quotaPlan, *entity.EntityID, *entity.EntityID)
+					if !containsQuotaPlan(collectedQuotaPlans, productName, qp.Id) {
+						if _, ok := collectedQuotaPlans[productName]; !ok {
+							collectedQuotaPlans[productName] = make([]*QuotaPlan, 0)
+						}
+						collectedQuotaPlans[productName] = append(collectedQuotaPlans[productName], qp)
+					}
+					quotaPlanIDs = append(quotaPlanIDs, qp.Id)
+				}
 			}
-			quotaPlanIDs = append(quotaPlanIDs, parentQuotaPlanIDs...)
-			tags = append(tags, parentTags...)
 		}
+
+		if entity.ParentID == nil || *entity.ParentID == "" {
+			break
+		}
+		entityID = *entity.ParentID
 	}
 
 	return quotaPlanIDs, tags, nil
 }
 
-// fetchEntityModelHierarchy recursively collects AllowModels and BlockModels from the entity hierarchy
+// fetchEntityModelHierarchy collects AllowModels and BlockModels from the entity hierarchy
+// by walking parent_id pointers in the provided entityMap.
 // Returns:
 //   - intersectedAllowModels: intersection of all AllowModels from entities in the hierarchy (nil if any entity has empty AllowModels)
 //   - unionBlockModels: union of all BlockModels from entities in the hierarchy
-func (rlm *APIKeyRuleManager) fetchEntityModelHierarchy(ctx context.Context, entityID string) ([]string, []string, error) {
-	entity, err := rlm.entityStorager.FetchEntity(ctx, &entpkg.EntityFilter{EntityID: &entityID})
-	if err != nil {
-		return nil, nil, err
-	}
-	if entity == nil {
-		return nil, nil, nil
-	}
-
+func (rlm *APIKeyRuleManager) fetchEntityModelHierarchy(ctx context.Context, entityMap map[string]*entpkg.EntityParam, entityID string) ([]string, []string, error) {
 	var allAllowModels [][]string
 	var allBlockModels []string
 
-	rlm.collectEntityModels(ctx, entity, &allAllowModels, &allBlockModels)
+	for depth := 0; depth < maxEntityHierarchyDepth; depth++ {
+		entity, ok := entityMap[entityID]
+		if !ok || entity == nil {
+			break
+		}
+
+		if len(entity.AllowModels) > 0 && !containsStar(entity.AllowModels) {
+			allAllowModels = append(allAllowModels, entity.AllowModels)
+		}
+		if len(entity.BlockModels) > 0 && !containsStar(entity.BlockModels) {
+			allBlockModels = append(allBlockModels, entity.BlockModels...)
+		}
+
+		if entity.ParentID == nil || *entity.ParentID == "" {
+			break
+		}
+		entityID = *entity.ParentID
+	}
 
 	return intersectAllowModels(allAllowModels), allBlockModels, nil
-}
-
-// collectEntityModels recursively walks the entity hierarchy to collect AllowModels and BlockModels
-// If an entity's AllowModels or BlockModels contains "*", it is skipped (meaning allow/block all)
-func (rlm *APIKeyRuleManager) collectEntityModels(ctx context.Context, entity *entpkg.EntityParam, allAllowModels *[][]string, allBlockModels *[]string) {
-	if len(entity.AllowModels) > 0 && !containsStar(entity.AllowModels) {
-		*allAllowModels = append(*allAllowModels, entity.AllowModels)
-	}
-	if len(entity.BlockModels) > 0 && !containsStar(entity.BlockModels) {
-		*allBlockModels = append(*allBlockModels, entity.BlockModels...)
-	}
-
-	if entity.ParentID != nil && *entity.ParentID != "" && rlm.entityStorager != nil {
-		parent, err := rlm.entityStorager.FetchEntity(ctx, &entpkg.EntityFilter{EntityID: entity.ParentID})
-		if err != nil || parent == nil {
-			return
-		}
-		rlm.collectEntityModels(ctx, parent, allAllowModels, allBlockModels)
-	}
 }
 
 // containsStar checks if the string slice contains "*"

--- a/model/imods/exporter_test.go
+++ b/model/imods/exporter_test.go
@@ -145,28 +145,32 @@ func TestAPIKeyRuleManager_ConfigExport_Concurrent(t *testing.T) {
 	}
 
 	quotaPlanStore := &fakeQuotaPlanStorager{
-		fetchFn: func(ctx context.Context, filter *quota.QuotaPlanFilter) (*quota.QuotaPlanParam, error) {
-			if filter.ID != nil {
-				return &quota.QuotaPlanParam{
-					ID:        filter.ID,
+		listFn: func(ctx context.Context, filter *quota.QuotaPlanFilter) ([]*quota.QuotaPlanParam, error) {
+			plans := make([]*quota.QuotaPlanParam, 5)
+			for i := 0; i < 5; i++ {
+				id := int64(i + 1)
+				plans[i] = &quota.QuotaPlanParam{
+					ID:        lib.PInt64(id),
 					Unlimited: lib.PBool(false),
 					Quota:     lib.PFloat64(100),
-				}, nil
+				}
 			}
-			return nil, nil
+			return plans, nil
 		},
 	}
 
 	entityStore := &fakeEntityStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityFilter) (*entity.EntityParam, error) {
-			if filter.EntityID != nil {
-				return &entity.EntityParam{
-					EntityID: filter.EntityID,
-					Name:     filter.EntityID,
+		listFn: func(ctx context.Context, filter *entity.EntityFilter) ([]*entity.EntityParam, error) {
+			entities := make([]*entity.EntityParam, 10)
+			for i := 0; i < 10; i++ {
+				id := fmt.Sprintf("entity-%d", i)
+				entities[i] = &entity.EntityParam{
+					EntityID: lib.PString(id),
+					Name:     lib.PString(id),
 					Type:     lib.PString("team"),
-				}, nil
+				}
 			}
-			return nil, nil
+			return entities, nil
 		},
 	}
 
@@ -183,11 +187,10 @@ func TestAPIKeyRuleManager_ConfigExport_Concurrent(t *testing.T) {
 	}
 
 	entityTypeStore := &fakeEntityTypeStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error) {
-			if filter.TypeName != nil && *filter.TypeName == "team" {
-				return &entity.EntityTypeParam{TypeName: lib.PString("team"), Level: lib.PInt(2)}, nil
-			}
-			return nil, nil
+		listFn: func(ctx context.Context, filter *entity.EntityTypeFilter) ([]*entity.EntityTypeParam, error) {
+			return []*entity.EntityTypeParam{
+				{TypeName: lib.PString("team"), Level: lib.PInt(2)},
+			}, nil
 		},
 	}
 
@@ -326,42 +329,39 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator(t *testing.T) {
 	}
 
 	quotaPlanStore := &fakeQuotaPlanStorager{
-		fetchFn: func(ctx context.Context, filter *quota.QuotaPlanFilter) (*quota.QuotaPlanParam, error) {
-			if filter.ID != nil && *filter.ID == quotaPlanID {
-				return &quota.QuotaPlanParam{
+		listFn: func(ctx context.Context, filter *quota.QuotaPlanFilter) ([]*quota.QuotaPlanParam, error) {
+			return []*quota.QuotaPlanParam{
+				{
 					ID:        lib.PInt64(quotaPlanID),
 					Unlimited: lib.PBool(false),
 					Quota:     lib.PFloat64(1000),
-				}, nil
-			}
-			return nil, nil
+				},
+			}, nil
 		},
 	}
 
 	entityStore := &fakeEntityStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityFilter) (*entity.EntityParam, error) {
-			if filter.EntityID != nil && *filter.EntityID == entityID {
-				return &entity.EntityParam{
+		listFn: func(ctx context.Context, filter *entity.EntityFilter) ([]*entity.EntityParam, error) {
+			return []*entity.EntityParam{
+				{
 					EntityID:    lib.PString(entityID),
 					Name:        lib.PString("team-a"),
 					Type:        lib.PString("team"),
 					AllowModels: []string{"gpt-4", "claude"},
 					BlockModels: []string{"gpt-2"},
-				}, nil
-			}
-			return nil, nil
+				},
+			}, nil
 		},
 	}
 
 	entityTypeStore := &fakeEntityTypeStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error) {
-			if filter.TypeName != nil && *filter.TypeName == "team" {
-				return &entity.EntityTypeParam{
+		listFn: func(ctx context.Context, filter *entity.EntityTypeFilter) ([]*entity.EntityTypeParam, error) {
+			return []*entity.EntityTypeParam{
+				{
 					TypeName: lib.PString("team"),
 					Level:    lib.PInt(2),
-				}, nil
-			}
-			return nil, nil
+				},
+			}, nil
 		},
 	}
 
@@ -546,15 +546,14 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_FalseUnlimitedWithNonUnlimitedQuo
 	}
 
 	quotaPlanStore := &fakeQuotaPlanStorager{
-		fetchFn: func(ctx context.Context, filter *quota.QuotaPlanFilter) (*quota.QuotaPlanParam, error) {
-			if filter.ID != nil && *filter.ID == quotaPlanID {
-				return &quota.QuotaPlanParam{
-					ID:        filter.ID,
+		listFn: func(ctx context.Context, filter *quota.QuotaPlanFilter) ([]*quota.QuotaPlanParam, error) {
+			return []*quota.QuotaPlanParam{
+				{
+					ID:        lib.PInt64(quotaPlanID),
 					Unlimited: lib.PBool(false),
 					Quota:     lib.PFloat64(100),
-				}, nil
-			}
-			return nil, nil
+				},
+			}, nil
 		},
 	}
 
@@ -727,10 +726,12 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_ModelIntersectionEmpty(t *testing
 	}
 
 	entityStore := &fakeEntityStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityFilter) (*entity.EntityParam, error) {
-			return &entity.EntityParam{
-				EntityID:    lib.PString(entityID),
-				AllowModels: []string{"claude"},
+		listFn: func(ctx context.Context, filter *entity.EntityFilter) ([]*entity.EntityParam, error) {
+			return []*entity.EntityParam{
+				{
+					EntityID:    lib.PString(entityID),
+					AllowModels: []string{"claude"},
+				},
 			}, nil
 		},
 	}
@@ -779,51 +780,44 @@ func TestAPIKeyRuleManager_APIKeyRuleGenerator_EntityHierarchy(t *testing.T) {
 	}
 
 	quotaPlanStore := &fakeQuotaPlanStorager{
-		fetchFn: func(ctx context.Context, filter *quota.QuotaPlanFilter) (*quota.QuotaPlanParam, error) {
-			if filter.ID != nil && *filter.ID == quotaPlanID {
-				return &quota.QuotaPlanParam{
+		listFn: func(ctx context.Context, filter *quota.QuotaPlanFilter) ([]*quota.QuotaPlanParam, error) {
+			return []*quota.QuotaPlanParam{
+				{
 					ID:        lib.PInt64(quotaPlanID),
 					Unlimited: lib.PBool(false),
 					Quota:     lib.PFloat64(500),
-				}, nil
-			}
-			return nil, nil
+				},
+			}, nil
 		},
 	}
 
 	entityStore := &fakeEntityStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityFilter) (*entity.EntityParam, error) {
-			if filter.EntityID != nil && *filter.EntityID == entityID {
-				return &entity.EntityParam{
+		listFn: func(ctx context.Context, filter *entity.EntityFilter) ([]*entity.EntityParam, error) {
+			return []*entity.EntityParam{
+				{
 					EntityID:    lib.PString(entityID),
 					Name:        lib.PString("team-a"),
 					Type:        lib.PString("team"),
 					ParentID:    &parentID,
 					QuotaPlanID: &quotaPlanID,
 					AllowModels: []string{"gpt-4"},
-				}, nil
-			}
-			if filter.EntityID != nil && *filter.EntityID == parentID {
-				return &entity.EntityParam{
+				},
+				{
 					EntityID:    lib.PString(parentID),
 					Name:        lib.PString("org-a"),
 					Type:        lib.PString("org"),
 					AllowModels: []string{"gpt-4", "claude"},
-				}, nil
-			}
-			return nil, nil
+				},
+			}, nil
 		},
 	}
 
 	entityTypeStore := &fakeEntityTypeStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error) {
-			if filter.TypeName != nil && *filter.TypeName == "team" {
-				return &entity.EntityTypeParam{TypeName: lib.PString("team"), Level: lib.PInt(2)}, nil
-			}
-			if filter.TypeName != nil && *filter.TypeName == "org" {
-				return &entity.EntityTypeParam{TypeName: lib.PString("org"), Level: lib.PInt(1)}, nil
-			}
-			return nil, nil
+		listFn: func(ctx context.Context, filter *entity.EntityTypeFilter) ([]*entity.EntityTypeParam, error) {
+			return []*entity.EntityTypeParam{
+				{TypeName: lib.PString("team"), Level: lib.PInt(2)},
+				{TypeName: lib.PString("org"), Level: lib.PInt(1)},
+			}, nil
 		},
 	}
 
@@ -859,48 +853,30 @@ func TestAPIKeyRuleManager_FetchQuotaPlansWithEntityHierarchy(t *testing.T) {
 		EntityID:    &entityID,
 	}
 
-	quotaPlanStore := &fakeQuotaPlanStorager{
-		fetchFn: func(ctx context.Context, filter *quota.QuotaPlanFilter) (*quota.QuotaPlanParam, error) {
-			if filter.ID != nil && *filter.ID == quotaPlanID {
-				return &quota.QuotaPlanParam{
-					ID:        lib.PInt64(quotaPlanID),
-					Unlimited: lib.PBool(false),
-					Quota:     lib.PFloat64(100),
-				}, nil
-			}
-			return nil, nil
+	quotaPlanMap := map[int64]*quota.QuotaPlanParam{
+		quotaPlanID: {
+			ID:        lib.PInt64(quotaPlanID),
+			Unlimited: lib.PBool(false),
+			Quota:     lib.PFloat64(100),
 		},
 	}
 
-	entityStore := &fakeEntityStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityFilter) (*entity.EntityParam, error) {
-			if filter.EntityID != nil && *filter.EntityID == entityID {
-				return &entity.EntityParam{
-					EntityID: lib.PString(entityID),
-					Name:     lib.PString("team-a"),
-					Type:     lib.PString("team"),
-				}, nil
-			}
-			return nil, nil
+	entityMap := map[string]*entity.EntityParam{
+		entityID: {
+			EntityID: lib.PString(entityID),
+			Name:     lib.PString("team-a"),
+			Type:     lib.PString("team"),
 		},
 	}
 
-	entityTypeStore := &fakeEntityTypeStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityTypeFilter) (*entity.EntityTypeParam, error) {
-			if filter.TypeName != nil && *filter.TypeName == "team" {
-				return &entity.EntityTypeParam{TypeName: lib.PString("team"), Level: lib.PInt(2)}, nil
-			}
-			return nil, nil
-		},
+	entityTypeMap := map[string]*entity.EntityTypeParam{
+		"team": {TypeName: lib.PString("team"), Level: lib.PInt(2)},
 	}
 
 	m := newTestAPIKeyRuleManager()
-	m.quotaPlanStorager = quotaPlanStore
-	m.entityStorager = entityStore
-	m.entityTypeStorager = entityTypeStore
 	collectedQuotaPlans := make(map[string][]*QuotaPlan)
 
-	ids, tags, err := m.fetchQuotaPlansWithEntityHierarchy(ctx, apiKey, "AI_product", collectedQuotaPlans)
+	ids, tags, err := m.fetchQuotaPlansWithEntityHierarchy(ctx, apiKey, "AI_product", collectedQuotaPlans, entityMap, quotaPlanMap, entityTypeMap)
 	require.NoError(t, err)
 	assert.Len(t, ids, 1)
 	assert.Len(t, tags, 1)
@@ -915,31 +891,23 @@ func TestAPIKeyRuleManager_FetchEntityModelHierarchy(t *testing.T) {
 	parentID := "parent-1"
 	entityID := "entity-1"
 
-	entityStore := &fakeEntityStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityFilter) (*entity.EntityParam, error) {
-			if filter.EntityID != nil && *filter.EntityID == entityID {
-				return &entity.EntityParam{
-					EntityID:    lib.PString(entityID),
-					ParentID:    &parentID,
-					AllowModels: []string{"gpt-4", "claude"},
-					BlockModels: []string{"gpt-2"},
-				}, nil
-			}
-			if filter.EntityID != nil && *filter.EntityID == parentID {
-				return &entity.EntityParam{
-					EntityID:    lib.PString(parentID),
-					AllowModels: []string{"gpt-4"},
-					BlockModels: []string{"bloom"},
-				}, nil
-			}
-			return nil, nil
+	entityMap := map[string]*entity.EntityParam{
+		entityID: {
+			EntityID:    lib.PString(entityID),
+			ParentID:    &parentID,
+			AllowModels: []string{"gpt-4", "claude"},
+			BlockModels: []string{"gpt-2"},
+		},
+		parentID: {
+			EntityID:    lib.PString(parentID),
+			AllowModels: []string{"gpt-4"},
+			BlockModels: []string{"bloom"},
 		},
 	}
 
 	m := newTestAPIKeyRuleManager()
-	m.entityStorager = entityStore
 
-	allow, block, err := m.fetchEntityModelHierarchy(ctx, entityID)
+	allow, block, err := m.fetchEntityModelHierarchy(ctx, entityMap, entityID)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"gpt-4"}, allow)
 	assert.Equal(t, []string{"gpt-2", "bloom"}, block)
@@ -949,38 +917,12 @@ func TestAPIKeyRuleManager_FetchEntityModelHierarchy_EntityNotFound(t *testing.T
 	setupState()
 	ctx := context.Background()
 
-	entityStore := &fakeEntityStorager{
-		fetchFn: func(ctx context.Context, filter *entity.EntityFilter) (*entity.EntityParam, error) {
-			return nil, nil
-		},
-	}
-
 	m := newTestAPIKeyRuleManager()
-	m.entityStorager = entityStore
 
-	allow, block, err := m.fetchEntityModelHierarchy(ctx, "missing")
+	allow, block, err := m.fetchEntityModelHierarchy(ctx, map[string]*entity.EntityParam{}, "missing")
 	require.NoError(t, err)
 	assert.Nil(t, allow)
 	assert.Empty(t, block)
-}
-
-func TestAPIKeyRuleManager_CollectEntityModels_Star(t *testing.T) {
-	setupState()
-	ctx := context.Background()
-
-	entityStore := &fakeEntityStorager{}
-	m := newTestAPIKeyRuleManager()
-	m.entityStorager = entityStore
-
-	var allAllowModels [][]string
-	var allBlockModels []string
-	m.collectEntityModels(ctx, &entity.EntityParam{
-		AllowModels: []string{"*"},
-		BlockModels: []string{"*"},
-	}, &allAllowModels, &allBlockModels)
-
-	assert.Empty(t, allAllowModels)
-	assert.Empty(t, allBlockModels)
 }
 
 func TestAPIKeyRuleManager_ContainsQuotaPlan(t *testing.T) {
@@ -993,4 +935,136 @@ func TestAPIKeyRuleManager_ContainsQuotaPlan(t *testing.T) {
 	assert.True(t, containsQuotaPlan(collectedQuotaPlans, "AI_product", "qp-1"))
 	assert.False(t, containsQuotaPlan(collectedQuotaPlans, "AI_product", "qp-2"))
 	assert.False(t, containsQuotaPlan(collectedQuotaPlans, "other", "qp-1"))
+}
+
+
+func TestAPIKeyRuleManager_ConfigExport_Performance(t *testing.T) {
+	setupState()
+	ctx := context.Background()
+
+	const numKeys = 690
+	const numEntities = 100
+	const numQuotaPlans = 20
+
+	// Build 3-level entity hierarchy: leaf -> middle -> root.
+	entityList := make([]*entity.EntityParam, 0, numEntities)
+	for i := 0; i < numEntities; i++ {
+		entityID := fmt.Sprintf("entity-%d", i)
+		entityType := "team"
+		var parentID *string
+		if i%3 == 0 {
+			// root
+			entityType = "org"
+		} else {
+			// middle -> root, or leaf -> middle
+			parent := fmt.Sprintf("entity-%d", i-1)
+			parentID = &parent
+		}
+
+		var quotaPlanID *int64
+		if i%2 == 0 {
+			qpID := int64(i%numQuotaPlans + 1)
+			quotaPlanID = &qpID
+		}
+
+		entityList = append(entityList, &entity.EntityParam{
+			EntityID:    lib.PString(entityID),
+			Name:        lib.PString(entityID),
+			Type:        lib.PString(entityType),
+			ParentID:    parentID,
+			QuotaPlanID: quotaPlanID,
+			AllowModels: []string{"gpt-4", "claude", "gpt-3.5"},
+			BlockModels: []string{"gpt-2"},
+		})
+	}
+
+	quotaPlanList := make([]*quota.QuotaPlanParam, 0, numQuotaPlans)
+	for i := 1; i <= numQuotaPlans; i++ {
+		id := int64(i)
+		quotaPlanList = append(quotaPlanList, &quota.QuotaPlanParam{
+			ID:        lib.PInt64(id),
+			Unlimited: lib.PBool(false),
+			Quota:     lib.PFloat64(1000),
+		})
+	}
+
+	entityTypeList := []*entity.EntityTypeParam{
+		{TypeName: lib.PString("team"), Level: lib.PInt(2)},
+		{TypeName: lib.PString("org"), Level: lib.PInt(1)},
+	}
+
+	apiKeyStore := &fakeAPIKeyStorager{
+		fetchListFn: func(ctx context.Context, filter *api_key.APIKeyFilter) ([]*api_key.APIKeyParam, error) {
+			keys := make([]*api_key.APIKeyParam, numKeys)
+			for i := 0; i < numKeys; i++ {
+				id := fmt.Sprintf("key-%d", i)
+				quotaPlanID := int64(i%numQuotaPlans + 1)
+				entityID := fmt.Sprintf("entity-%d", i%numEntities)
+				keys[i] = &api_key.APIKeyParam{
+					ID:          lib.PString(id),
+					Key:         lib.PString(fmt.Sprintf("ak-%s", id)),
+					ProductName: lib.PString("AI_product"),
+					Enable:      lib.PBool(true),
+					QuotaPlanID: &quotaPlanID,
+					EntityID:    lib.PString(entityID),
+					Models:      []string{"gpt-4"},
+					KeyCreateAt: lib.PTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.Local)),
+				}
+			}
+			return keys, nil
+		},
+	}
+
+	quotaPlanStore := &fakeQuotaPlanStorager{
+		listFn: func(ctx context.Context, filter *quota.QuotaPlanFilter) ([]*quota.QuotaPlanParam, error) {
+			return quotaPlanList, nil
+		},
+	}
+
+	entityStore := &fakeEntityStorager{
+		listFn: func(ctx context.Context, filter *entity.EntityFilter) ([]*entity.EntityParam, error) {
+			return entityList, nil
+		},
+	}
+
+	entityTypeStore := &fakeEntityTypeStorager{
+		listFn: func(ctx context.Context, filter *entity.EntityTypeFilter) ([]*entity.EntityTypeParam, error) {
+			return entityTypeList, nil
+		},
+	}
+
+	aiRouteStore := &fakeAIRouteRuleStorager{
+		fetchFn: func(ctx context.Context, filter *iai_route.AIRouteFilter) ([]*iai_route.Rule, error) {
+			return nil, nil
+		},
+	}
+
+	versionStore := &fakeVersionControlStorager{
+		upsertFn: func(ctx context.Context, css *iversion_control.ExportData) (string, error) {
+			return "v-performance", nil
+		},
+	}
+
+	m := NewAPIKeyRuleManager(
+		&fakeTxn{},
+		iversion_control.NewVersionControllerManager(&fakeTxn{}, versionStore),
+		apiKeyStore,
+		aiRouteStore,
+		quotaPlanStore,
+		entityStore,
+		entityTypeStore, nil)
+
+	start := time.Now()
+	conf, err := m.ConfigExport(ctx, "")
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+	assert.Len(t, conf.Tokens["AI_product"], numKeys)
+	assert.NotEmpty(t, conf.QuotaPlans["AI_product"])
+
+	t.Logf("ConfigExport with %d keys, %d entities, %d quota plans took %d ms",
+		numKeys, numEntities, numQuotaPlans, elapsed.Milliseconds())
+
+	assert.Less(t, elapsed.Milliseconds(), int64(500), "ConfigExport should complete within 500 ms")
 }


### PR DESCRIPTION
…xport

Avoid N+1 DB queries by loading all entities, quota plans and entity types into memory maps before iterating over API keys. This reduces DB query complexity from O(N * hierarchy_depth) to O(4) and keeps ConfigExport under 500ms for 690 API keys.

- Add buildEntityMap/buildQuotaPlanMap/buildEntityTypeMap helpers.
- Rewrite fetchEntityModelHierarchy and fetchEntityQuotaPlanHierarchy to walk parent_id pointers in memory.
- Add maxEntityHierarchyDepth guard against parent_id cycles.
- Update unit tests and add TestAPIKeyRuleManager_ConfigExport_Performance.

Fixes #75