### PR TITLE
feat: RMB 分时段定价能力

### DIFF
--- a/db_ddl.sql
+++ b/db_ddl.sql
@@ -420,6 +420,7 @@ CREATE TABLE `model_prices` (
   `supported_parameters` JSON COMMENT '支持的请求参数列表',
   `limits` JSON COMMENT '限制对象',
   `prices` JSON NOT NULL COMMENT '价格对象',
+  `tier_prices` JSON COMMENT '分时段价格对象',
   `price_currency` VARCHAR(10) DEFAULT 'RMB' COMMENT '币种',
   `metadata` JSON COMMENT '元数据',
   `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
@@ -440,6 +441,8 @@ CREATE TABLE `providers` (
   `keys` JSON COMMENT 'API key 列表',
   `instance_pool` JSON NOT NULL COMMENT '实例池列表',
   `model_protocols` JSON NOT NULL COMMENT '支持的模型协议列表',
+  `time_zone` VARCHAR(255) NOT NULL DEFAULT 'Asia/Shanghai' COMMENT '计算时段所使用的时区',
+  `tiers` JSON COMMENT '时段 tier 定义列表',
   `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
   `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
   UNIQUE KEY `uk_name` (`name`)

--- a/db_ddl_sqlite.sql
+++ b/db_ddl_sqlite.sql
@@ -438,6 +438,7 @@ CREATE TABLE model_prices (
   supported_parameters TEXT,
   limits TEXT,
   prices TEXT NOT NULL,
+  tier_prices TEXT,
   price_currency TEXT DEFAULT 'RMB',
   metadata TEXT,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -460,6 +461,8 @@ CREATE TABLE providers (
   keys TEXT,
   instance_pool TEXT NOT NULL,
   model_protocols TEXT NOT NULL,
+  time_zone TEXT NOT NULL DEFAULT 'Asia/Shanghai',
+  tiers TEXT,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   UNIQUE (name)

--- a/design-docs/api-define/InnerAPI接口定义/server-data-conf.md
+++ b/design-docs/api-define/InnerAPI接口定义/server-data-conf.md
@@ -159,6 +159,17 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/tls_conf/server_data_co
                     "StripPrefix": true,
                     "ModelProtocols": ["openai"],
                     "ModelTable": {
+                        "Currency": "RMB",
+                        "TimeZone": "Asia/Shanghai",
+                        "Tiers": [
+                            {
+                                "Name": "peak",
+                                "TimeRanges": [
+                                    { "Weekdays": [1, 2, 3, 4, 5], "Start": "09:00", "End": "12:00" },
+                                    { "Weekdays": [1, 2, 3, 4, 5], "Start": "14:00", "End": "18:00" }
+                                ]
+                            }
+                        ],
                         "Models": [
                             {
                                 "Provider": "deepseek",
@@ -174,7 +185,15 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/tls_conf/server_data_co
                                 },
                                 "Prices": {
                                     "input_cost_per_token": 0.000002,
-                                    "output_cost_per_token": 0.000008
+                                    "output_cost_per_token": 0.000008,
+                                    "cache_read_input_token_cost": 0.0000005
+                                },
+                                "TierPrices": {
+                                    "peak": {
+                                        "input_cost_per_token": 0.000004,
+                                        "output_cost_per_token": 0.000016,
+                                        "cache_read_input_token_cost": 0.000001
+                                    }
                                 }
                             }
                         ]
@@ -203,7 +222,15 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/tls_conf/server_data_co
 | MatchPrefix | string | 需要匹配的 provider/model 前缀；对应 OpenAPI `llm_config.match_prefix` |
 | StripPrefix | bool | 是否裁剪 `MatchPrefix` 前缀；对应 OpenAPI `llm_config.strip_prefix` |
 | ModelProtocols | []string | 该集群所属 provider 支持的模型访问协议；来源为 OpenAPI `/providers` 的 `model_protocols`。枚举值如 `openai`、`anthropic`；为空数组时 BFE 兜底为仅支持 `openai` |
-| ModelTable | object | 该 cluster 的成本定价表；无 `Currency` 字段 |
+| ModelTable | object | 该 cluster 的成本定价表 |
+| ModelTable.Currency | string | 价格货币；固定为 `"RMB"` |
+| ModelTable.TimeZone | string | 计算时段所使用的时区；默认 `"Asia/Shanghai"` |
+| ModelTable.Tiers | array | 时段 tier 定义列表；为空时按固定价格处理 |
+| ModelTable.Tiers[].Name | string | Tier 名称；**初期只支持 `"peak"`** |
+| ModelTable.Tiers[].TimeRanges | array | 时段范围列表；命中任意一个即属于该 tier |
+| ModelTable.Tiers[].TimeRanges[].Weekdays | []int | 星期几；0=周日，1=周一，...，6=周六；为空表示每天 |
+| ModelTable.Tiers[].TimeRanges[].Start | string | 开始时间，格式 `HH:MM` |
+| ModelTable.Tiers[].TimeRanges[].End | string | 结束时间，格式 `HH:MM`；采用左闭右开语义 |
 | ModelTable.Models | array | 模型定价条目列表 |
 | ModelTable.Models[].Provider | string | Provider 名 |
 | ModelTable.Models[].Model | string | 模型名，用于匹配请求中的 target_model |
@@ -212,9 +239,10 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/tls_conf/server_data_co
 | ModelTable.Models[].Capabilities | []string | 能力列表；枚举值同 OpenAPI `model_prices.capabilities` |
 | ModelTable.Models[].SupportedParameters | []string | 支持的请求参数列表；枚举值同 OpenAPI `model_prices.supported_parameters` |
 | ModelTable.Models[].Limits | object | 限制对象；键名枚举值同 OpenAPI `model_prices.limits` |
-| ModelTable.Models[].Prices | object | 价格对象；键名枚举值同 OpenAPI `model_prices.prices`；当前价格货币固定为 RMB |
+| ModelTable.Models[].Prices | object | 默认价格对象；键名枚举值同 OpenAPI `model_prices.prices`；未命中 tier 时作为 fallback |
+| ModelTable.Models[].TierPrices | object | 分时段价格对象；key 为 tier name，value 为价格对象；键名枚举值同 OpenAPI `model_prices.prices` |
 
-> **说明**：`ModelTable` 由 InnerAPI 根据 `Provider` 查询 `model_prices` 自动填充，不在 OpenAPI `/clusters` 端点中展示。`ModelTable` 不包含 `Currency` 字段，v0.4 仅支持 RMB。
+> **说明**：`ModelTable` 由 InnerAPI 根据 `cluster.llm_config.provider` 查询 `/providers` 的 `time_zone` / `tiers` 与 `/model-prices` 的 `prices` / `tier_prices` 拼接后自动填充，不在 OpenAPI `/clusters` 端点中展示。`Currency` 固定为 `RMB`。
 
 ## 4. 配置未变化返回示例
 

--- a/design-docs/api-define/OpenAPI接口定义/model-prices.md
+++ b/design-docs/api-define/OpenAPI接口定义/model-prices.md
@@ -18,7 +18,15 @@
   },
   "prices": {
     "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000008
+    "output_cost_per_token": 0.000008,
+    "cache_read_input_token_cost": 0.0000005
+  },
+  "tier_prices": {
+    "peak": {
+      "input_cost_per_token": 0.000004,
+      "output_cost_per_token": 0.000016,
+      "cache_read_input_token_cost": 0.000001
+    }
   },
   "price_currency": "RMB",
   "metadata": {
@@ -42,7 +50,8 @@
 | `capabilities` | []string | 模型支持的能力列表 | 默认空数组；元素应为枚举值 |
 | `supported_parameters` | []string | 支持的请求参数列表 | 默认空数组；元素应为枚举值 |
 | `limits` | object | 限制对象 | 默认空对象；键名应为枚举值；所有限制字段必须为非负整数 |
-| `prices` | object | 价格对象 | 必填；至少包含一个价格字段；所有价格字段必须为非负数；键名应为枚举值 |
+| `prices` | object | 价格对象 | 必填；至少包含一个价格字段；所有价格字段必须为非负数；键名应为枚举值；未命中 tier 时作为 fallback 价格 |
+| `tier_prices` | object | 分时段价格对象 | 非必填；键为 tier name（**初期只支持 `peak`**），值为价格对象；内部键名应为 `prices` 枚举；与 provider 的 `tiers` 不做强制引用校验 |
 | `price_currency` | string | 价格货币 | 固定为 `RMB`，请求体中无需传入 |
 | `metadata` | object | 元数据 | 默认空对象；键名应为枚举值 |
 | `create_time` | int64 | 创建时间 | Unix 时间戳（秒） |
@@ -189,6 +198,12 @@ models:
     prices:
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
+      cache_read_input_token_cost: 0.0000005
+    tier_prices:
+      peak:
+        input_cost_per_token: 0.000004
+        output_cost_per_token: 0.000016
+        cache_read_input_token_cost: 0.000001
     metadata:
       source: "https://platform.deepseek.com/pricing"
       notes: "DeepSeek V3"
@@ -205,7 +220,8 @@ models:
 | `capabilities` | N | 能力列表，枚举值同第 1 节 `capabilities` 枚举 |
 | `supported_parameters` | N | 支持的请求参数列表，枚举值同第 1 节 `supported_parameters` 枚举 |
 | `limits` | N | 限制对象，键名枚举值同第 1 节 `limits` 枚举；所有限制字段必须为非负整数 |
-| `prices` | Y | 价格对象，键名枚举值同第 1 节 `prices` 枚举；至少包含一个价格字段 |
+| `prices` | Y | 价格对象，键名枚举值同第 1 节 `prices` 枚举；至少包含一个价格字段；未命中 tier 时作为 fallback 价格 |
+| `tier_prices` | N | 分时段价格对象，键为 tier name（**初期只支持 `peak`**），值为价格对象；内部键名枚举值同第 1 节 `prices` 枚举 |
 | `metadata` | N | 元数据，键名枚举值同第 1 节 `metadata` 枚举 |
 
 > **唯一性约束**：`(provider, model, mode)` 三元组必须唯一。
@@ -235,6 +251,11 @@ models:
       output_cost_per_token: 0.000008
       cache_read_input_token_cost: 0.0000005
       cache_creation_input_token_cost: 0.000001
+    tier_prices:
+      peak:
+        input_cost_per_token: 0.000004
+        output_cost_per_token: 0.000016
+        cache_read_input_token_cost: 0.000001
     metadata:
       source: "https://platform.deepseek.com/pricing"
       notes: "DeepSeek V3 官方 API"
@@ -285,9 +306,13 @@ models:
 2. 校验每条记录的 `(provider, model, mode)` 唯一性；
 3. 校验必填字段：`provider`、`model`、`base_model`、`mode`、`prices`；
 4. 校验 `prices` 中至少包含一个价格字段，且所有价格字段为非负数；
-5. 校验 `limits` 中所有限制字段值为非负整数；
-6. `replace` 模式：先清空 `model_prices` 表，再写入新数据；
-7. `merge` 模式：对已有 `(provider, model, mode)` 记录更新，新增记录插入。
+5. 若记录包含 `tier_prices`：
+   - **初期 tier name 只支持 `peak`**；
+   - 每个 tier 对应的价格对象中，键名须为 `prices` 枚举；
+   - 所有 tier 价格字段必须为非负数。
+6. 校验 `limits` 中所有限制字段值为非负整数；
+7. `replace` 模式：先清空 `model_prices` 表，再写入新数据；
+8. `merge` 模式：对已有 `(provider, model, mode)` 记录更新，新增记录插入。
 
 **权限**
 
@@ -389,7 +414,15 @@ models:
     },
     "prices": {
         "input_cost_per_token": 0.000002,
-        "output_cost_per_token": 0.000008
+        "output_cost_per_token": 0.000008,
+        "cache_read_input_token_cost": 0.0000005
+    },
+    "tier_prices": {
+        "peak": {
+            "input_cost_per_token": 0.000004,
+            "output_cost_per_token": 0.000016,
+            "cache_read_input_token_cost": 0.000001
+        }
     },
     "metadata": {
         "source": "https://platform.deepseek.com/pricing",
@@ -592,11 +625,16 @@ Data 为 null。
 3. `(provider, model, mode)` 组合不能重复；
 4. `prices` 必填，至少包含一个价格字段；
 5. 所有价格字段必须为非负数；
-6. `price_currency` 当前只支持 `RMB`；
-7. `mode` 必须是预定义枚举值；
-8. `capabilities`、`supported_parameters` 若传入，其元素应取自对应枚举值（非枚举值可接收但建议告警或记录，便于后续收敛）；
-9. `limits`、`prices`、`metadata` 的键名应取自对应枚举值（非枚举键可接收但建议告警或记录，便于后续收敛）；
-10. `limits` 中所有限制字段值必须为非负整数；
-11. `/v1/model-prices/import` 仅接受 YAML 文件，且 `default_currency` 必须为 `RMB`；导入时不再校验 `provider` 是否已存在于 `/providers`。
+6. `tier_prices` 非必填；若传入：
+   - **初期 tier name 只支持 `peak`**；
+   - 每个 tier 对应的价格对象中，键名须为 `prices` 枚举；
+   - 所有 tier 价格字段必须为非负数；
+   - 与 provider 的 `tiers` 不做强制引用校验；若引用了 provider 未定义的 tier name，可记录告警，但不阻塞写入。
+7. `price_currency` 当前只支持 `RMB`；
+8. `mode` 必须是预定义枚举值；
+9. `capabilities`、`supported_parameters` 若传入，其元素应取自对应枚举值（非枚举值可接收但建议告警或记录，便于后续收敛）；
+10. `limits`、`prices`、`tier_prices.<tier>`、`metadata` 的键名应取自对应枚举值（非枚举键可接收但建议告警或记录，便于后续收敛）；
+11. `limits` 中所有限制字段值必须为非负整数；
+12. `/v1/model-prices/import` 仅接受 YAML 文件，且 `default_currency` 必须为 `RMB`；导入时不再校验 `provider` 是否已存在于 `/providers`。
 
 ---

--- a/design-docs/api-define/OpenAPI接口定义/providers.md
+++ b/design-docs/api-define/OpenAPI接口定义/providers.md
@@ -30,6 +30,16 @@
         }
     ],
     "model_protocols": ["openai"],
+    "time_zone": "Asia/Shanghai",
+    "tiers": [
+        {
+            "name": "peak",
+            "time_ranges": [
+                { "weekdays": [1, 2, 3, 4, 5], "start": "09:00", "end": "12:00" },
+                { "weekdays": [1, 2, 3, 4, 5], "start": "14:00", "end": "18:00" }
+            ]
+        }
+    ],
     "create_time": 1716883200,
     "update_time": 1716883200
 }
@@ -46,8 +56,30 @@
 | `keys` | []ProviderKey | 该 provider 可用的 API Key 明文 | - | 非必填；默认空数组 `[]`；元素须满足 表：ProviderKey 结构 |
 | `instance_pool` | []Instance | Provider 对应的后端实例池 | 系统自动据此创建实例池和子集群 | 必填；至少 1 个元素；同一 provider 内，对于 `name` 不为空的实例，`name` 不能重复；同一 provider 内 `(name, addr, port)` 组合不能重复；至少有一个实例 `weight > 0` |
 | `model_protocols` | []string | 支持的模型访问协议 | 首期枚举：`openai`、`anthropic` | 必填；至少 1 个元素；元素不可重复；枚举值见下方 |
+| `time_zone` | string | 计算时段所使用的时区 | 用于 tier 价格匹配 | 非必填；默认 `Asia/Shanghai`；须为合法 IANA 时区名 |
+| `tiers` | []PricingTier | 时段 tier 定义列表 | 描述该 provider 在什么时段属于哪个 tier | 非必填；元素须满足 表：PricingTier 结构；**初期 `name` 只支持 `peak`** |
 | `create_time` | int64 | 创建时间 | - | 系统生成 |
 | `update_time` | int64 | 更新时间 | - | 系统生成 |
+
+**表：PricingTier 结构（`tiers` 元素）**
+
+| 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
+| - | - | - | - | - | - |
+| `name` | string | Tier 名称 | Y | 用于与 `model-prices` 的 `tier_prices` 关联 | 必填；**初期只支持 `peak`** |
+| `time_ranges` | []TimeRange | 时段范围列表 | Y | 命中任意一个即属于该 tier | 必填；至少 1 个元素；元素须满足 表：TimeRange 结构 |
+
+**表：TimeRange 结构（`time_ranges` 元素）**
+
+| 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
+| - | - | - | - | - | - |
+| `weekdays` | []int | 星期几 | N | 0=周日，1=周一，...，6=周六 | 为空表示每天；元素须在 0-6 之间 |
+| `start` | string | 开始时间 | Y | 格式 `HH:MM` | 必填；`HH:MM` 格式 |
+| `end` | string | 结束时间 | Y | 格式 `HH:MM` | 必填；`HH:MM` 格式；`end` 必须大于 `start`；跨午夜请拆成两段 |
+
+> **说明**：
+> - 同一 tier 内的多个 `time_ranges` 为"或"关系；`tiers` 列表按顺序匹配，命中第一个即停止。
+> - `start` / `end` 采用左闭右开语义（`start <= cur < end`），跨午夜请拆成两段。
+> - `time_zone` / `tiers` 可通过 `PUT /providers/{provider_name}/pricing-tiers` 接口单独维护，创建 provider 时无需传入。
 
 **表：Endpoint（`model_endpoint`）**
 
@@ -138,8 +170,10 @@
 1. 校验 `name` 全局唯一、`instance_pool` 合法、`model_protocols` 合法。
 2. 若未传 `model_endpoint`，使用默认值 `{schema: "https", uri: "/v1/models"}`。
 3. 若未传 `keys`，默认空数组。
-4. 若请求中携带 `models` 且非空，直接保存；否则可在创建后调用 `/providers/tools/discover-models` 接口探测模型列表，再回填到 provider。
-5. 写入 provider 记录，返回完整对象。
+4. 若未传 `time_zone`，默认 `Asia/Shanghai`。
+5. 若请求中携带 `tiers`，按 表：PricingTier 结构 校验；**初期只支持 `name="peak"`**。
+6. 若请求中携带 `models` 且非空，直接保存；否则可在创建后调用 `/providers/tools/discover-models` 接口探测模型列表，再回填到 provider。
+7. 写入 provider 记录，返回完整对象。
 
 **返回数据（Data内容）**
 
@@ -167,6 +201,16 @@
             {"name": "backend-1", "addr": "api.deepseek.com", "weight": 100, "port": 443}
         ],
         "model_protocols": ["openai"],
+        "time_zone": "Asia/Shanghai",
+        "tiers": [
+            {
+                "name": "peak",
+                "time_ranges": [
+                    {"weekdays": [1, 2, 3, 4, 5], "start": "09:00", "end": "12:00"},
+                    {"weekdays": [1, 2, 3, 4, 5], "start": "14:00", "end": "18:00"}
+                ]
+            }
+        ],
         "create_time": 1716883200,
         "update_time": 1716883200
     }
@@ -380,6 +424,102 @@ Data 为 null。
 }
 ```
 
+### 2.8 设置 Provider 高峰/闲时模板
+
+**基本信息**
+
+| 项目 | 值 | 说明 |
+| - | - | - |
+| 含义 | 设置/更新指定 provider 的高峰/闲时模板 | 支持 JSON body 或 YAML 文件；**初期 tier name 只支持 `peak`** |
+| 端点 | /providers/{provider_name}/pricing-tiers | - |
+| 版本 | v1 | - |
+| method | PUT | - |
+
+**输入参数（URI）**
+
+| 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
+| - | - | - | - | - | - |
+| `provider_name` | string | Provider 名称 | Y | - | 必填；类型为 [ProviderName](./00-common.md#17-provider-名称providername)；必须引用已存在的 provider |
+
+**输入参数（Body）**
+
+两种提交方式：
+
+1. **JSON 格式**（`Content-Type: application/json`）：
+
+```json
+{
+    "time_zone": "Asia/Shanghai",
+    "tiers": [
+        {
+            "name": "peak",
+            "time_ranges": [
+                { "weekdays": [1, 2, 3, 4, 5], "start": "09:00", "end": "12:00" },
+                { "weekdays": [1, 2, 3, 4, 5], "start": "14:00", "end": "18:00" }
+            ]
+        }
+    ]
+}
+```
+
+2. **YAML 文件格式**（`Content-Type: text/yaml` 或 `multipart/form-data` 上传文件）：
+
+```yaml
+time_zone: "Asia/Shanghai"
+tiers:
+  - name: "peak"
+    time_ranges:
+      - weekdays: [1, 2, 3, 4, 5]
+        start: "09:00"
+        end: "12:00"
+      - weekdays: [1, 2, 3, 4, 5]
+        start: "14:00"
+        end: "18:00"
+```
+
+**执行逻辑**
+
+1. 校验 `provider_name` 对应的 provider 存在。
+2. 校验 `time_zone` 为合法 IANA 时区名；为空时默认 `Asia/Shanghai`。
+3. 校验 `tiers` 中每个 tier 包含非空 `name` 和至少一个 `time_range`；**初期 `name` 只支持 `peak`**。
+4. 校验 `time_ranges` 中 `weekdays` 元素在 0-6 之间；`start` / `end` 格式为 `HH:MM`，且 `end` > `start`；同一 tier 内部 `time_ranges` 不得重叠。
+5. 更新 provider 的 `time_zone` / `tiers` 字段，并刷新 `update_time`。
+6. 返回更新后的完整 provider 记录。
+
+**返回数据（Data内容）**
+
+同 `GET /providers/{provider_name}`，包含基础信息 + `time_zone` / `tiers`。
+
+**成功返回示例**
+
+```json
+{
+    "ErrNum": 200,
+    "ErrMsg": "success",
+    "Data": {
+        "name": "deepseek",
+        "description": "DeepSeek 官方 API",
+        "model_endpoint": { "schema": "https", "uri": "/v1/models" },
+        "models": ["deepseek-v4-pro", "deepseek-v4-flash"],
+        "keys": [...],
+        "instance_pool": [...],
+        "model_protocols": ["openai"],
+        "time_zone": "Asia/Shanghai",
+        "tiers": [
+            {
+                "name": "peak",
+                "time_ranges": [
+                    { "weekdays": [1, 2, 3, 4, 5], "start": "09:00", "end": "12:00" },
+                    { "weekdays": [1, 2, 3, 4, 5], "start": "14:00", "end": "18:00" }
+                ]
+            }
+        ],
+        "create_time": 1716883200,
+        "update_time": 1716883200
+    }
+}
+```
+
 ## 3. 校验规则
 
 1. `name` 必填，类型为 [ProviderName](./00-common.md#17-provider-名称providername)，全局唯一。
@@ -392,5 +532,13 @@ Data 为 null。
    - 每个元素 `name` 必填，长度 1-128，同一 provider 内唯一；
    - 每个元素 `key` 必填且非空，长度 1-512。
 8. `model_protocols` 必填，至少 1 个元素，元素不可重复，取值须为枚举值：`openai`、`anthropic`。
-9. 删除 provider 前，须校验无 cluster 引用，否则返回 `409 Conflict`；`/model-prices` 记录不再作为阻塞条件。
-10. 触发模型发现时，`model_protocol`、`schema`、`addr`、`port` 为必填，`uri` 和 `apikey` 为选填；各参数须满足对应合法性条件；`model_protocol` 不在枚举值范围内时返回 `422`。
+9. `time_zone` 非必填，为空时默认 `Asia/Shanghai`；若传入，须为合法 IANA 时区名。
+10. `tiers` 非必填；若传入：
+    - 每个 tier 必须包含非空 `name` 和至少一个 `time_range`；
+    - **初期 `name` 只支持 `peak`**；
+    - `time_ranges` 中 `weekdays` 元素须在 0-6 之间，为空表示每天；
+    - `start` / `end` 格式为 `HH:MM`，且 `end` 必须大于 `start`；
+    - 同一 tier 内部 `time_ranges` 不得重叠。
+11. `PUT /providers/{provider_name}/pricing-tiers` 中，`time_zone` / `tiers` 的校验规则同上；YAML 文件格式须能正确解析为相同结构。
+12. 删除 provider 前，须校验无 cluster 引用，否则返回 `409 Conflict`；`/model-prices` 记录不再作为阻塞条件。
+13. 触发模型发现时，`model_protocol`、`schema`、`addr`、`port` 为必填，`uri` 和 `apikey` 为选填；各参数须满足对应合法性条件；`model_protocol` 不在枚举值范围内时返回 `422`。

--- a/design-docs/modifications/2026-08-25-rmb-tiered-pricing/api-changes.md
+++ b/design-docs/modifications/2026-08-25-rmb-tiered-pricing/api-changes.md
@@ -1,0 +1,269 @@
+# RMB 配额分时段定价——API 接口变更说明
+
+## 1. `/providers` 资源增强
+
+### 1.1 新增字段
+
+在现有 provider 数据模型基础上新增：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `time_zone` | string | 否 | 计算时段所使用的时区，默认 `Asia/Shanghai`，须为 IANA 时区名 |
+| `tiers` | []object | 否 | 时段 tier 定义列表，元素包含 `name` + `time_ranges`；**初期 `name` 只支持 `peak`** |
+
+`tiers` 元素结构示例：
+
+```json
+{
+  "name": "peak",
+  "time_ranges": [
+    { "weekdays": [1, 2, 3, 4, 5], "start": "09:00", "end": "12:00" },
+    { "weekdays": [1, 2, 3, 4, 5], "start": "14:00", "end": "18:00" }
+  ]
+}
+```
+
+字段约束：
+
+- `weekdays`：0=周日，1=周一，...，6=周六；为空表示每天。
+- `start` / `end`：格式 `HH:MM`，`end` 必须大于 `start`；跨午夜请拆成两段。
+- 同一 tier 内的多个 `time_ranges` 为"或"关系；`tiers` 列表按顺序匹配，命中第一个即停止。
+
+### 1.2 新增接口
+
+| 方法 | 端点 | 含义 |
+|------|------|------|
+| PUT | `/providers/{provider_name}/pricing-tiers` | 设置/更新指定 provider 的高峰/闲时模板 |
+
+#### 输入参数（URI）
+
+| 参数名 | 类型 | 参数含义 | 必填 |
+|--------|------|----------|------|
+| `provider_name` | string | Provider 名称 | 是 |
+
+#### 输入参数（Body）
+
+支持两种提交方式：
+
+1. **JSON 格式**（`Content-Type: application/json`）：
+
+```json
+{
+    "time_zone": "Asia/Shanghai",
+    "tiers": [
+        {
+            "name": "peak",
+            "time_ranges": [
+                { "weekdays": [1, 2, 3, 4, 5], "start": "09:00", "end": "12:00" },
+                { "weekdays": [1, 2, 3, 4, 5], "start": "14:00", "end": "18:00" }
+            ]
+        }
+    ]
+}
+```
+
+2. **YAML 文件格式**（`Content-Type: text/yaml` 或 `multipart/form-data` 上传文件）：
+
+```yaml
+time_zone: "Asia/Shanghai"
+tiers:
+  - name: "peak"
+    time_ranges:
+      - weekdays: [1, 2, 3, 4, 5]
+        start: "09:00"
+        end: "12:00"
+      - weekdays: [1, 2, 3, 4, 5]
+        start: "14:00"
+        end: "18:00"
+```
+
+#### 返回数据
+
+返回更新后的完整 provider 记录（包含基础信息 + `time_zone` / `tiers`）。
+
+### 1.3 读取接口响应变化
+
+现有 `GET /providers/{provider_name}` 与 `GET /providers` 接口保持不变，响应中同时返回基础信息与 `time_zone` / `tiers`：
+
+```json
+{
+    "name": "deepseek",
+    "description": "DeepSeek 官方 API",
+    "model_endpoint": { "schema": "https", "uri": "/v1/models" },
+    "models": ["deepseek-v4-pro", "deepseek-v4-flash"],
+    "keys": [...],
+    "instance_pool": [...],
+    "model_protocols": ["openai"],
+    "time_zone": "Asia/Shanghai",
+    "tiers": [
+        { "name": "peak", "time_ranges": [...] }
+    ],
+    "create_time": 1716883200,
+    "update_time": 1716883200
+}
+```
+
+### 1.4 配置流程
+
+1. **创建 provider**：调用 `POST /providers`，只提交基础信息，不提交高峰/闲时信息。
+2. **设置高峰/闲时模板**：调用 `PUT /providers/{provider_name}/pricing-tiers`，提交 JSON 或 YAML 格式的高峰/闲时信息。
+3. **读取 provider**：调用 `GET /providers/{provider_name}`，返回完整信息。
+
+## 2. `/model-prices` 资源增强
+
+### 2.1 新增字段
+
+在现有 model-prices 数据模型基础上新增：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `tier_prices` | object | 否 | tier name -> 价格表；**初期键名只支持 `peak`**；内部键名须为 `prices` 枚举；与 provider 的 `tiers` 不做强制引用校验 |
+
+`tier_prices` 示例：
+
+```json
+{
+  "tier_prices": {
+    "peak": {
+      "input_cost_per_token": 9.0e-06,
+      "output_cost_per_token": 2.7e-05,
+      "cache_read_input_token_cost": 3.0e-07
+    }
+  }
+}
+```
+
+### 2.2 字段说明
+
+- `prices` 作为默认价格，用于未命中任何 tier 的场景（如 DeepSeek 的空闲时段）。
+- `tier_prices` 只列出与默认价格不同的 tier（如 `peak`）；如果某个 tier 未配置某个价格键，自动 fallback 到 `prices` 中的对应键。
+- `tier_prices` 中的 tier name 建议与 provider 的 `tiers` 保持一致。
+- 若 provider 的 `tiers` 中不存在该 tier name，则对应价格永远不会被命中。
+
+### 2.3 对 `model-list.yaml` 源格式的影响
+
+`model-list.yaml` 仍只维护模型价格数据，不引入 `providers` 段落；provider 的高峰/闲时模板通过独立的 `/providers/{provider_name}/pricing-tiers` 接口维护。
+
+```yaml
+version: v1.0
+default_currency: "RMB"
+
+models:
+  - provider: "deepseek"
+    model: "deepseek-v4-pro"
+    base_model: "deepseek-v4-pro"
+    mode: "chat"
+    prices:
+      input_cost_per_token: 0.0000045
+      output_cost_per_token: 0.0000135
+      cache_read_input_token_cost: 0.00000015
+    tier_prices:
+      peak:
+        input_cost_per_token: 0.000009
+        output_cost_per_token: 0.000027
+        cache_read_input_token_cost: 0.0000003
+```
+
+## 3. 校验规则
+
+### 3.1 `/providers` 校验
+
+1. `time_zone` 须为合法 IANA 时区名；为空时默认 `Asia/Shanghai`。
+2. `tiers` 中每个 tier 必须包含非空 `name` 和至少一个 `time_range`。
+3. **`tiers` 中每个 tier 的 `name` 初期只支持 `peak`**。
+4. `time_ranges` 中 `weekdays` 元素必须在 0-6 之间；`start` / `end` 格式为 `HH:MM`，且 `end` > `start`。
+5. 同一 tier 内部 `time_ranges` 不得重叠；不同 tier 之间允许重叠（按列表顺序匹配）。
+
+### 3.2 `/model-prices` 校验
+
+1. `tier_prices.<tier>.<key>` 必须是 `prices` 枚举中的合法键名，且值为非负数。
+2. **`tier_prices` 的键名初期只支持 `peak`**。
+3. `tier_prices` 中的 tier name 与 provider 的 `tiers` 不做强制引用校验；若引用了一个不存在的 tier name，可记录告警，但不阻塞写入。
+
+## 4. Inner API 变更
+
+### 4.1 `/configs/tls_conf/server_data_conf` 导出结构变化
+
+受影响的端点：
+
+| 端点 | 方法 | 变更点 |
+|------|------|--------|
+| `/configs/tls_conf/server_data_conf` | GET | 返回的 `ClusterConf.Config.<cluster_name>.AIConf.ModelTable` 结构增强 |
+
+该 Inner API 的 URL、Method、鉴权均无变化，但导出逻辑与返回结构均发生变化：
+
+- **导出逻辑**：`model/iroute_conf/exporter.go` 在导出 route rule 时，会先全量查询 `/providers`，按 `provider_name` 构建 `providerPricingTable`（含 `time_zone`、`tiers`），再传入 `model/icluster_conf.NewBfeClusterConf`。
+- **结构增强**：返回的 `ClusterConf.Config.<cluster_name>.AIConf.ModelTable` 结构增强：
+
+| 变更项 | 说明 |
+|--------|------|
+| 新增 `ModelTable.Currency` | 固定为 `"RMB"` |
+| 新增 `ModelTable.TimeZone` | 来源为 `/providers` 的 `time_zone`；未配置时默认 `"Asia/Shanghai"` |
+| 新增 `ModelTable.Tiers` | 来源为 `/providers` 的 `tiers`；为空时 BFE 按固定价格处理 |
+| 新增 `ModelTable.Models[].TierPrices` | 来源为 `/model-prices` 的 `tier_prices`；key 为 tier name，value 为价格对象 |
+| `ModelTable.Models[].Prices` 语义调整 | 从"唯一价格"变为"默认 / fallback 价格"；未命中 tier 或 tier 未覆盖某个键时使用 |
+
+导出后的 `ModelTable` 示例：
+
+```json
+{
+    "ModelTable": {
+        "Currency": "RMB",
+        "TimeZone": "Asia/Shanghai",
+        "Tiers": [
+            {
+                "Name": "peak",
+                "TimeRanges": [
+                    { "Weekdays": [1, 2, 3, 4, 5], "Start": "09:00", "End": "12:00" },
+                    { "Weekdays": [1, 2, 3, 4, 5], "Start": "14:00", "End": "18:00" }
+                ]
+            }
+        ],
+        "Models": [
+            {
+                "Provider": "deepseek",
+                "Model": "deepseek-v4-pro",
+                "BaseModel": "deepseek-v4-pro",
+                "Mode": "chat",
+                "Prices": {
+                    "input_cost_per_token": 4.5e-06,
+                    "output_cost_per_token": 1.35e-05,
+                    "cache_read_input_token_cost": 1.5e-07
+                },
+                "TierPrices": {
+                    "peak": {
+                        "input_cost_per_token": 9.0e-06,
+                        "output_cost_per_token": 2.7e-05,
+                        "cache_read_input_token_cost": 3.0e-07
+                    }
+                }
+            }
+        ]
+    }
+}
+```
+
+### 4.2 配置导出逻辑
+
+`ai-gateway-api` 在生成 BFE 配置时，关键实现位于 `model/iroute_conf/exporter.go` 与 `model/icluster_conf/cluster.go`：
+
+1. `exportRouteRule` 全量查询 `/providers`，构建 `map[string]ProviderPricingInfo`（`providerPricingTable`），包含每个 provider 的 `time_zone`、`tiers`。
+2. `NewBfeClusterConf` 接收 `providerPricingTable`，根据 `cluster.llm_config.provider` 取出对应 `ProviderPricingInfo`。
+3. 按同一 `provider` 查询 `/model-prices`，把每条记录转换成 `ModelPrice`。
+4. 将 `time_zone` / `tiers` 填入 `AIConf.ModelTable`，将 `prices` / `tier_prices` 填入对应 `ModelPrice`；`Currency` 固定为 `"RMB"`。
+5. 若 provider 未配置 `time_zone` / `tiers`，则 `AIConf.ModelTable` 中 `TimeZone` / `Tiers` 为空，BFE 按固定价格处理。
+
+### 4.3 对 BFE 的兼容要求
+
+- BFE 侧 `AIConf.ModelTable` 结构复用 v0.4 方案，字段名保持 PascalCase（`Currency`、`TimeZone`、`Tiers`、`TierPrices`、`Weekdays`、`Start`、`End`）。
+- `Currency` 固定为 `"RMB"`；BFE 加载阶段需校验。
+- `TimeZone` 为空时，BFE 默认使用 `"Asia/Shanghai"`。
+- `Tiers` 为空时，BFE 直接按 `Prices` 固定价格计费。
+- `TierPrices` 中引用了未在 `Tiers` 中定义的 tier name 时，BFE 不报错，对应价格仅永不命中。
+
+## 5. 实现状态
+
+- 接口层：`PUT /providers/{provider_name}/pricing-tiers` 已在 `endpoints/openapi_v1/provider/pricing_tiers.go` 实现并注册。
+- 模型层：`model/iprovider` 完成 `time_zone`/`tiers` 校验与 `UpdatePricingTiers`；`model/imodel_price` 完成 `tier_prices` 校验。
+- 导出层：`model/iroute_conf/exporter.go` + `model/icluster_conf/cluster.go` 完成 `ModelTable` 拼接。
+- 测试：`go test ./...` 全量通过。

--- a/design-docs/modifications/2026-08-25-rmb-tiered-pricing/change-summary.md
+++ b/design-docs/modifications/2026-08-25-rmb-tiered-pricing/change-summary.md
@@ -1,0 +1,64 @@
+# RMB 配额支持分时段/分工作日定价——变更摘要
+
+## 1. 背景
+
+随着 DeepSeek 等模型提供商采用"高峰 / 空闲"分时段定价策略，BFE RMB 配额扣费需要具备按请求发生时刻匹配不同价格的能力。本变更是 v0.4《BFE RMB 配额支持 peak/off-peak 时段定价增强方案》的更新版，主要应对以下变化：
+
+1. **ai-gateway-api 已完成 provider 与 cluster 的概念分离**：`provider` 负责下游模型提供商接入能力，`cluster` 负责转发策略并引用 provider。时段规则需要明确归属与下发链路。
+2. **DeepSeek 价格体系调整**：官方以北京时间区分工作日高峰时段（周一至周五 09:00-12:00、14:00-18:00）与空闲时段，空闲价格为高峰价格的一半。
+
+由于 v0.4 已预留 `TimeRange.Weekdays` 按星期几分段的能力，BFE 运行时匹配逻辑无需大改。本次重点是在 provider/cluster 分离后的新架构下，重新明确时段配置的归属、下发链路，并更新 DeepSeek 配置示例。
+
+## 2. 目标
+
+1. 支持按请求发生时刻匹配特定价格 tier（如 `peak`），未命中时 fallback 到默认价格；通过 `Weekdays` 保留区分工作日与休息日的扩展能力。
+2. 支持不同 provider 配置不同的时区和时段规则。
+3. 结合 provider/cluster 分离，明确时段配置归属：时段模板放在 `/providers`，分时段价格放在 `/model-prices`。
+4. 保持对现有固定价格的向后兼容。
+5. 结构可扩展，自然支持缓存命中 / 未命中、200k+ 长文本等分层价格。
+6. 运行时成本计算仍保持纯整数运算，不引入浮点误差。
+7. 价格键名符合 `model-prices.md` 的枚举规范。
+
+## 3. 范围
+
+- **涉及面**：`ai-gateway-api` 控制面（`/providers`、`/model-prices`、配置导出）及 `bfe` 数据面（`AIConf.ModelTable` 加载、时段匹配、`calcCostUnits`）。
+- **不涉及面**：`TokenUsage.UsedCost`、Lua 扣减逻辑、Redis 定点数存储等已有 RMB 扣费基础设施。
+- **数据面影响**：BFE `AIConf.ModelTable` 结构复用 v0.4 设计，仅在配置来源上发生变化。
+
+## 4. 关键决策
+
+| 决策 | 说明 |
+|------|------|
+| 时段模板归属 provider | 同一 provider 下所有模型共享 `time_zone` 和 `tiers`，避免重复配置。 |
+| 分时段价格归属 model-prices | 不同模型在同一 tier 下可有不同价格，保留价格灵活性。 |
+| 独立 pricing-tiers 接口 | 高峰/闲时模板通过 `PUT /providers/{provider_name}/pricing-tiers` 单独维护，保持创建 provider 时接口简洁。 |
+| 默认价格作为 fallback | `prices` 字段继续表示非 tier 命中或 tier 未覆盖键时的默认价格。 |
+| 初期只支持 `peak` tier | 简化首期实现，后续按需放开 tier name 约束。 |
+| 定点整数运算 | `prices` 与 `tier_prices` 在加载阶段转换为定点整数，运行时避免浮点误差。 |
+| 缓存命中价格键名 | 使用 `model-prices.md` 标准键名 `cache_read_input_token_cost`。 |
+
+## 5. 关联文档
+
+- 详细设计：`design-changes.md`
+- 接口变更：`api-changes.md`
+- 上游设计来源：`document-ai-gateway/迭代系统设计/v0.5/计费能力扩展/bfe-rmb-tiered-pricing-design.md`
+- 相关基础设计：`ai-gateway-api/design-docs/sys-design/details/provider与cluster概念分离.md`
+
+## 6. 实施阶段
+
+| 阶段 | 内容 | 状态 | 关键文件 |
+|------|------|------|----------|
+| 1 | 设计与文档冻结 | ✅ 已完成 | `design-docs/sys-design/details/RMB配额分时段定价.md`、`design-docs/api-define/OpenAPI接口定义/providers.md`、`model-prices.md`、`InnerAPI接口定义/server-data-conf.md` |
+| 2 | 控制面数据模型与存储（provider / model-prices 新增字段） | ✅ 已完成 | `db_ddl.sql`、`db_ddl_sqlite.sql`、`storage/rdb/internal/dao/table_providers.go`、`table_model_prices.go`、`storage/rdb/provider/provider.go`、`storage/rdb/model_price/model_price.go` |
+| 3 | `pricing-tiers` 接口与校验 | ✅ 已完成 | `endpoints/openapi_v1/provider/pricing_tiers.go`、`model/iprovider/provider.go`、`model/iprovider/validate.go`、`model/imodel_price/model_price.go`、`model/imodel_price/validate.go` |
+| 4 | 配置导出适配（`AIConf.ModelTable` 拼接） | ✅ 已完成 | `model/icluster_conf/cluster.go`、`model/iroute_conf/exporter.go` |
+| 5 | BFE 数据面加载、匹配与成本计算 | ✅ 已完成（BFE 侧结构已就绪） | `bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go`（已有 `TimeZone`/`Tiers`/`TierPrices`/`ActiveTierName`） |
+| 6 | 测试与发布 | ✅ 已完成 | `go test ./...` 全量通过；新增集成测试 `test/integration/tests/provider/pricing_tiers`、`model_price/tier_prices`、`innerapi/tls_conf/tiered_pricing` |
+
+## 7. 实现结果
+
+- 代码已于 `2026-08-25` 完成并全量测试通过（`go build ./...`、`go test ./...`）。
+- 新增 OpenAPI 端点 `PUT /providers/{provider_name}/pricing-tiers` 已注册并支持 `application/json`、`text/yaml`、`multipart/form-data` 三种提交方式。
+- Inner API `/configs/tls_conf/server_data_conf` 返回的 `ClusterConf.Config.<cluster>.AIConf.ModelTable` 已自动填充 `Currency`、`TimeZone`、`Tiers`、`Models[].TierPrices`。
+- BFE 数据面无需额外改动，其 `AIConf.ModelTable` 结构与 `ActiveTierName` / `calcCostUnits` 已支持分时段定价。
+- 集成测试覆盖 pricing-tiers、model-prices tier_prices、InnerAPI 导出三个链路；测试期间修复了 `UpdatePricingTiers` 覆盖其他 provider 字段、`mergeModelPrice` 遗漏 `TierPrices`、时段重叠未校验 3 个问题。

--- a/design-docs/modifications/2026-08-25-rmb-tiered-pricing/design-changes.md
+++ b/design-docs/modifications/2026-08-25-rmb-tiered-pricing/design-changes.md
@@ -1,0 +1,251 @@
+# RMB 配额分时段定价——设计变更说明
+
+## 1. 概念定义
+
+| 概念 | 定义 |
+|------|------|
+| **Tier** | 按时间维度划分的价格层级，如 `peak`（高峰）。请求发生时刻命中某个 tier 时，使用对应价格；否则 fallback 到默认 `prices`。 |
+| **TimeRange** | 一个时段定义，包含 `weekdays`（星期几）、`start` / `end`（HH:MM）。 |
+| **Provider 时段模板** | 定义在 `/providers` 上的 `time_zone` 和 `tiers`，同一 provider 下所有模型共享。 |
+| **Model tier 价格** | 定义在 `/model-prices` 上的 `tier_prices`，描述某个模型在某个 tier 下的价格。 |
+
+## 2. 配置归属与下发链路
+
+### 2.1 provider/cluster 分离后的配置归属
+
+按"同一 provider 内所有模型共享时段规则"的原则，将时段模板与价格数据拆分到两个资源：
+
+- **`/providers`**：新增 `time_zone`、`tiers` 字段，描述"该 provider 在什么时区、哪些时段属于哪个 tier"。
+- **`/model-prices`**：新增 `tier_prices` 字段，描述"某个 provider 的某个模型在某个 tier 下按什么价格计费"；默认 `prices` 继续作为非 tier 命中或 tier 未覆盖键时的 fallback 价格。
+
+### 2.2 控制面 → 数据面转换
+
+```
+/provider deepseek
+    ├── time_zone: Asia/Shanghai
+    └── tiers: [peak]
+    ├── model-prices deepseek-v4-pro chat
+    │       ├── prices: 默认/空闲价
+    │       └── tier_prices.peak: 高峰价
+    └── model-prices deepseek-v4-flash chat
+            └── ...
+
+/cluster my-cluster
+    ├── llm_config.provider: deepseek
+    └── AIConf.ModelTable（导出时由 control-plane 把 provider 的 time_zone/tiers 与 model-prices 的 prices/tier_prices 拼接）
+```
+
+多个 cluster 引用同一个 provider 时，会各自得到一份相同的 `ModelTable` 数据；provider 的时段规则变更后，所有引用它的 cluster 在下一次配置导出时自动生效。
+
+## 3. 数据模型改动
+
+### 3.1 ai-gateway-api `/providers` 数据模型
+
+新增字段：
+
+| 字段 | 类型 | 说明 | 合法性条件 |
+|------|------|------|------------|
+| `time_zone` | string | 计算时段所使用的时区 | 默认 `Asia/Shanghai`；须为 IANA 时区名 |
+| `tiers` | []object | 时段 tier 定义列表 | 可选；元素包含 `name` + `time_ranges`；**初期 `name` 只支持 `peak`** |
+
+### 3.2 ai-gateway-api `/model-prices` 数据模型
+
+新增字段：
+
+| 字段 | 类型 | 说明 | 合法性条件 |
+|------|------|------|------------|
+| `tier_prices` | object | tier name -> 价格表 | 可选；**初期键名只支持 `peak`**；内部键名须为 `prices` 枚举；与 provider 的 `tiers` 不做强制引用校验 |
+
+### 3.3 数据库表结构
+
+#### `providers` 表新增字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `time_zone` | varchar(255) | 默认 `"Asia/Shanghai"`；IANA 时区名 |
+| `tiers` | text (JSON) | 时段 tier 定义列表 |
+
+示例：
+
+```sql
+ALTER TABLE `providers`
+    ADD COLUMN `time_zone` varchar(255) NOT NULL DEFAULT 'Asia/Shanghai',
+    ADD COLUMN `tiers` text;
+```
+
+#### `model_prices` 表新增字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `tier_prices` | text (JSON) | tier name -> 价格表 |
+
+示例：
+
+```sql
+ALTER TABLE `model_prices`
+    ADD COLUMN `tier_prices` text;
+```
+
+### 3.4 BFE `AIConf.ModelTable` 配置结构
+
+BFE 侧保持 v0.4 方案的结构，仅把配置来源明确为"由 ai-gateway-api 根据 provider 的 `time_zone` / `tiers` 与 model-prices 的 `prices` / `tier_prices` 拼接后填充"。
+
+```go
+type TimeRange struct {
+    Weekdays []int  // 0=周日, 1=周一 ... 6=周六；为空表示每天
+    Start    string // "HH:MM"
+    End      string // "HH:MM"，必须 > Start；跨午夜请拆成两段
+}
+
+type PriceTier struct {
+    Name       string      // 初期只支持 "peak"
+    TimeRanges []TimeRange // 命中任意一个即属于该 Tier
+}
+
+type ModelPrice struct {
+    Provider            string
+    Model               string
+    BaseModel           string
+    Mode                string
+    Capabilities        []string
+    SupportedParameters []string
+    Limits              map[string]interface{}
+    Prices              map[string]float64            // 默认价格（标准 prices 键名）
+    TierPrices          map[string]map[string]float64 // tier name -> 价格表（标准 prices 键名）
+    Metadata            map[string]interface{}
+
+    // 运行时字段：配置加载阶段预计算定点整数
+    pricesInt     map[string]int64            // 默认价格定点整数
+    tierPricesInt map[string]map[string]int64 // tier 价格定点整数
+}
+
+type ModelTable struct {
+    Currency string      // 仍是 "RMB"
+    TimeZone string      // 默认 "Asia/Shanghai"
+    Tiers    []PriceTier // 时段定义
+    Models   []ModelPrice
+
+    priceIndex map[string]map[string]*ModelPrice // model -> mode -> *ModelPrice
+    tierIndex  map[string]*PriceTier             // tier name -> *PriceTier
+    tz         *time.Location                    // 加载时解析的时区
+}
+```
+
+## 4. 控制面改造点
+
+### 4.1 配置导出（`model/icluster_conf/exporter.go`）
+
+生成 `AIConf` 时：
+
+1. 根据 `cluster.llm_config.provider` 查询 `/providers`，获取 `time_zone`、`tiers`。
+2. 根据同一 `provider` 查询 `/model-prices`，把每条记录转换成 `ModelPrice`。
+3. 将 `time_zone` / `tiers` 填入 `AIConf.ModelTable`，将 `prices` / `tier_prices` 填入对应 `ModelPrice`。
+4. 若 provider 未配置 `time_zone` / `tiers`，则 `AIConf.ModelTable` 中 `TimeZone` / `Tiers` 为空，BFE 按固定价格处理。
+
+### 4.2 多 provider 时段差异
+
+provider/cluster 分离后，时段规则天然跟随 provider：
+
+- `/providers` 中每个 provider 可以有自己的 `time_zone` 和 `tiers`。
+- 导出到 BFE 时，每个 cluster 的 `AIConf.ModelTable` 携带其引用的 provider 的时区与时段规则。
+- 不同 provider 的高峰/空闲定义可以完全不同。
+
+## 5. BFE 数据面改动
+
+BFE 侧与 v0.4 方案基本一致，因为 `AIConf.ModelTable` 结构未变，仅配置来源发生变化。
+
+### 5.1 加载阶段增强
+
+在 `ModelTableCheck` 里：
+
+1. 解析 `TimeZone`，默认 `Asia/Shanghai`。
+2. 校验 `Tiers`：名字非空、**初期 `name` 只支持 `peak`**、时间格式正确、`Weekdays` 合法、同一 Tier 内时间不重叠。
+3. 将默认 `Prices` 和每个 tier 的价格表分别转成定点整数；`TierPrices` 中的 tier name 不强制要求在 `Tiers` 中已定义（运行时只有 `Tiers` 中命中的 tier 才会被使用），但**初期 `TierPrices` 的键名只支持 `peak`**。
+
+### 5.2 运行时时段匹配
+
+按请求发生时刻、模型表绑定的时区，依次匹配 `Tiers` 列表：
+
+- 命中 tier 后，成本计算优先从该 tier 的价格表中取价。
+- 未命中 tier 或 tier 未覆盖某个价格键时，fallback 到默认 `Prices`。
+- 时间区间采用左闭右开语义（`start <= cur < end`）。
+
+### 5.3 运行时成本计算
+
+`calcCostUnits` 根据当前时间匹配 tier，再取对应价格；同时支持缓存命中 / 未命中分层：
+
+- `TokenUsage` 增加 `CachedTokens` 字段，用于命中缓存的输入 token 数。
+- `UpdateCtxByUsage` 增加缓存 token 解析（不同 provider 字段不同，如 `usage.prompt_tokens_details.cached_tokens` 或 `usage.prompt_cache_hit_tokens`）。
+- 成本计算区分 `input_cost_per_token` 与 `cache_read_input_token_cost`。
+
+## 6. 向后兼容
+
+- `/providers` 不填 `time_zone` / `tiers` 时，BFE 的 `ModelTable.TimeZone` / `ModelTable.Tiers` 为空，行为与现在完全一致（固定价格）。
+- `/model-prices` 不填 `tier_prices` 时，按默认 `Prices` 固定价格计费。
+- 命中 tier 但该 tier 未配置某个价格键时，自动 fallback 到默认 `Prices` 中的对应键。
+- `TokenUsage.UsedCost`、Lua 扣减逻辑、Redis 定点数存储都不需要改。
+
+## 7. 风险与注意事项
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| tier name 首期约束 | 仅支持 `peak`，业务上若需要表达 `off_peak` / 周末等需后续放开 | 设计时已通过 `Weekdays` 预留扩展能力，后续只需放开命名约束。 |
+| provider 与 model-prices 的 tier 松耦合 | `tier_prices` 可能引用 provider 未定义的 tier，导致价格永不命中 | 可记录告警，但不做强制引用校验以保持灵活性。 |
+| 时区解析依赖系统时区数据库 | 部署环境需包含 IANA 时区数据 | 使用 Go 标准库 `time.LoadLocation`，确保容器镜像包含时区数据。 |
+| 高峰/空闲切换时刻的边界 | 时间区间左闭右开，切换瞬间价格突变 | 产品侧明确规则，BFE 按配置精确匹配。 |
+| 多 cluster 共享 provider | 修改 provider 时段规则会影响所有引用 cluster | 更新时给出引用列表确认。 |
+
+## 8. 实现与测试
+
+### 8.1 已实现的关键代码
+
+| 模块 | 文件 | 说明 |
+|------|------|------|
+| 数据库 DDL | `db_ddl.sql`、`db_ddl_sqlite.sql` | `providers` 新增 `time_zone`、`tiers`；`model_prices` 新增 `tier_prices` |
+| 存储层 | `storage/rdb/internal/dao/table_providers.go`、`table_model_prices.go` | DAO struct 新增字段 |
+| 存储层 | `storage/rdb/provider/provider.go`、`storage/rdb/model_price/model_price.go` | JSON 序列化/反序列化 |
+| 模型层 | `model/iprovider/provider.go`、`model/iprovider/validate.go` | `Provider`/`ProviderParam` 新增字段、`UpdatePricingTiers`、时区/时段校验 |
+| 模型层 | `model/imodel_price/model_price.go`、`model/imodel_price/validate.go` | `ModelPrice` 新增 `TierPrices`、`tier_prices` 校验 |
+| 导出层 | `model/icluster_conf/cluster.go`、`model/icluster_conf/cluster_test.go` | `NewBfeClusterConf` 新增 `providerPricingTable`、拼接 `ModelTable` |
+| 导出层 | `model/iroute_conf/exporter.go` | 构建 `providerPricingTable` 并传入 cluster conf |
+| 接口层 | `endpoints/openapi_v1/provider/pricing_tiers.go`、`endpoints/openapi_v1/provider/endpoints.go` | `PUT /providers/{provider_name}/pricing-tiers` |
+| 集成测试 | `test/integration/tests/provider/pricing_tiers/pricing_tiers_test.go` | pricing-tiers 接口 JSON/YAML/multipart 正例与异常校验 |
+| 集成测试 | `test/integration/tests/model_price/tier_prices/tier_prices_test.go` | model-prices `tier_prices` 正例与异常校验、导入覆盖 |
+| 集成测试 | `test/integration/tests/innerapi/tls_conf/tiered_pricing_test.go` | InnerAPI 导出 `ModelTable` 含 `Currency`/`TimeZone`/`Tiers`/`TierPrices` |
+| 集成测试 | `test/integration/tests/schema/openapi/provider.go` | ProviderSchema 增加 `time_zone`、`tiers` 定义 |
+| 集成测试 | `test/integration/tests/schema/openapi/model_price.go` | ModelPriceSchema 增加 `tier_prices` 定义 |
+| 集成测试 | `test/integration/tests/schema/openapi/openapi_schema_test.go` | schema 测试数据携带 `time_zone`/`tiers`/`tier_prices` |
+| 测试工具 | `test/integration/testutil/client.go`、`test/integration/testutil/api_helpers.go` | `PutMultipartFile`、pricing-tiers/YAML 辅助函数 |
+
+### 8.2 测试期间发现并修复的问题
+
+1. **`model/iprovider/provider.go` `UpdatePricingTiers`**：原实现只构造含 `time_zone`/`tiers` 的 `ProviderParam`，导致 `UpdateProvider` 把 provider 的 `models`、`keys`、`instance_pool` 等字段覆盖为空。已修复为从 existing provider 回填全部字段，仅更新时区与 tiers。
+2. **`endpoints/openapi_v1/model_price/update.go` `mergeModelPrice`**：原合并逻辑遗漏 `TierPrices`，导致 `PUT /model-prices/{id}` 更新 `tier_prices` 不生效。已补充合并分支。
+3. **`model/iprovider/provider.go` 时段重叠校验**：设计文档要求“同一 tier 内部 `time_ranges` 不得重叠”，但实现仅校验重复。已补充 `timeRangesOverlap` 检测。
+4. **`tests/schema/innerapi/innerapi_schema_test.go` `redis_key` 前缀断言**：限流策略的 `redis_key` 实际包含产品线/集群前缀（如 `default_bfe_rlp-2_RL_TPM_rlp-2_tpm-1m`），原断言使用严格前缀导致失败。已改为校验关键片段 `RL_<TYPE>_<policy>_`。
+
+- **单元测试**：`model/iprovider`、`model/imodel_price`、`model/icluster_conf`、`model/iroute_conf`、`endpoints/openapi_v1/provider`、`endpoints/openapi_v1/model_price` 均新增或更新用例。
+- **全量测试**：`go test ./...` 全量通过。
+
+### 8.3 测试建议（已落地的验证点）
+
+1. **Provider 校验**：`time_zone` 非法时拒绝；`tiers` 中 `name` 非 `peak` 时拒绝；时间重叠、`weekdays` 越界、`end <= start` 时拒绝。
+2. **Model-prices 校验**：`tier_prices.<tier>.<key>` 使用非枚举键名时拒绝；`tier_prices` 中出现非 `peak` 的 tier name 时拒绝。
+3. **Pricing-tiers 接口**：JSON / YAML / multipart 均可正确解析并写入；`GET /providers/{provider_name}` 可返回完整信息。
+4. **配置导出**：引用同一 provider 的多个 cluster 导出的 `ModelTable` 一致；provider 时段规则变更后同步更新；未配置时段规则时固定价格行为正确。
+5. **BFE 数据面**：BFE 侧结构已就绪，加载、时段匹配与成本计算由 BFE 现有逻辑承载。
+
+## 9. 设计文档更新
+
+为与代码和测试保持一致，已同步更新以下设计文档：
+
+| 文档 | 更新内容 |
+|------|----------|
+| `test/integration/tests/provider/design.md` | 新增 PV-8 `PUT /providers/{provider_name}/pricing-tiers` 接口说明、目录结构、测试用例（JSON/YAML/multipart、异常校验、GET 返回验证） |
+| `test/integration/tests/model_price/design.md` | 在模块概述、接口参数、数据示例中补充 `tier_prices`；新增第 17 节“分时段价格字段测试（MTP-1）”，覆盖创建、更新、导入、非法 tier name/价格键/负数价格等 6 个场景 |
+| `test/integration/tests/innerapi/design.md` | 在模块概述中补充分时段定价下发链路；更新测试用例统计；在 `tls_conf` 章节新增 IN-TIER-1-001/IN-TIER-1-002，验证 `ModelTable.TimeZone/Tiers/TierPrices` 导出及向后兼容 |
+| `test/integration/tests/schema/openapi/provider.go` | ProviderSchema 增加 `time_zone`、`tiers` 字段定义 |
+| `test/integration/tests/schema/openapi/model_price.go` | ModelPriceSchema 增加 `tier_prices` 字段定义 |
+| `test/integration/tests/schema/openapi/openapi_schema_test.go` | schema 测试数据携带 `time_zone`/`tiers`/`tier_prices`，验证字段生效 |
+| `test/integration/tests/schema/innerapi/schema.go` | ServerDataConfSchema 增加 `ClusterConf` 嵌套校验；新增 `ModelTableSchema` 与 `ModelPriceSchema`，覆盖 `Currency`/`TimeZone`/`Tiers`/`Models`/`Prices`/`TierPrices` 等字段 |
+| `test/integration/tests/schema/innerapi/innerapi_schema_test.go` | 新增 `server_data_conf_tiered_pricing` schema 测试，验证 InnerAPI 导出 `AIConf.ModelTable` 含分时段定价字段 |

--- a/design-docs/sys-design/details/RMB配额分时段定价.md
+++ b/design-docs/sys-design/details/RMB配额分时段定价.md
@@ -1,0 +1,232 @@
+# RMB 配额分时段定价
+
+## 1. 背景与目标
+
+随着 DeepSeek 等模型提供商采用"高峰 / 空闲"分时段定价策略，BFE RMB 配额扣费需要具备按请求发生时刻匹配不同价格的能力。
+
+本设计目标：
+
+1. 支持按请求发生时刻匹配特定价格 tier（如 `peak`），未命中时 fallback 到默认价格。
+2. 支持不同 provider 配置不同的时区和时段规则。
+3. 结合 provider/cluster 分离，时段模板放在 `/providers`，分时段价格放在 `/model-prices`。
+4. 保持对现有固定价格的向后兼容。
+5. 运行时成本计算仍保持纯整数运算，不引入浮点误差。
+
+## 2. 核心概念
+
+| 概念 | 说明 |
+|------|------|
+| **Tier** | 按时间维度划分的价格层级，如 `peak`（高峰）。请求发生时刻命中某个 tier 时，使用对应价格；否则 fallback 到默认 `prices`。 |
+| **TimeRange** | 一个时段定义，包含 `weekdays`（星期几，0=周日）、`start` / `end`（HH:MM，左闭右开）。 |
+| **Provider 时段模板** | 定义在 `/providers` 上的 `time_zone` 和 `tiers`，同一 provider 下所有模型共享。 |
+| **Model tier 价格** | 定义在 `/model-prices` 上的 `tier_prices`，描述某个模型在某个 tier 下的价格。 |
+
+## 3. 配置归属与下发链路
+
+```
+/provider deepseek
+    ├── time_zone: Asia/Shanghai
+    └── tiers: [peak]
+    ├── model-prices deepseek-v4-pro chat
+    │       ├── prices: 默认/空闲价
+    │       └── tier_prices.peak: 高峰价
+    └── model-prices deepseek-v4-flash chat
+            └── ...
+
+/cluster my-cluster
+    ├── llm_config.provider: deepseek
+    └── AIConf.ModelTable（导出时由 control-plane 把 provider 的 time_zone/tiers 与 model-prices 的 prices/tier_prices 拼接）
+```
+
+多个 cluster 引用同一个 provider 时，会各自得到一份相同的 `ModelTable` 数据；provider 的时段规则变更后，所有引用它的 cluster 在下一次配置导出时自动生效。
+
+## 4. 数据模型
+
+### 4.1 `/providers` 新增字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `time_zone` | string | 计算时段所使用的时区；默认 `Asia/Shanghai`；须为 IANA 时区名 |
+| `tiers` | []PricingTier | 时段 tier 定义列表；**初期 `name` 只支持 `peak`** |
+
+```json
+{
+  "name": "peak",
+  "time_ranges": [
+    { "weekdays": [1, 2, 3, 4, 5], "start": "09:00", "end": "12:00" },
+    { "weekdays": [1, 2, 3, 4, 5], "start": "14:00", "end": "18:00" }
+  ]
+}
+```
+
+### 4.2 `/model-prices` 新增字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `tier_prices` | object | tier name -> 价格表；**初期键名只支持 `peak`**；内部键名须为 `prices` 枚举 |
+
+### 4.3 BFE `AIConf.ModelTable` 结构
+
+```go
+type TimeRange struct {
+    Weekdays []int  // 0=周日，1=周一 ... 6=周六；为空表示每天
+    Start    string // "HH:MM"
+    End      string // "HH:MM"，必须 > Start；跨午夜请拆成两段
+}
+
+type PriceTier struct {
+    Name       string      // 初期只支持 "peak"
+    TimeRanges []TimeRange // 命中任意一个即属于该 Tier
+}
+
+type ModelPrice struct {
+    Provider            string
+    Model               string
+    BaseModel           string
+    Mode                string
+    Capabilities        []string
+    SupportedParameters []string
+    Limits              map[string]interface{}
+    Prices              map[string]float64            // 默认价格
+    TierPrices          map[string]map[string]float64 // tier name -> 价格表
+    Metadata            map[string]interface{}
+}
+
+type ModelTable struct {
+    Currency string      // 固定 "RMB"
+    TimeZone string      // 默认 "Asia/Shanghai"
+    Tiers    []PriceTier // 时段定义
+    Models   []ModelPrice
+}
+```
+
+## 5. 控制面实现要点
+
+### 5.1 接口层
+
+- `PUT /providers/{provider_name}/pricing-tiers`：单独维护 provider 的高峰/闲时模板，支持 JSON / YAML 两种提交方式。
+- `/providers` 的 CRUD 与读取接口均须支持 `time_zone` / `tiers` 字段。
+- `/model-prices` 的 CRUD 与导入接口须支持 `tier_prices` 字段。
+
+### 5.2 模型层
+
+- `model/iprovider`：
+  - `Provider` / `ProviderParam` 新增 `time_zone`、`tiers`。
+  - 新增 `UpdatePricingTiers` 方法，负责解析、校验并更新时段模板。
+  - `CreateProvider` / `UpdateProvider` 增加对 `tiers` 的校验。
+- `model/imodel_price`：
+  - `ModelPrice` / `ModelPriceParam` 新增 `tier_prices`。
+  - CRUD 与 YAML 导入增加对 `tier_prices` 的校验（tier name、价格键名、非负价格）。
+- `model/icluster_conf/exporter.go`：
+  - 导出 `AIConf` 时，根据 `cluster.llm_config.provider` 查询 Provider，将 `time_zone` / `tiers` 填入 `ModelTable`。
+  - 按同一 `provider` 查询 `model_prices`，将 `prices` / `tier_prices` 填入对应 `ModelPrice`。
+  - `Currency` 固定为 `"RMB"`。
+
+### 5.3 存储层
+
+- `providers` 表新增 `time_zone`（varchar，默认 `Asia/Shanghai`）、`tiers`（text / JSON）。
+- `model_prices` 表新增 `tier_prices`（JSON）。
+
+## 6. BFE 数据面行为
+
+BFE 侧与 v0.4 方案基本一致，`AIConf.ModelTable` 结构未变，仅配置来源发生变化。
+
+### 6.1 加载阶段
+
+- 解析 `TimeZone`，默认 `Asia/Shanghai`。
+- 校验 `Tiers`：名字非空、**初期 `name` 只支持 `peak`**、时间格式正确、`Weekdays` 合法、同一 Tier 内时间不重叠。
+- 将默认 `Prices` 和每个 tier 的价格表分别转成定点整数。
+
+### 6.2 运行时时段匹配
+
+```go
+func (table *ModelTable) ActiveTierName(now time.Time) string {
+    if table == nil || len(table.Tiers) == 0 {
+        return ""
+    }
+    t := now.In(table.tz)
+    wd := int(t.Weekday())
+    hour, min := t.Hour(), t.Minute()
+    cur := hour*60 + min
+
+    for i := range table.Tiers {
+        tier := &table.Tiers[i]
+        for _, tr := range tier.TimeRanges {
+            if len(tr.Weekdays) > 0 && !containsInt(tr.Weekdays, wd) {
+                continue
+            }
+            start := parseHHMM(tr.Start)
+            end := parseHHMM(tr.End)
+            if start <= cur && cur < end {
+                return tier.Name
+            }
+        }
+    }
+    return ""
+}
+```
+
+### 6.3 运行时成本计算
+
+- `TokenUsage` 增加 `CachedTokens`，用于命中缓存的输入 token 数。
+- `calcCostUnits` 根据当前时间匹配 tier，再取对应价格。
+- 缓存命中 / 未命中分别按 `cache_read_input_token_cost` 和 `input_cost_per_token` 计算。
+
+## 7. 校验规则
+
+### 7.1 `/providers`
+
+1. `time_zone` 须为合法 IANA 时区名；为空时默认 `Asia/Shanghai`。
+2. `tiers` 中每个 tier 必须包含非空 `name` 和至少一个 `time_range`。
+3. **`tiers` 中每个 tier 的 `name` 初期只支持 `peak`**。
+4. `time_ranges` 中 `weekdays` 元素必须在 0-6 之间；`start` / `end` 格式为 `HH:MM`，且 `end` > `start`。
+5. 同一 tier 内部 `time_ranges` 不得重叠。
+
+### 7.2 `/model-prices`
+
+1. `tier_prices.<tier>.<key>` 必须是 `prices` 枚举中的合法键名，且值为非负数。
+2. **`tier_prices` 的键名初期只支持 `peak`**。
+3. `tier_prices` 中的 tier name 与 provider 的 `tiers` 不做强制引用校验；若引用了一个不存在的 tier name，可记录告警，但不阻塞写入。
+
+## 8. 向后兼容
+
+- `/providers` 不填 `time_zone` / `tiers` 时，BFE 的 `ModelTable.TimeZone` / `ModelTable.Tiers` 为空，行为与现在完全一致（固定价格）。
+- `/model-prices` 不填 `tier_prices` 时，按默认 `Prices` 固定价格计费。
+- 命中 tier 但该 tier 未配置某个价格键时，自动 fallback 到默认 `Prices` 中的对应键。
+- `TokenUsage.UsedCost`、Lua 扣减逻辑、Redis 定点数存储都不需要改。
+
+## 9. 风险与注意事项
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| tier name 首期约束 | 仅支持 `peak` | 设计时已通过 `Weekdays` 预留扩展能力，后续只需放开命名约束。 |
+| provider 与 model-prices 的 tier 松耦合 | `tier_prices` 可能引用 provider 未定义的 tier | 可记录告警，但不做强制引用校验以保持灵活性。 |
+| 时区解析依赖系统时区数据库 | 部署环境需包含 IANA 时区数据 | 使用 Go 标准库 `time.LoadLocation`，确保容器镜像包含时区数据。 |
+| 高峰/空闲切换时刻的边界 | 时间区间左闭右开，切换瞬间价格突变 | 产品侧明确规则，BFE 按配置精确匹配。 |
+| 多 cluster 共享 provider | 修改 provider 时段规则会影响所有引用 cluster | 更新时给出引用列表确认。 |
+
+## 10. 实现状态
+
+本设计已于 `2026-08-25` 完成编码并全量测试通过（`go build ./...`、`go test ./...`）。
+
+主要落地文件：
+
+| 层次 | 文件 | 说明 |
+|------|------|------|
+| DDL | `db_ddl.sql`、`db_ddl_sqlite.sql` | 表结构扩展 |
+| 存储层 | `storage/rdb/internal/dao/table_providers.go`、`table_model_prices.go` | DAO 字段 |
+| 存储层 | `storage/rdb/provider/provider.go`、`storage/rdb/model_price/model_price.go` | JSON 序列化 |
+| 模型层 | `model/iprovider/provider.go`、`validate.go` | provider 时区/时段模型与校验 |
+| 模型层 | `model/imodel_price/model_price.go`、`validate.go` | model price tier 价格模型与校验 |
+| 导出层 | `model/icluster_conf/cluster.go`、`model/iroute_conf/exporter.go` | `AIConf.ModelTable` 拼接 |
+| 接口层 | `endpoints/openapi_v1/provider/pricing_tiers.go` | `PUT /providers/{provider_name}/pricing-tiers` |
+| BFE 数据面 | `bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go` | 已有 `TimeZone`/`Tiers`/`TierPrices`/`ActiveTierName`，无需额外改动 |
+
+BFE 数据面保持原有 v0.4 实现，仅配置来源由 ai-gateway-api 控制面按本设计拼接后下发。
+
+## 11. 相关文档
+
+- API 定义：`design-docs/api-define/OpenAPI接口定义/providers.md`、`design-docs/api-define/OpenAPI接口定义/model-prices.md`
+- Inner API 定义：`design-docs/api-define/InnerAPI接口定义/server-data-conf.md`
+- 修改说明：`design-docs/modifications/2026-08-25-rmb-tiered-pricing/`
+- 上游设计来源：`document-ai-gateway/迭代系统设计/v0.5/计费能力扩展/bfe-rmb-tiered-pricing-design.md`

--- a/design-docs/sys-design/summary.md
+++ b/design-docs/sys-design/summary.md
@@ -30,6 +30,7 @@
 | Claude 协议转发支持 | [details/Claude协议转发支持.md](./details/Claude协议转发支持.md) | 描述 ai-gateway-api 控制面为支持 BFE 转发 Claude Messages API 所需配合的修改，包括 `AIConf.ModelProtocols` 透传、模型发现解析器下沉与废弃配置清理。 |
 | Redis Key 清理机制 | [details/Redis Key 清理机制.md](./details/Redis%20Key%20清理机制.md) | 描述 API-Key / Entity 删除及 rate-limit 规则变更时的 Redis Key 清理逻辑，包括 Quota Key 与 Rate-Limit Key 格式、触发场景、对 BFE 的影响以及控制面立即清理实现方案。 |
 | 模型定价管理 | [api-define/OpenAPI接口定义/model-prices.md](../api-define/OpenAPI接口定义/model-prices.md) | 描述 `/model-prices` 管理接口、`model-list.yaml` 导入格式、`ModelPrice` 数据模型与校验规则，是 InnerAPI `AIConf.ModelTable` 的数据源。 |
+| RMB 配额分时段定价 | [details/RMB配额分时段定价.md](./details/RMB配额分时段定价.md) | 描述 RMB 配额按 provider 时段模板与 model-prices 分时段价格进行计费的设计，包括 `time_zone` / `tiers` / `tier_prices` 数据模型、控制面导出逻辑、BFE 数据面时段匹配与成本计算。 |
 
 ---
 

--- a/design-docs/sys-design/接口层设计文档.md
+++ b/design-docs/sys-design/接口层设计文档.md
@@ -235,7 +235,7 @@ func endpoints() []*xreq.Endpoint {
 
 代码位置：`endpoints/openapi_v1/provider/`、`endpoints/openapi_v1/product_cluster/`、`endpoints/openapi_v1/model_price/`
 
-> 说明：Provider 与 Cluster 概念分离后，`/providers` 集中管理接入能力（`model_endpoint`、`models`、`keys`、`instance_pool`、`model_protocols`），`/clusters` 只保留转发策略。`llm_config.provider` 必填，且必须引用 `/providers` 中已存在的 Provider；`llm_config.models` 须为 Provider `models` 的子集；`llm_config.keys` 元素结构变为 `{name, weight}`，通过 `name` 引用 Provider 中的 key，不再返回 key 明文。`llm_config.model_endpoint`、`llm_config.provider_type` 已删除。`llm_config.model_mappings` 字段仍使用 `source_model`/`target_model` 描述模型映射；`llm_config.key_policy` 用于声明选择策略、请求内重试与退避参数。InnerAPI 据此自动填充 `AIConf.ModelTable`，并将 Provider 的 `model_protocols` 透传为 `AIConf.ModelProtocols`；`llm_config.model_table` 不在 OpenAPI `/clusters` 中展示。集群实例 `weight=0` 表示不接收流量，不会被后端强制改为默认值。
+> 说明：Provider 与 Cluster 概念分离后，`/providers` 集中管理接入能力（`model_endpoint`、`models`、`keys`、`instance_pool`、`model_protocols`），并通过 `time_zone` / `tiers` 描述高峰/闲时时段规则；`/clusters` 只保留转发策略。`llm_config.provider` 必填，且必须引用 `/providers` 中已存在的 Provider；`llm_config.models` 须为 Provider `models` 的子集；`llm_config.keys` 元素结构变为 `{name, weight}`，通过 `name` 引用 Provider 中的 key，不再返回 key 明文。`llm_config.model_endpoint`、`llm_config.provider_type` 已删除。`llm_config.model_mappings` 字段仍使用 `source_model`/`target_model` 描述模型映射；`llm_config.key_policy` 用于声明选择策略、请求内重试与退避参数。InnerAPI 据此自动填充 `AIConf.ModelTable`：从 Provider 取 `time_zone` / `tiers`，从 `model-prices` 取 `prices` / `tier_prices`，并将 Provider 的 `model_protocols` 透传为 `AIConf.ModelProtocols`；`llm_config.model_table` 不在 OpenAPI `/clusters` 中展示。集群实例 `weight=0` 表示不接收流量，不会被后端强制改为默认值。
 
 | Method | Path | 用途 | Authorizer |
 |--------|------|------|------------|
@@ -244,6 +244,7 @@ func endpoints() []*xreq.Endpoint {
 | GET | `/providers/{provider_name}` | Provider 详情 | `FeatureProvider + ActionRead` |
 | PATCH | `/providers/{provider_name}` | 更新 Provider | `FeatureProvider + ActionUpdate` |
 | DELETE | `/providers/{provider_name}` | 删除 Provider | `FeatureProvider + ActionDelete` |
+| PUT | `/providers/{provider_name}/pricing-tiers` | 设置/更新 Provider 高峰/闲时模板（支持 JSON / YAML） | `FeatureProvider + ActionUpdate` |
 | POST | `/providers/tools/discover-models` | 触发模型发现 | `FeatureProvider + ActionUpdate` |
 | GET | `/providers/actions/get-provider-names` | 获取所有 Provider 名称列表 | `FeatureProvider + ActionRead` |
 | POST | `/clusters` | 创建集群（通过引用 Provider 自动创建实例池 + 子集群） | `FeatureProductCluster + ActionCreate` |
@@ -261,7 +262,7 @@ func endpoints() []*xreq.Endpoint {
 | DELETE | `/model-prices` | 按 `(provider, model, mode)` 组合删除 | `FeatureModelPrice + ActionDelete` |
 | GET | `/model-prices/actions/get-providers` | 查询所有 price provider 名称列表 | `FeatureModelPrice + ActionRead` |
 
-> 说明：`/model-prices/import` 使用 `multipart/form-data` 接收 `file`（`model-list.yaml`）与 `mode`（`replace` / `merge`，默认 `replace`）两个字段，仅允许管理员调用。`replace` 模式会清空 `model_prices` 表后全量写入；`merge` 模式对已有 `(provider, model, mode)` 记录更新、新增记录插入。导入时不再校验 `provider` 是否已存在于 `/providers`，未知 provider 可正常写入。
+> 说明：`/model-prices/import` 使用 `multipart/form-data` 接收 `file`（`model-list.yaml`）与 `mode`（`replace` / `merge`，默认 `replace`）两个字段，仅允许管理员调用。`replace` 模式会清空 `model_prices` 表后全量写入；`merge` 模式对已有 `(provider, model, mode)` 记录更新、新增记录插入。导入时支持 `tier_prices` 字段（**初期 tier name 只支持 `peak`**）。导入时不再校验 `provider` 是否已存在于 `/providers`，未知 provider 可正常写入。
 
 #### 4.2.7 证书（certificate）
 

--- a/design-docs/sys-design/数据库设计文档.md
+++ b/design-docs/sys-design/数据库设计文档.md
@@ -232,6 +232,8 @@ CREATE TABLE `providers` (
   `keys` text,
   `instance_pool` text,
   `model_protocols` text,
+  `time_zone` varchar(255) NOT NULL DEFAULT 'Asia/Shanghai',
+  `tiers` text,
   `created_at` datetime NOT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
@@ -249,8 +251,12 @@ CREATE TABLE `providers` (
 | `keys` | text | NULL | API Key 明文列表 JSON；元素为 `{name, key}` |
 | `instance_pool` | text | NULL | 后端实例池 JSON；元素为 `{name, addr, weight, port}` |
 | `model_protocols` | text | NULL | 支持的模型访问协议 JSON；首期枚举：`openai`、`anthropic` |
+| `time_zone` | varchar(255) | NOT NULL DEFAULT 'Asia/Shanghai' | 计算时段所使用的时区；IANA 时区名 |
+| `tiers` | text | NULL | 时段 tier 定义列表 JSON；元素为 `{name, time_ranges}`；**初期 `name` 只支持 `peak`** |
 | `created_at` | datetime | NOT NULL | 创建时间 |
 | `updated_at` | timestamp | 自动更新 | 更新时间 |
+
+> 说明：`time_zone` / `tiers` 描述该 provider 的时段规则，供 InnerAPI 导出 `AIConf.ModelTable` 时使用。同一 provider 下所有模型共享该规则。
 
 > 说明：`providers` 表使用 `utf8mb4` 字符集以支持模型名等多语言内容。Provider 被 `/clusters` 引用时不可删除；`/model-prices` 中的同名 provider 不再阻塞删除。
 
@@ -957,6 +963,7 @@ CREATE TABLE `model_prices` (
   `supported_parameters` JSON,
   `limits` JSON,
   `prices` JSON NOT NULL,
+  `tier_prices` JSON,
   `price_currency` VARCHAR(10) NOT NULL DEFAULT 'RMB',
   `metadata` JSON,
   `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -976,7 +983,8 @@ CREATE TABLE `model_prices` (
 | `capabilities` | JSON | NULL | 能力列表 |
 | `supported_parameters` | JSON | NULL | 支持的请求参数列表 |
 | `limits` | JSON | NULL | 限制对象 |
-| `prices` | JSON | NOT NULL | 价格对象，至少包含一个价格字段 |
+| `prices` | JSON | NOT NULL | 默认价格对象；至少包含一个价格字段；未命中 tier 时作为 fallback |
+| `tier_prices` | JSON | NULL | 分时段价格对象；key 为 tier name（**初期只支持 `peak`**），value 为价格对象；内部键名须为 `prices` 枚举 |
 | `price_currency` | VARCHAR(10) | NOT NULL DEFAULT 'RMB' | 价格货币；v0.4 固定为 RMB |
 | `metadata` | JSON | NULL | 元数据 |
 | `created_at` | DATETIME | NOT NULL DEFAULT CURRENT_TIMESTAMP | 创建时间 |
@@ -984,7 +992,7 @@ CREATE TABLE `model_prices` (
 
 **唯一索引**：`(provider, model, mode)`。
 
-> 说明：`capabilities`、`supported_parameters`、`limits`、`prices`、`metadata` 为 JSON 字段，由 Storage 层负责序列化与反序列化。`model_prices` 变更不会同步触发 InnerAPI 推送，由 BFE/Conf Agent 按自身周期拉取配置。
+> 说明：`capabilities`、`supported_parameters`、`limits`、`prices`、`tier_prices`、`metadata` 为 JSON 字段，由 Storage 层负责序列化与反序列化。`tier_prices` 中的 tier name 与 provider 的 `tiers` 不做强制引用校验；若引用了未定义的 tier name，可记录告警但不阻塞写入。`model_prices` 变更不会同步触发 InnerAPI 推送，由 BFE/Conf Agent 按自身周期拉取配置。
 
 ### 6.8 `rate_limit_policies`
 
@@ -1089,6 +1097,8 @@ CREATE TABLE `rate_limit_policies` (
 
 删除 Provider 前，业务代码须校验无 `clusters` 记录引用；`model_prices` 同名 provider 不再阻塞删除。
 
+> 补充：InnerAPI 导出 `AIConf.ModelTable` 时，根据 `clusters.llm_config.provider` 读取 `providers.time_zone` / `providers.tiers`，并与 `model_prices.prices` / `model_prices.tier_prices` 拼接后下发给 BFE。
+
 ### 7.3 集群与子集群 / 实例池
 
 | 主表 | 从表 | 字段 | 说明 |
@@ -1138,4 +1148,4 @@ CREATE TABLE `rate_limit_policies` (
 2. **`users` 表复用**：普通用户与 API Token 共用 `users` 表，通过 `type` 字段区分：0=普通用户，1=Token。
 3. **`route_cases` 表**：仅在 DDL 中定义，当前代码中无对应 DAO 与业务代码引用。
 4. **MySQL 与 SQLite**：字段类型等价；SQLite 通过 trigger 模拟 `updated_at` 自动更新。
-5. **JSON 字段**：`providers.model_endpoint`、`providers.models`、`providers.keys`、`providers.instance_pool`、`providers.model_protocols`、`instance_detail`、`lb_matrix`、`llm_config`、`allowed_models`、`subnet`、`tpm_configs`、`rpm_configs`、`rules`、`basic`、`params`、`route_action`、`host_names`、`paths`、`model_prices.capabilities`、`model_prices.supported_parameters`、`model_prices.limits`、`model_prices.prices`、`model_prices.metadata` 等字段均为 JSON 或文本序列化存储。
+5. **JSON 字段**：`providers.model_endpoint`、`providers.models`、`providers.keys`、`providers.instance_pool`、`providers.model_protocols`、`providers.tiers`、`instance_detail`、`lb_matrix`、`llm_config`、`allowed_models`、`subnet`、`tpm_configs`、`rpm_configs`、`rules`、`basic`、`params`、`route_action`、`host_names`、`paths`、`model_prices.capabilities`、`model_prices.supported_parameters`、`model_prices.limits`、`model_prices.prices`、`model_prices.tier_prices`、`model_prices.metadata` 等字段均为 JSON 或文本序列化存储。

--- a/design-docs/sys-design/模型层设计文档.md
+++ b/design-docs/sys-design/模型层设计文档.md
@@ -663,11 +663,26 @@ type ModelPriceEntry struct {
     Capabilities        []string
     SupportedParameters []string
     Limits              map[string]any
-    Prices              map[string]any
+    Prices              map[string]any            // 默认价格；未命中 tier 时作为 fallback
+    TierPrices          map[string]map[string]any // tier name -> 价格对象
 }
 
 type ModelTable struct {
-    Models []ModelPriceEntry
+    Currency string              // 固定为 "RMB"
+    TimeZone string              // 计算时段所使用的时区；默认 "Asia/Shanghai"
+    Tiers    []PriceTier         // 时段 tier 定义列表
+    Models   []ModelPriceEntry
+}
+
+type PriceTier struct {
+    Name       string      // 初期只支持 "peak"
+    TimeRanges []TimeRange // 命中任意一个即属于该 tier
+}
+
+type TimeRange struct {
+    Weekdays []int  // 0=周日，1=周一，...，6=周六；为空表示每天
+    Start    string // "HH:MM"
+    End      string // "HH:MM"；必须 > Start；跨午夜请拆成两段
 }
 
 type AIConf struct {
@@ -690,7 +705,11 @@ type AIConf struct {
 1. 根据 `cluster.LLMConfig.Provider` 查询 Provider，读取 `instance_pool` 生成 BFE 实例池/子集群/集群配置（结构与原 cluster 直接持有 `instance_pool` 时一致）。
 2. 根据 `cluster.LLMConfig.Keys` 中的 `name`，从 Provider `keys` 中查找对应 `key` 明文，按 `weight` 组装为 `AIConf.Keys`。
 3. 将 Provider 的 `model_protocols` 原样透传到 `AIConf.ModelProtocols`，供 BFE 判断请求协议风格是否被当前集群支持。若 Provider 未设置 `model_protocols`，`AIConf.ModelProtocols` 为空数组，BFE 兜底为仅支持 `openai`。
-4. 若 `Provider` 非空，调用 `model/imodel_price` 按 `provider` 查询 `model_prices` 记录，并填充到 `AIConf.ModelTable.Models`；若 `Provider` 为空或该 provider 无记录，`ModelTable.Models` 为空列表。
+4. 若 `Provider` 非空：
+   - 读取 Provider 的 `time_zone` 和 `tiers`，填充到 `AIConf.ModelTable.TimeZone` / `Tiers`；`time_zone` 为空时默认 `"Asia/Shanghai"`；`tiers` 为空时 `Tiers` 为空数组。
+   - 调用 `model/imodel_price` 按 `provider` 查询 `model_prices` 记录，将 `prices` 和 `tier_prices` 分别填充到 `AIConf.ModelTable.Models[].Prices` / `TierPrices`。
+   - `Currency` 固定填充为 `"RMB"`。
+   - 若 `Provider` 为空或该 provider 无记录，`ModelTable.Models` 为空列表。
 
 `model_prices` 变更不会同步触发 InnerAPI 推送，由 BFE/Conf Agent 按自身周期拉取配置。
 
@@ -709,6 +728,8 @@ type Provider struct {
     Keys            string   `json:"keys"`             // JSON：ProviderKey 数组
     InstancePool    string   `json:"instance_pool"`    // JSON：Instance 数组
     ModelProtocols  string   `json:"model_protocols"`  // JSON：协议枚举数组
+    TimeZone        string   `json:"time_zone"`        // 计算时段所使用的时区；默认 "Asia/Shanghai"
+    Tiers           string   `json:"tiers"`            // JSON：PricingTier 数组
     CreatedAt       time.Time `json:"created_at"`
     UpdatedAt       time.Time `json:"updated_at"`
 }
@@ -721,6 +742,8 @@ type ProviderParam struct {
     Keys           *string `json:"keys"`
     InstancePool   *string `json:"instance_pool"`
     ModelProtocols *string `json:"model_protocols"`
+    TimeZone       *string `json:"time_zone"`
+    Tiers          *string `json:"tiers"`
 }
 
 type ProviderFilter struct {
@@ -748,8 +771,9 @@ type ProviderManager struct {
 
 `ProviderManager` 提供与通用模型一致的 CRUD，并额外处理引用关系：
 
-- `CreateProvider`：校验 `name` 全局唯一、`instance_pool` 合法、`model_protocols` 合法；若未传 `model_endpoint` 则使用默认值。
-- `UpdateProvider`：允许更新 `instance_pool`、`keys`、`models` 等；若 `keys` 中的 `name` 被 cluster 引用，更新后所有引用该 `name` 的 cluster 在导出时会自动使用新 key 明文（由 `AIConf` 导出逻辑按 name join 实现）。
+- `CreateProvider`：校验 `name` 全局唯一、`instance_pool` 合法、`model_protocols` 合法；若未传 `model_endpoint` 则使用默认值；若携带 `tiers` 则按 PricingTier 结构校验（**初期 `name` 只支持 `peak`**）。
+- `UpdateProvider`：允许更新 `instance_pool`、`keys`、`models`、`time_zone`、`tiers` 等；若 `keys` 中的 `name` 被 cluster 引用，更新后所有引用该 `name` 的 cluster 在导出时会自动使用新 key 明文（由 `AIConf` 导出逻辑按 name join 实现）。
+- `UpdatePricingTiers`：接收 `provider_name`、`time_zone`、`tiers`（JSON 或 YAML 解析后），校验 `time_zone` 为合法 IANA 时区名、`tiers` 中每个 tier 的 `name` 非空且 **初期只支持 `peak`**、`time_ranges` 格式合法且不重叠，然后更新 provider 的 `time_zone` / `tiers` 字段。
 - `DeleteProvider`：删除前校验无 `/clusters` 引用，否则返回错误；`/model-prices` 中的同名 provider 不再作为阻塞条件。通过校验后删除 provider。
 - `DiscoverModels`：接收 `model_protocol`、`schema`、`addr`、`port`、`uri`、`apikey` 参数；构造请求 URL 并携带认证头调用模型列表接口；按 `model_protocol` 选择对应响应解析器（如 `openai` 用 `data[].id`，`anthropic` 用 `models[].model_id`），解析并返回模型名列表。
 
@@ -1000,7 +1024,8 @@ type ModelPrice struct {
     Capabilities        []string       `json:"capabilities"`          // 能力列表
     SupportedParameters []string       `json:"supported_parameters"`  // 支持的请求参数列表
     Limits              map[string]any `json:"limits"`                // 限制对象
-    Prices              map[string]any `json:"prices"`                // 价格对象
+    Prices              map[string]any `json:"prices"`                // 默认价格对象；未命中 tier 时作为 fallback
+    TierPrices          map[string]map[string]any `json:"tier_prices"` // tier name -> 价格对象
     PriceCurrency       string         `json:"price_currency"`        // 当前固定 RMB
     Metadata            map[string]any `json:"metadata"`              // 元数据
     CreatedAt           time.Time      `json:"created_at"`
@@ -1017,6 +1042,7 @@ type ModelPriceParam struct {
     SupportedParameters []string        `json:"supported_parameters"`
     Limits              map[string]any  `json:"limits"`
     Prices              map[string]any  `json:"prices"`
+    TierPrices          map[string]map[string]any `json:"tier_prices"`
     PriceCurrency       *string         `json:"price_currency"`
     Metadata            map[string]any  `json:"metadata"`
 }
@@ -1052,7 +1078,7 @@ type ModelPriceManager struct {
 
 `ModelPriceManager` 提供与通用模型一致的 CRUD：
 
-- `CreateModelPrice`：新增单条记录，校验必填字段与唯一键；`provider` 不强制引用已存在的 Provider；`price_currency` 由系统固定填充为 `RMB`。
+- `CreateModelPrice`：新增单条记录，校验必填字段与唯一键；`provider` 不强制引用已存在的 Provider；`price_currency` 由系统固定填充为 `RMB`；若携带 `tier_prices`，校验 tier name（**初期只支持 `peak`**）及内部价格键名。
 - `FetchModelPrice` / `FetchModelPriceList`：支持按 `id` 或 `(provider, model, mode)` 查询单条；列表查询支持按 `provider`、`mode` 分页过滤。
 - `UpdateModelPrice`：支持部分字段更新，未传字段保持原值；按 `id` 或 `(provider, model, mode)` 定位记录；`provider` 更新时不校验存在性。
 - `DeleteModelPrice`：按 `id` 或 `(provider, model, mode)` 删除。
@@ -1064,8 +1090,9 @@ type ModelPriceManager struct {
 - `provider` 仅作为价格归集标识，不强制引用 `/providers` 中已存在的 Provider；
 - `(provider, model, mode)` 不能重复；
 - `prices` 必填且至少包含一个价格字段，所有价格字段非负；
+- `tier_prices` 非必填；若传入，tier name **初期只支持 `peak`**，内部价格键名须为 `prices` 枚举，所有 tier 价格字段非负；
 - `mode` 必须取自预定义枚举；
-- `capabilities`、`supported_parameters`、`limits`、`prices`、`metadata` 的元素/键名必须取自对应枚举（非枚举值不可接受）。
+- `capabilities`、`supported_parameters`、`limits`、`prices`、`tier_prices.<tier>`、`metadata` 的元素/键名必须取自对应枚举（非枚举值不可接受）。
 
 #### 4.4.3 YAML 导入逻辑
 
@@ -1093,8 +1120,9 @@ type ImportResult struct {
 2. 校验每条记录的 `(provider, model, mode)` 唯一性；
 3. 校验必填字段：`provider`、`model`、`base_model`、`mode`、`prices`；
 4. 校验 `prices` 中至少包含一个价格字段且所有价格字段非负；
-5. `replace` 模式：清空 `model_prices` 表后批量写入；
-6. `merge` 模式：对已有 `(provider, model, mode)` 记录执行更新，新增记录执行插入。
+5. 若记录包含 `tier_prices`：校验 tier name（**初期只支持 `peak`**），内部价格键名须为 `prices` 枚举，所有 tier 价格字段非负；
+6. `replace` 模式：清空 `model_prices` 表后批量写入；
+7. `merge` 模式：对已有 `(provider, model, mode)` 记录执行更新，新增记录执行插入。
 
 > 说明：v0.4 仅支持人民币（RMB），不扩展美元、欧元等多币种。
 
@@ -1111,7 +1139,10 @@ if cluster.LLMConfig != nil && cluster.LLMConfig.Provider != nil && *cluster.LLM
     }
 
     modelTable := &cluster_conf.ModelTable{
-        Models: make([]cluster_conf.ModelPriceEntry, 0, len(modelPrices)),
+        Currency: "RMB",
+        TimeZone: providerRecord.TimeZone, // 为空时 BFE 默认 "Asia/Shanghai"
+        Tiers:    providerRecord.Tiers,    // []cluster_conf.PriceTier
+        Models:   make([]cluster_conf.ModelPriceEntry, 0, len(modelPrices)),
     }
     for _, mp := range modelPrices {
         modelTable.Models = append(modelTable.Models, cluster_conf.ModelPriceEntry{
@@ -1123,6 +1154,7 @@ if cluster.LLMConfig != nil && cluster.LLMConfig.Provider != nil && *cluster.LLM
             SupportedParameters: mp.SupportedParameters,
             Limits:              mp.Limits,
             Prices:              mp.Prices,
+            TierPrices:          mp.TierPrices,
         })
     }
 
@@ -1132,6 +1164,8 @@ if cluster.LLMConfig != nil && cluster.LLMConfig.Provider != nil && *cluster.LLM
 ```
 
 若 `llm_config.provider` 为空，`AIConf.ModelTable.Models` 为空列表。
+
+> 说明：`providerRecord.Tiers` 为空时，`ModelTable.Tiers` 为空数组，BFE 按固定价格处理。`TierPrices` 中引用了未在 `Tiers` 中定义的 tier name 时，BFE 不报错，对应价格仅永不命中。
 
 #### 4.4.5 查询所有 price provider 名称
 

--- a/endpoints/openapi_v1/model_price/update.go
+++ b/endpoints/openapi_v1/model_price/update.go
@@ -125,6 +125,9 @@ func mergeModelPrice(dst, src *imodel_price.ModelPrice) *imodel_price.ModelPrice
 	if len(src.Prices) > 0 {
 		merged.Prices = src.Prices
 	}
+	if len(src.TierPrices) > 0 {
+		merged.TierPrices = src.TierPrices
+	}
 	if strings.TrimSpace(src.PriceCurrency) != "" {
 		merged.PriceCurrency = src.PriceCurrency
 	}

--- a/endpoints/openapi_v1/provider/endpoints.go
+++ b/endpoints/openapi_v1/provider/endpoints.go
@@ -25,6 +25,7 @@ var Endpoints = []*xreq.Endpoint{
 	ListNamesEndpoint,
 	OneEndpoint,
 	UpdateEndpoint,
+	PricingTiersEndpoint,
 	DeleteEndpoint,
 	DiscoverEndpoint,
 }

--- a/endpoints/openapi_v1/provider/endpoints_test.go
+++ b/endpoints/openapi_v1/provider/endpoints_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestEndpoints(t *testing.T) {
-	require.Len(t, Endpoints, 7)
+	require.Len(t, Endpoints, 8)
 	for _, ep := range Endpoints {
 		require.NotNil(t, ep)
 		assert.NotEmpty(t, ep.Path)

--- a/endpoints/openapi_v1/provider/pricing_tiers.go
+++ b/endpoints/openapi_v1/provider/pricing_tiers.go
@@ -1,0 +1,86 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"gopkg.in/yaml.v3"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xreq"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iauth"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iprovider"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful/container"
+)
+
+// PricingTiersEndpoint updates the pricing tiers of a provider.
+var PricingTiersEndpoint = &xreq.Endpoint{
+	Path:       "/providers/{provider_name}/pricing-tiers",
+	Method:     http.MethodPut,
+	Handler:    xreq.Convert(PricingTiersAction),
+	Authorizer: iauth.FA(iauth.FeatureProvider, iauth.ActionUpdate),
+}
+
+// PricingTiersAction handles PUT /providers/{provider_name}/pricing-tiers.
+// It accepts both JSON (application/json) and YAML (text/yaml or multipart/form-data file) bodies.
+func PricingTiersAction(req *http.Request) (interface{}, error) {
+	name := mux.Vars(req)["provider_name"]
+	if name == "" {
+		return nil, xerror.WrapParamErrorWithMsg("provider_name is required")
+	}
+
+	param := &iprovider.PricingTiersParam{}
+	contentType := strings.ToLower(req.Header.Get("Content-Type"))
+
+	switch {
+	case strings.HasPrefix(contentType, "application/json"):
+		if err := xreq.BindJSON(req, param); err != nil {
+			return nil, err
+		}
+	case strings.HasPrefix(contentType, "text/yaml"), strings.HasPrefix(contentType, "application/x-yaml"):
+		data, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, xerror.WrapParamErrorWithMsg("failed to read body: %v", err)
+		}
+		if err := yaml.Unmarshal(data, param); err != nil {
+			return nil, xerror.WrapParamErrorWithMsg("failed to parse yaml: %v", err)
+		}
+	case strings.HasPrefix(contentType, "multipart/form-data"):
+		file, _, err := req.FormFile("file")
+		if err != nil {
+			return nil, xerror.WrapParamErrorWithMsg("file is required for multipart/form-data")
+		}
+		defer file.Close()
+		data, err := io.ReadAll(file)
+		if err != nil {
+			return nil, xerror.WrapParamErrorWithMsg("failed to read file: %v", err)
+		}
+		if err := yaml.Unmarshal(data, param); err != nil {
+			return nil, xerror.WrapParamErrorWithMsg("failed to parse yaml: %v", err)
+		}
+	default:
+		return nil, xerror.WrapParamErrorWithMsg("unsupported Content-Type: %s", req.Header.Get("Content-Type"))
+	}
+
+	if err := container.ProviderManager.UpdatePricingTiers(req.Context(), name, param); err != nil {
+		return nil, err
+	}
+
+	return container.ProviderManager.FetchProvider(req.Context(), &iprovider.ProviderFilter{Name: &name})
+}

--- a/model/icluster_conf/cluster.go
+++ b/model/icluster_conf/cluster.go
@@ -909,10 +909,16 @@ func normalizeBFEHashStrategy(sticky *ClusterStickySessions) int32 {
 	return sticky.HashStrategy
 }
 
+type ProviderPricingInfo struct {
+	TimeZone string
+	Tiers    []cluster_conf.PriceTier
+}
+
 func NewBfeClusterConf(version string, clusters []*Cluster,
 	providerModelTable map[string][]*imodel_price.ModelPrice,
 	providerKeyTable map[string][]iprovider.ProviderKey,
-	providerProtocolTable map[string][]string) *cluster_conf.BfeClusterConf {
+	providerProtocolTable map[string][]string,
+	providerPricingTable map[string]ProviderPricingInfo) *cluster_conf.BfeClusterConf {
 	clusterConfMap := cluster_conf.ClusterToConf{}
 
 	int322intp := func(i int32) *int {
@@ -1001,12 +1007,20 @@ func NewBfeClusterConf(version string, clusters []*Cluster,
 								SupportedParameters: e.SupportedParameters,
 								Limits:              e.Limits,
 								Prices:              e.Prices,
+								TierPrices:          e.TierPrices,
 								Metadata:            e.Metadata,
 							})
 						}
 					}
+					pricingInfo := providerPricingTable[provider]
+					timeZone := pricingInfo.TimeZone
+					if timeZone == "" {
+						timeZone = "Asia/Shanghai"
+					}
 					modelTable = &cluster_conf.ModelTable{
 						Currency: "RMB",
+						TimeZone: timeZone,
+						Tiers:    pricingInfo.Tiers,
 						Models:   models,
 					}
 				}

--- a/model/icluster_conf/cluster_test.go
+++ b/model/icluster_conf/cluster_test.go
@@ -19,8 +19,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/bfenetworks/bfe/bfe_config/bfe_cluster_conf/cluster_conf"
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ibasic"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/imodel_price"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iprovider"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iversion_control"
 	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
@@ -771,7 +773,7 @@ func TestAppendAdvancedRuleCluster(t *testing.T) {
 
 func TestNewBfeClusterConf(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterBase()}, nil, nil, nil)
+		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterBase()}, nil, nil, nil, nil)
 		require.NotNil(t, conf)
 		require.NotNil(t, conf.Config)
 		assert.Equal(t, "v1", *conf.Version)
@@ -787,26 +789,26 @@ func TestNewBfeClusterConf(t *testing.T) {
 		conf := NewBfeClusterConf("v1", []*Cluster{
 			newTestClusterBase(),
 			{ID: RouteAdvancedModeClusterID, Name: RouteAdvancedModeClusterName},
-		}, nil, nil, nil)
+		}, nil, nil, nil, nil)
 		require.Len(t, *conf.Config, 1)
 	})
 
 	t.Run("EPP addrs", func(t *testing.T) {
-		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterEPP()}, nil, nil, nil)
+		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterEPP()}, nil, nil, nil, nil)
 		cConf := (*conf.Config)["c1"]
 		require.NotNil(t, cConf.GslbBasic.EPPAddr)
 		assert.Equal(t, []string{"epp.example.com:8080"}, *cConf.GslbBasic.EPPAddr)
 	})
 
 	t.Run("https conf", func(t *testing.T) {
-		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterHTTPS()}, nil, nil, nil)
+		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterHTTPS()}, nil, nil, nil, nil)
 		cConf := (*conf.Config)["c1"]
 		require.NotNil(t, cConf.HTTPSConf)
 		assert.True(t, *cConf.HTTPSConf.RSInsecureSkipVerify)
 	})
 
 	t.Run("domain pool disable checks", func(t *testing.T) {
-		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterDomain()}, nil, nil, nil)
+		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterDomain()}, nil, nil, nil, nil)
 		cConf := (*conf.Config)["c1"]
 		assert.True(t, *cConf.ClusterBasic.DisableHealthCheck)
 		assert.True(t, *cConf.ClusterBasic.DisableHostHeader)
@@ -822,7 +824,7 @@ func TestNewBfeClusterConf(t *testing.T) {
 		providerProtocolTable := map[string][]string{
 			"openai": {"openai"},
 		}
-		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterLLM()}, nil, providerKeyTable, providerProtocolTable)
+		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterLLM()}, nil, providerKeyTable, providerProtocolTable, nil)
 		cConf := (*conf.Config)["c1"]
 		require.NotNil(t, cConf.AIConf)
 		require.Len(t, cConf.AIConf.Keys, 2)
@@ -844,6 +846,60 @@ func TestNewBfeClusterConf(t *testing.T) {
 		assert.Equal(t, []string{"openai"}, cConf.AIConf.ModelProtocols)
 	})
 
+	t.Run("LLM config with tiered pricing", func(t *testing.T) {
+		providerModelTable := map[string][]*imodel_price.ModelPrice{
+			"deepseek": {
+				{
+					Provider:  "deepseek",
+					Model:     "deepseek-v4-pro",
+					BaseModel: "deepseek-v4-pro",
+					Mode:      "chat",
+					Prices: map[string]float64{
+						"input_cost_per_token":        0.0000045,
+						"output_cost_per_token":       0.0000135,
+						"cache_read_input_token_cost": 0.00000015,
+					},
+					TierPrices: map[string]map[string]float64{
+						"peak": {
+							"input_cost_per_token":        0.000009,
+							"output_cost_per_token":       0.000027,
+							"cache_read_input_token_cost": 0.0000003,
+						},
+					},
+				},
+			},
+		}
+		providerPricingTable := map[string]ProviderPricingInfo{
+			"deepseek": {
+				TimeZone: "Asia/Shanghai",
+				Tiers: []cluster_conf.PriceTier{
+					{
+						Name: "peak",
+						TimeRanges: []cluster_conf.TimeRange{
+							{Weekdays: []int{1, 2, 3, 4, 5}, Start: "09:00", End: "12:00"},
+							{Weekdays: []int{1, 2, 3, 4, 5}, Start: "14:00", End: "18:00"},
+						},
+					},
+				},
+			},
+		}
+		c := newTestClusterLLM()
+		c.LLMConfig.Provider = lib.PString("deepseek")
+		conf := NewBfeClusterConf("v1", []*Cluster{c}, providerModelTable, nil, nil, providerPricingTable)
+		cConf := (*conf.Config)["c1"]
+		require.NotNil(t, cConf.AIConf)
+		require.NotNil(t, cConf.AIConf.ModelTable)
+		assert.Equal(t, "RMB", cConf.AIConf.ModelTable.Currency)
+		assert.Equal(t, "Asia/Shanghai", cConf.AIConf.ModelTable.TimeZone)
+		require.Len(t, cConf.AIConf.ModelTable.Tiers, 1)
+		assert.Equal(t, "peak", cConf.AIConf.ModelTable.Tiers[0].Name)
+		require.Len(t, cConf.AIConf.ModelTable.Models, 1)
+		model := cConf.AIConf.ModelTable.Models[0]
+		assert.Equal(t, "deepseek-v4-pro", model.Model)
+		require.NotNil(t, model.TierPrices)
+		assert.Equal(t, 0.000009, model.TierPrices["peak"]["input_cost_per_token"])
+	})
+
 	t.Run("disabled sticky sessions with empty hash_header falls back to CLIENT_IP_ONLY", func(t *testing.T) {
 		c := newTestClusterBase()
 		c.StickySessions = &ClusterStickySessions{
@@ -851,7 +907,7 @@ func TestNewBfeClusterConf(t *testing.T) {
 			HashStrategy:  ClusterHashStrategyClientIDOnlyI,
 			HashHeader:    "",
 		}
-		conf := NewBfeClusterConf("v1", []*Cluster{c}, nil, nil, nil)
+		conf := NewBfeClusterConf("v1", []*Cluster{c}, nil, nil, nil, nil)
 		cConf := (*conf.Config)["c1"]
 		require.NotNil(t, cConf.GslbBasic)
 		require.NotNil(t, cConf.GslbBasic.HashConf)

--- a/model/imodel_price/model_price.go
+++ b/model/imodel_price/model_price.go
@@ -24,19 +24,20 @@ import (
 
 // ModelPrice represents a single model pricing/capability record.
 type ModelPrice struct {
-	ID                  int64                  `json:"id" yaml:"id,omitempty"`
-	Provider            string                 `json:"provider" yaml:"provider"`
-	Model               string                 `json:"model" yaml:"model"`
-	BaseModel           string                 `json:"base_model" yaml:"base_model"`
-	Mode                string                 `json:"mode" yaml:"mode"`
-	Capabilities        []string               `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
-	SupportedParameters []string               `json:"supported_parameters,omitempty" yaml:"supported_parameters,omitempty"`
-	Limits              map[string]interface{} `json:"limits,omitempty" yaml:"limits,omitempty"`
-	Prices              map[string]float64     `json:"prices,omitempty" yaml:"prices,omitempty"`
-	PriceCurrency       string                 `json:"price_currency,omitempty" yaml:"price_currency,omitempty"`
-	Metadata            map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	CreateTime          *int64                 `json:"create_time,omitempty" yaml:"create_time,omitempty"`
-	UpdateTime          *int64                 `json:"update_time,omitempty" yaml:"update_time,omitempty"`
+	ID                  int64                       `json:"id" yaml:"id,omitempty"`
+	Provider            string                      `json:"provider" yaml:"provider"`
+	Model               string                      `json:"model" yaml:"model"`
+	BaseModel           string                      `json:"base_model" yaml:"base_model"`
+	Mode                string                      `json:"mode" yaml:"mode"`
+	Capabilities        []string                    `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	SupportedParameters []string                    `json:"supported_parameters,omitempty" yaml:"supported_parameters,omitempty"`
+	Limits              map[string]interface{}      `json:"limits,omitempty" yaml:"limits,omitempty"`
+	Prices              map[string]float64          `json:"prices,omitempty" yaml:"prices,omitempty"`
+	TierPrices          map[string]map[string]float64 `json:"tier_prices,omitempty" yaml:"tier_prices,omitempty"`
+	PriceCurrency       string                      `json:"price_currency,omitempty" yaml:"price_currency,omitempty"`
+	Metadata            map[string]interface{}      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	CreateTime          *int64                      `json:"create_time,omitempty" yaml:"create_time,omitempty"`
+	UpdateTime          *int64                      `json:"update_time,omitempty" yaml:"update_time,omitempty"`
 }
 
 // ModelPriceFilter is used to query model price records.

--- a/model/imodel_price/validate.go
+++ b/model/imodel_price/validate.go
@@ -193,6 +193,24 @@ func ValidateModelPrice(m *ModelPrice) error {
 		}
 	}
 
+	for tierName, tierPrices := range m.TierPrices {
+		// 初期只支持 peak tier
+		if tierName != "peak" {
+			return xerror.WrapParamErrorWithMsg("invalid tier name: %s, only 'peak' is allowed", tierName)
+		}
+		if len(tierPrices) == 0 {
+			return xerror.WrapParamErrorWithMsg("tier_prices.%s must contain at least one price", tierName)
+		}
+		for k, v := range tierPrices {
+			if !ValidPriceKeys[k] {
+				return xerror.WrapParamErrorWithMsg("invalid tier price key in tier %s: %s", tierName, k)
+			}
+			if v < 0 {
+				return xerror.WrapParamErrorWithMsg("tier price %s in tier %s must be >= 0", k, tierName)
+			}
+		}
+	}
+
 	if m.PriceCurrency != "" && m.PriceCurrency != "RMB" {
 		return xerror.WrapParamErrorWithMsg("price_currency must be RMB")
 	}

--- a/model/imodel_price/validate_test.go
+++ b/model/imodel_price/validate_test.go
@@ -64,6 +64,41 @@ func TestValidateModelPrice(t *testing.T) {
 		{"valid positive limit", func() *ModelPrice { p := validModelPrice(); p.Limits = map[string]interface{}{"context_window": 128000}; return p }(), false},
 		{"valid positive limit float64", func() *ModelPrice { p := validModelPrice(); p.Limits = map[string]interface{}{"context_window": float64(128000)}; return p }(), false},
 		{"invalid metadata key", func() *ModelPrice { p := validModelPrice(); p.Metadata = map[string]interface{}{"unknown": 1}; return p }(), true},
+		{"valid tier prices", func() *ModelPrice {
+			p := validModelPrice()
+			p.TierPrices = map[string]map[string]float64{
+				"peak": {"input_cost_per_token": 0.002},
+			}
+			return p
+		}(), false},
+		{"invalid tier name", func() *ModelPrice {
+			p := validModelPrice()
+			p.TierPrices = map[string]map[string]float64{
+				"off_peak": {"input_cost_per_token": 0.002},
+			}
+			return p
+		}(), true},
+		{"invalid tier price key", func() *ModelPrice {
+			p := validModelPrice()
+			p.TierPrices = map[string]map[string]float64{
+				"peak": {"invalid_key": 0.002},
+			}
+			return p
+		}(), true},
+		{"negative tier price", func() *ModelPrice {
+			p := validModelPrice()
+			p.TierPrices = map[string]map[string]float64{
+				"peak": {"input_cost_per_token": -0.002},
+			}
+			return p
+		}(), true},
+		{"empty tier prices", func() *ModelPrice {
+			p := validModelPrice()
+			p.TierPrices = map[string]map[string]float64{
+				"peak": {},
+			}
+			return p
+		}(), true},
 	}
 
 	for _, tc := range cases {

--- a/model/iprovider/provider.go
+++ b/model/iprovider/provider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -65,6 +66,19 @@ type ProviderInstance struct {
 	Disable bool   `json:"disable"`
 }
 
+// TimeRange defines a time window within a day for a pricing tier.
+type TimeRange struct {
+	Weekdays []int  `json:"weekdays,omitempty" yaml:"weekdays,omitempty"`
+	Start    string `json:"start" yaml:"start"`
+	End      string `json:"end" yaml:"end"`
+}
+
+// PricingTier defines a named pricing tier (e.g., "peak") with time ranges.
+type PricingTier struct {
+	Name       string      `json:"name" yaml:"name"`
+	TimeRanges []TimeRange `json:"time_ranges" yaml:"time_ranges"`
+}
+
 // Provider represents a model provider.
 type Provider struct {
 	ID             int64              `json:"id"`
@@ -75,6 +89,8 @@ type Provider struct {
 	Keys           []ProviderKey      `json:"keys"`
 	InstancePool   []ProviderInstance `json:"instance_pool"`
 	ModelProtocols []string           `json:"model_protocols"`
+	TimeZone       string             `json:"time_zone"`
+	Tiers          []PricingTier      `json:"tiers,omitempty"`
 	CreateTime     int64              `json:"create_time"`
 	UpdateTime     int64              `json:"update_time"`
 }
@@ -89,6 +105,14 @@ type ProviderParam struct {
 	Keys           []ProviderKey      `json:"keys,omitempty"`
 	InstancePool   []ProviderInstance `json:"instance_pool"`
 	ModelProtocols []string           `json:"model_protocols"`
+	TimeZone       *string            `json:"time_zone,omitempty"`
+	Tiers          []PricingTier      `json:"tiers,omitempty"`
+}
+
+// PricingTiersParam is used to update a provider's pricing tiers.
+type PricingTiersParam struct {
+	TimeZone string        `json:"time_zone" yaml:"time_zone"`
+	Tiers    []PricingTier `json:"tiers" yaml:"tiers"`
 }
 
 // ProviderFilter is used to query providers.
@@ -163,6 +187,38 @@ func (m *ProviderManager) UpdateProvider(ctx context.Context, name string, param
 		}
 
 		return m.storager.UpdateProvider(ctx, name, param)
+	})
+}
+
+// UpdatePricingTiers updates the time zone and pricing tiers of a provider.
+// It supports both JSON (parsed into PricingTiersParam) and YAML bodies at the endpoint layer.
+func (m *ProviderManager) UpdatePricingTiers(ctx context.Context, name string, param *PricingTiersParam) error {
+	if err := ValidatePricingTiersParam(param); err != nil {
+		return err
+	}
+
+	return m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+		existing, err := m.storager.FetchProvider(ctx, &ProviderFilter{Name: &name})
+		if err != nil {
+			return err
+		}
+		if existing == nil {
+			return xerror.WrapRecordNotExist("provider")
+		}
+
+		// Preserve all existing provider fields; only update time_zone and tiers.
+		updateParam := &ProviderParam{
+			Name:           &existing.Name,
+			Description:    &existing.Description,
+			ModelEndpoint:  existing.ModelEndpoint,
+			Models:         existing.Models,
+			Keys:           existing.Keys,
+			InstancePool:   existing.InstancePool,
+			ModelProtocols: existing.ModelProtocols,
+			TimeZone:       &param.TimeZone,
+			Tiers:          param.Tiers,
+		}
+		return m.storager.UpdateProvider(ctx, name, updateParam)
 	})
 }
 
@@ -351,7 +407,151 @@ func ValidateProviderParam(param *ProviderParam) error {
 		}
 	}
 
+	if err := validatePricingTiers(param.Tiers); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// ValidatePricingTiersParam validates a pricing tiers update request.
+func ValidatePricingTiersParam(param *PricingTiersParam) error {
+	if param == nil {
+		return xerror.WrapParamErrorWithMsg("pricing tiers param is required")
+	}
+	if err := validateTimeZone(param.TimeZone); err != nil {
+		return err
+	}
+	return validatePricingTiers(param.Tiers)
+}
+
+func validatePricingTiers(tiers []PricingTier) error {
+	seenTier := map[string]bool{}
+	for i, tier := range tiers {
+		if strings.TrimSpace(tier.Name) == "" {
+			return xerror.WrapParamErrorWithMsg("tiers[%d].name is required", i)
+		}
+		// 初期只支持 peak tier
+		if tier.Name != "peak" {
+			return xerror.WrapParamErrorWithMsg("tiers[%d].name: unsupported tier name %s, only 'peak' is allowed", i, tier.Name)
+		}
+		if seenTier[tier.Name] {
+			return xerror.WrapParamErrorWithMsg("duplicate tier name: %s", tier.Name)
+		}
+		seenTier[tier.Name] = true
+
+		if len(tier.TimeRanges) == 0 {
+			return xerror.WrapParamErrorWithMsg("tiers[%d].time_ranges is required", i)
+		}
+
+		seenRange := map[string]bool{}
+		for j, tr := range tier.TimeRanges {
+			key := fmt.Sprintf("%v|%s|%s", tr.Weekdays, tr.Start, tr.End)
+			if seenRange[key] {
+				return xerror.WrapParamErrorWithMsg("tiers[%d].time_ranges[%d]: duplicate time range", i, j)
+			}
+			seenRange[key] = true
+
+			if err := validateTimeRange(tr); err != nil {
+				return xerror.WrapParamErrorWithMsg("tiers[%d].time_ranges[%d]: %v", i, j, err)
+			}
+
+			for k := 0; k < j; k++ {
+				if timeRangesOverlap(tr, tier.TimeRanges[k]) {
+					return xerror.WrapParamErrorWithMsg("tiers[%d].time_ranges[%d] overlaps with time_ranges[%d]", i, j, k)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateTimeZone(tz string) error {
+	if strings.TrimSpace(tz) == "" {
+		return nil
+	}
+	if _, err := time.LoadLocation(tz); err != nil {
+		return xerror.WrapParamErrorWithMsg("invalid time_zone: %s", tz)
+	}
+	return nil
+}
+
+// timeRangesOverlap reports whether two time ranges overlap.
+// It assumes each range has been validated (end > start, weekdays in [0,6]).
+// Two ranges overlap iff they share at least one weekday and their time intervals overlap.
+func timeRangesOverlap(a, b TimeRange) bool {
+	// Check weekday intersection.
+	sharedWeekday := false
+	if len(a.Weekdays) == 0 || len(b.Weekdays) == 0 {
+		sharedWeekday = true
+	} else {
+		for _, wdA := range a.Weekdays {
+			for _, wdB := range b.Weekdays {
+				if wdA == wdB {
+					sharedWeekday = true
+					break
+				}
+			}
+			if sharedWeekday {
+				break
+			}
+		}
+	}
+	if !sharedWeekday {
+		return false
+	}
+
+	ast, _ := parseHHMM(a.Start)
+	aet, _ := parseHHMM(a.End)
+	bst, _ := parseHHMM(b.Start)
+	bet, _ := parseHHMM(b.End)
+
+	// Intervals are left-closed, right-open.
+	return ast < bet && bst < aet
+}
+
+func validateTimeRange(tr TimeRange) error {
+	seenWeekday := map[int]bool{}
+	for _, wd := range tr.Weekdays {
+		if wd < 0 || wd > 6 {
+			return fmt.Errorf("weekdays must be between 0 and 6")
+		}
+		if seenWeekday[wd] {
+			return fmt.Errorf("duplicate weekday: %d", wd)
+		}
+		seenWeekday[wd] = true
+	}
+
+	start, err := parseHHMM(tr.Start)
+	if err != nil {
+		return fmt.Errorf("invalid start time: %v", err)
+	}
+	end, err := parseHHMM(tr.End)
+	if err != nil {
+		return fmt.Errorf("invalid end time: %v", err)
+	}
+	if end <= start {
+		return fmt.Errorf("end must be greater than start")
+	}
+	return nil
+}
+
+func parseHHMM(s string) (int, error) {
+	if len(s) != 5 || s[2] != ':' {
+		return 0, fmt.Errorf("time must be in HH:MM format")
+	}
+	hour, err := strconv.Atoi(s[0:2])
+	if err != nil {
+		return 0, fmt.Errorf("invalid hour")
+	}
+	min, err := strconv.Atoi(s[3:5])
+	if err != nil {
+		return 0, fmt.Errorf("invalid minute")
+	}
+	if hour < 0 || hour > 23 || min < 0 || min > 59 {
+		return 0, fmt.Errorf("time out of range")
+	}
+	return hour*60 + min, nil
 }
 
 // ProviderName validates a provider name.
@@ -450,6 +650,10 @@ func FillDefaults(param *ProviderParam) {
 	}
 	if param.Keys == nil {
 		param.Keys = []ProviderKey{}
+	}
+	if param.TimeZone == nil {
+		defaultTZ := "Asia/Shanghai"
+		param.TimeZone = &defaultTZ
 	}
 }
 

--- a/model/iprovider/provider_test.go
+++ b/model/iprovider/provider_test.go
@@ -554,3 +554,75 @@ func TestParseModelDiscoveryResponse(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestValidatePricingTiersParam(t *testing.T) {
+	t.Run("valid peak tier", func(t *testing.T) {
+		param := &PricingTiersParam{
+			TimeZone: "Asia/Shanghai",
+			Tiers: []PricingTier{
+				{
+					Name: "peak",
+					TimeRanges: []TimeRange{
+						{Weekdays: []int{1, 2, 3, 4, 5}, Start: "09:00", End: "12:00"},
+						{Weekdays: []int{1, 2, 3, 4, 5}, Start: "14:00", End: "18:00"},
+					},
+				},
+			},
+		}
+		require.NoError(t, ValidatePricingTiersParam(param))
+	})
+
+	t.Run("empty tiers allowed", func(t *testing.T) {
+		param := &PricingTiersParam{
+			TimeZone: "Asia/Shanghai",
+			Tiers:    []PricingTier{},
+		}
+		require.NoError(t, ValidatePricingTiersParam(param))
+	})
+
+	t.Run("default time zone", func(t *testing.T) {
+		param := &PricingTiersParam{
+			TimeZone: "",
+			Tiers:    []PricingTier{},
+		}
+		require.NoError(t, ValidatePricingTiersParam(param))
+	})
+
+	t.Run("invalid time zone", func(t *testing.T) {
+		param := &PricingTiersParam{
+			TimeZone: "Invalid/TimeZone",
+			Tiers:    []PricingTier{},
+		}
+		require.Error(t, ValidatePricingTiersParam(param))
+	})
+
+	t.Run("unsupported tier name", func(t *testing.T) {
+		param := &PricingTiersParam{
+			TimeZone: "Asia/Shanghai",
+			Tiers: []PricingTier{
+				{Name: "off_peak", TimeRanges: []TimeRange{{Start: "00:00", End: "08:00"}}},
+			},
+		}
+		require.Error(t, ValidatePricingTiersParam(param))
+	})
+
+	t.Run("end must be greater than start", func(t *testing.T) {
+		param := &PricingTiersParam{
+			TimeZone: "Asia/Shanghai",
+			Tiers: []PricingTier{
+				{Name: "peak", TimeRanges: []TimeRange{{Start: "12:00", End: "09:00"}}},
+			},
+		}
+		require.Error(t, ValidatePricingTiersParam(param))
+	})
+
+	t.Run("invalid weekday", func(t *testing.T) {
+		param := &PricingTiersParam{
+			TimeZone: "Asia/Shanghai",
+			Tiers: []PricingTier{
+				{Name: "peak", TimeRanges: []TimeRange{{Weekdays: []int{7}, Start: "09:00", End: "12:00"}}},
+			},
+		}
+		require.Error(t, ValidatePricingTiersParam(param))
+	})
+}

--- a/model/iroute_conf/exporter.go
+++ b/model/iroute_conf/exporter.go
@@ -101,6 +101,7 @@ func (rm *RouteRuleManager) exportRouteRule(ctx context.Context) (*iversion_cont
 
 	providerKeyTable := map[string][]iprovider.ProviderKey{}
 	providerProtocolTable := map[string][]string{}
+	providerPricingTable := map[string]icluster_conf.ProviderPricingInfo{}
 	if rm.providerStorager != nil {
 		providers, _, err := rm.providerStorager.FetchProviderList(ctx, &iprovider.ProviderFilter{})
 		if err != nil {
@@ -110,6 +111,10 @@ func (rm *RouteRuleManager) exportRouteRule(ctx context.Context) (*iversion_cont
 			if p != nil {
 				providerKeyTable[p.Name] = p.Keys
 				providerProtocolTable[p.Name] = p.ModelProtocols
+				providerPricingTable[p.Name] = icluster_conf.ProviderPricingInfo{
+					TimeZone: p.TimeZone,
+					Tiers:    convertPricingTiers(p.Tiers),
+				}
 			}
 		}
 	}
@@ -151,7 +156,7 @@ func (rm *RouteRuleManager) exportRouteRule(ctx context.Context) (*iversion_cont
 		Version:     emptyVersion,
 		RouteTable:  newRouteTableFile(emptyVersion, productMapID2Name, routeRules),
 		HostTable:   newHostTableConf(emptyVersion, productMapID2Name, domains),
-		ClusterConf: icluster_conf.NewBfeClusterConf(emptyVersion, clusters, providerModelTable, providerKeyTable, providerProtocolTable),
+		ClusterConf: icluster_conf.NewBfeClusterConf(emptyVersion, clusters, providerModelTable, providerKeyTable, providerProtocolTable, providerPricingTable),
 	}
 
 	return &iversion_control.ExportData{
@@ -207,4 +212,23 @@ func newRouteTableFile(version string, productMapID2Name map[int64]string,
 		BasicRule:   &basicRule,
 		ProductRule: &advanceRule,
 	}
+}
+
+func convertPricingTiers(tiers []iprovider.PricingTier) []cluster_conf.PriceTier {
+	rst := make([]cluster_conf.PriceTier, 0, len(tiers))
+	for _, t := range tiers {
+		ranges := make([]cluster_conf.TimeRange, 0, len(t.TimeRanges))
+		for _, r := range t.TimeRanges {
+			ranges = append(ranges, cluster_conf.TimeRange{
+				Weekdays: r.Weekdays,
+				Start:    r.Start,
+				End:      r.End,
+			})
+		}
+		rst = append(rst, cluster_conf.PriceTier{
+			Name:       t.Name,
+			TimeRanges: ranges,
+		})
+	}
+	return rst
 }

--- a/storage/rdb/internal/dao/table_model_prices.go
+++ b/storage/rdb/internal/dao/table_model_prices.go
@@ -42,6 +42,7 @@ type TModelPrice struct {
 	SupportedParameters string    `db:"supported_parameters"`
 	Limits              string    `db:"limits"`
 	Prices              string    `db:"prices"`
+	TierPrices          string    `db:"tier_prices"`
 	PriceCurrency       string    `db:"price_currency"`
 	Metadata            string    `db:"metadata"`
 	CreatedAt           time.Time `db:"created_at"`
@@ -59,6 +60,7 @@ type TModelPriceParam struct {
 	SupportedParameters *string    `db:"supported_parameters"`
 	Limits              *string    `db:"limits"`
 	Prices              *string    `db:"prices"`
+	TierPrices          *string    `db:"tier_prices"`
 	PriceCurrency       *string    `db:"price_currency"`
 	Metadata            *string    `db:"metadata"`
 	CreatedAt           *time.Time `db:"created_at"`

--- a/storage/rdb/internal/dao/table_providers.go
+++ b/storage/rdb/internal/dao/table_providers.go
@@ -35,6 +35,8 @@ type TProvider struct {
 	Keys           string    `db:"keys"`
 	InstancePool   string    `db:"instance_pool"`
 	ModelProtocols string    `db:"model_protocols"`
+	TimeZone       string    `db:"time_zone"`
+	Tiers          string    `db:"tiers"`
 	CreatedAt      time.Time `db:"created_at"`
 	UpdatedAt      time.Time `db:"updated_at"`
 }
@@ -165,6 +167,8 @@ type TProviderParam struct {
 	Keys           *string    `db:"keys"`
 	InstancePool   *string    `db:"instance_pool"`
 	ModelProtocols *string    `db:"model_protocols"`
+	TimeZone       *string    `db:"time_zone"`
+	Tiers          *string    `db:"tiers"`
 	CreatedAt      *time.Time `db:"created_at"`
 	UpdatedAt      *time.Time `db:"updated_at"`
 

--- a/storage/rdb/model_price/model_price.go
+++ b/storage/rdb/model_price/model_price.go
@@ -191,6 +191,10 @@ func toDAOParam(param *imodel_price.ModelPrice) (*dao.TModelPriceParam, error) {
 	if err != nil {
 		return nil, err
 	}
+	tierPrices, err := marshalJSON(param.TierPrices)
+	if err != nil {
+		return nil, err
+	}
 	metadata, err := marshalJSON(param.Metadata)
 	if err != nil {
 		return nil, err
@@ -205,6 +209,7 @@ func toDAOParam(param *imodel_price.ModelPrice) (*dao.TModelPriceParam, error) {
 		SupportedParameters: supportedParameters,
 		Limits:              limits,
 		Prices:              prices,
+		TierPrices:          tierPrices,
 		PriceCurrency:       lib.PString(param.PriceCurrency),
 		Metadata:            metadata,
 	}, nil
@@ -240,6 +245,7 @@ func fromDAO(one *dao.TModelPrice) *imodel_price.ModelPrice {
 		SupportedParameters: unmarshalStringSlice(one.SupportedParameters),
 		Limits:              unmarshalMap(one.Limits),
 		Prices:              unmarshalPriceMap(one.Prices),
+		TierPrices:          unmarshalTierPrices(one.TierPrices),
 		PriceCurrency:       one.PriceCurrency,
 		Metadata:            unmarshalMap(one.Metadata),
 		CreateTime:          &createTime,
@@ -285,6 +291,17 @@ func unmarshalPriceMap(s string) map[string]float64 {
 		return nil
 	}
 	var rst map[string]float64
+	if err := json.Unmarshal([]byte(s), &rst); err != nil {
+		return nil
+	}
+	return rst
+}
+
+func unmarshalTierPrices(s string) map[string]map[string]float64 {
+	if s == "" || s == "null" {
+		return nil
+	}
+	var rst map[string]map[string]float64
 	if err := json.Unmarshal([]byte(s), &rst); err != nil {
 		return nil
 	}

--- a/storage/rdb/provider/provider.go
+++ b/storage/rdb/provider/provider.go
@@ -168,6 +168,10 @@ func toDAOParam(param *iprovider.ProviderParam) (*dao.TProviderParam, error) {
 	if err != nil {
 		return nil, err
 	}
+	tiers, err := marshalJSON(param.Tiers)
+	if err != nil {
+		return nil, err
+	}
 
 	return &dao.TProviderParam{
 		Name:           param.Name,
@@ -177,6 +181,8 @@ func toDAOParam(param *iprovider.ProviderParam) (*dao.TProviderParam, error) {
 		Keys:           keys,
 		InstancePool:   instancePool,
 		ModelProtocols: modelProtocols,
+		TimeZone:       param.TimeZone,
+		Tiers:          tiers,
 	}, nil
 }
 
@@ -208,6 +214,8 @@ func fromDAO(one *dao.TProvider) *iprovider.Provider {
 		Keys:           unmarshalKeys(one.Keys),
 		InstancePool:   unmarshalInstancePool(one.InstancePool),
 		ModelProtocols: unmarshalStringSlice(one.ModelProtocols),
+		TimeZone:       one.TimeZone,
+		Tiers:          unmarshalTiers(one.Tiers),
 		CreateTime:     createTime,
 		UpdateTime:     updateTime,
 	}
@@ -268,6 +276,17 @@ func unmarshalInstancePool(s string) []iprovider.ProviderInstance {
 		return nil
 	}
 	var rst []iprovider.ProviderInstance
+	if err := json.Unmarshal([]byte(s), &rst); err != nil {
+		return nil
+	}
+	return rst
+}
+
+func unmarshalTiers(s string) []iprovider.PricingTier {
+	if s == "" || s == "null" {
+		return nil
+	}
+	var rst []iprovider.PricingTier
 	if err := json.Unmarshal([]byte(s), &rst); err != nil {
 		return nil
 	}

--- a/test/integration/tests/innerapi/design.md
+++ b/test/integration/tests/innerapi/design.md
@@ -4,6 +4,8 @@
 
 InnerAPI 模块为 BFE/Conf Agent 提供只读配置导出接口，支持基于 `version` 的增量同步。所有接口均为 GET 请求，返回值包含 `WorkMode` 字段。v0.3.0 对应 OpenAPI 的模块精简不影响 InnerAPI 导出结构（底层表结构未变）。v0.3.0 起，路由规则导出（`/configs/tls_conf/server_data_conf`）中的 `ClusterConf` 会包含模型定价表（`AIConf.ModelTable`），用于 BFE 按 provider 匹配可用模型。
 
+v0.5.0 起，模型定价表支持分时段定价：OpenAPI 在 `/providers` 上维护 `time_zone`/`tiers` 时段模板，在 `/model-prices` 上维护 `tier_prices`；InnerAPI 导出时把 provider 的时段模板与 model-prices 的分时价格拼接到 `AIConf.ModelTable` 中，BFE 按请求时刻匹配 tier 并取对应价格。
+
 v0.0.7 起，Cluster 表导出（`/configs/gslb_data/cluster_table`）中的 `AIConf` 字段不再使用单 `Key`，而是输出 `Keys`（`[]{Name, Key, Weight}`）和 `KeyPolicy`（`{Strategy, MaxRetries, RetryBackoffInitial, RetryBackoffMax}`），以支持多 API-Key 路由。InnerAPI 应验证该导出结构与 OpenAPI 写入的多 Key 配置一致。
 
 ## 2. 接口列表
@@ -24,7 +26,7 @@ v0.0.7 起，Cluster 表导出（`/configs/gslb_data/cluster_table`）中的 `AI
 
 | 接口 | 测试用例数 |
 |------|-----------|
-| 导出 TLS/Server 配置 | 4 |
+| 导出 TLS/Server 配置 | 6 |
 | 导出 GSLB 配置 | 2 |
 | 导出集群表配置 | 2 |
 | 导出证书配置 | 1 |
@@ -33,7 +35,7 @@ v0.0.7 起，Cluster 表导出（`/configs/gslb_data/cluster_table`）中的 `AI
 | 导出请求体处理配置 | 1 |
 | 导出限流策略配置 | 1 |
 | 导出 AI 路由配置 | 2 |
-| **合计** | **16** |
+| **合计** | **18** |
 
 ## 4. 认证方式
 
@@ -45,7 +47,8 @@ InnerAPI 鉴权为 `McUserProbe`，测试环境需配置为可跳过或使用 Su
 innerapi/
 ├── design.md
 ├── tls_conf/
-│   └── tls_conf_test.go
+│   ├── tls_conf_test.go
+│   └── tiered_pricing_test.go
 ├── gslb/
 │   └── gslb_test.go
 ├── cluster_table/
@@ -105,6 +108,8 @@ innerapi/
 | IN-1-002 | 导出 ClusterConf 含多 Key AIConf | 返回数据 | 验证 ClusterConf.AIConf.Keys/KeyPolicy 与 OpenAPI 写入一致 |
 | IN-1-003 | 导出 ClusterConf 含模型定价表 | 返回数据 | 验证 ClusterConf.AIConf.ModelTable 与导入的 model prices 一致 |
 | IN-1-004 | 导出 ClusterConf 含 ModelProtocols（对应 IN-TLS-1-007） | 返回数据 | 验证 ClusterConf.AIConf.ModelProtocols 与 OpenAPI 写入一致 |
+| IN-TIER-1-001 | 导出 ClusterConf 含分时段定价 | 返回数据 | 验证 ModelTable 携带 TimeZone/Tiers 与 ModelPrice 的 TierPrices |
+| IN-TIER-1-002 | 未配置时段规则时导出固定价格 | 返回数据 | 验证 ModelTable.Tiers 为空，仍按默认 Prices 导出 |
 
 ### 6.4 测试场景详细设计
 
@@ -273,6 +278,83 @@ innerapi/
 |------|--------|---------|
 | Data.ClusterConf.Config.cluster_inner_model_protocols.AIConf.ModelProtocols | 长度为 1 | Len=1 |
 | Data.ClusterConf.Config.cluster_inner_model_protocols.AIConf.ModelProtocols[0] | "anthropic" | Equals |
+
+---
+
+### 6.5 IN-TIER-1-001：导出 ClusterConf 含分时段定价（返回数据）
+
+##### 设计思路
+
+验证 OpenAPI 设置 provider `time_zone`/`tiers`、导入 model-prices `tier_prices` 并创建 cluster 后，InnerAPI 导出的 `ClusterConf.AIConf.ModelTable` 能正确携带 `Currency`、`TimeZone`、`Tiers` 以及 `Models[*].TierPrices`。
+
+##### 前提数据准备
+
+1. 创建 Provider `tier_provider`，并通过 `PUT /providers/{provider_name}/pricing-tiers` 设置：
+   - `time_zone`: `Asia/Shanghai`
+   - `tiers`: `[{name:"peak", time_ranges:[{weekdays:[1,2,3,4,5], start:"09:00", end:"12:00"}, {weekdays:[1,2,3,4,5], start:"14:00", end:"18:00"}]}]`
+2. 通过 `POST /open-api/v1/model-prices/import` 导入含 `tier_prices.peak` 的 model-list.yaml。
+3. 创建 Cluster，其 `llm_config.provider=tier_provider`、`llm_config.models=["deepseek-chat"]`。
+
+##### 执行步骤
+
+1. GET `/inner-api/v1/configs/tls_conf/server_data_conf`。
+2. 在 `Data.ClusterConf.Config` 中找到目标 cluster。
+3. 校验 `AIConf.ModelTable`：
+   - `Currency` = `"RMB"`
+   - `TimeZone` = `"Asia/Shanghai"`
+   - `Tiers` 长度为 1，`Tiers[0].Name` = `"peak"`
+   - `Models` 长度为 1，`Models[0].Model` = `"deepseek-chat"`
+   - `Models[0].Prices.input_cost_per_token` = `0.000002`
+   - `Models[0].TierPrices.peak.input_cost_per_token` = `0.000004`
+
+##### 预期返回结果
+
+**ErrNum**：200  
+**ErrMsg**：success
+
+**Data 字段校验**：
+
+| 字段 | 预期值 | 校验方式 |
+|------|--------|---------|
+| Data.ClusterConf.Config.{cluster}.AIConf.ModelTable.Currency | "RMB" | Equals |
+| Data.ClusterConf.Config.{cluster}.AIConf.ModelTable.TimeZone | "Asia/Shanghai" | Equals |
+| Data.ClusterConf.Config.{cluster}.AIConf.ModelTable.Tiers | 长度为 1 | Len=1 |
+| Data.ClusterConf.Config.{cluster}.AIConf.ModelTable.Tiers[0].Name | "peak" | Equals |
+| Data.ClusterConf.Config.{cluster}.AIConf.ModelTable.Models[0].TierPrices.peak.input_cost_per_token | 0.000004 | Equals |
+
+---
+
+### 6.6 IN-TIER-1-002：未配置时段规则时导出固定价格（返回数据）
+
+##### 设计思路
+
+验证 Provider 未设置 `time_zone`/`tiers`、model-prices 未设置 `tier_prices` 时，导出的 `ModelTable` 仍只包含默认 `Prices`，`Tiers` 与 `TierPrices` 为空，保证向后兼容。
+
+##### 前提数据准备
+
+1. 创建 Provider，不设置 `time_zone`/`tiers`。
+2. 导入只含 `prices` 的 model-list.yaml。
+3. 创建引用该 Provider 的 Cluster。
+
+##### 执行步骤
+
+1. GET `/inner-api/v1/configs/tls_conf/server_data_conf`。
+2. 找到目标 cluster 的 `AIConf.ModelTable`。
+3. 校验 `Currency` = `"RMB"`，`Tiers` 为空，`Models[0].Prices` 存在，`Models[0].TierPrices` 为空。
+
+##### 预期返回结果
+
+**ErrNum**：200  
+**ErrMsg**：success
+
+**Data 字段校验**：
+
+| 字段 | 预期值 | 校验方式 |
+|------|--------|---------|
+| Data.ClusterConf.Config.{cluster}.AIConf.ModelTable.Currency | "RMB" | Equals |
+| Data.ClusterConf.Config.{cluster}.AIConf.ModelTable.Tiers | 空数组 | Len=0 / Empty |
+| Data.ClusterConf.Config.{cluster}.AIConf.ModelTable.Models[0].Prices.input_cost_per_token | 与导入一致 | Equals |
+| Data.ClusterConf.Config.{cluster}.AIConf.ModelTable.Models[0].TierPrices | 空对象 | Empty |
 
 ---
 
@@ -1019,7 +1101,7 @@ version=XXX
 
 ## 15. 依赖与数据准备
 
-1. 需要预先通过 OpenAPI 创建 API-Key、Entity、Cluster、证书、Global Route 等数据，才能验证导出内容非空；验证模型定价表时需先导入 model prices 并创建对应 provider 的 Cluster。
+1. 需要预先通过 OpenAPI 创建 API-Key、Entity、Cluster、证书、Global Route 等数据，才能验证导出内容非空；验证模型定价表时需先导入 model prices 并创建对应 provider 的 Cluster；验证分时段定价时需先设置 provider 的 `time_zone`/`tiers` 并导入含 `tier_prices` 的 model prices。
 2. `/configs/gslb_data/gslb` 依赖正确的 `bfe_cluster` 参数，通常为 `BFE-AI_product.szyf`。
 3. InnerAPI 鉴权为 `McUserProbe`，测试环境需配置为可跳过或使用 Support Token。
 

--- a/test/integration/tests/innerapi/tls_conf/tiered_pricing_test.go
+++ b/test/integration/tests/innerapi/tls_conf/tiered_pricing_test.go
@@ -1,0 +1,237 @@
+package innerapi_test
+
+import (
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInnerAPI_TlsConf_TieredPricing(t *testing.T) {
+	t.Run("IN-TIER-1-001 导出 ClusterConf 含分时段定价", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		providerResp, err := testutil.GetClient().Post("/open-api/v1/providers", map[string]interface{}{
+			"name": providerName,
+			"instance_pool": []interface{}{
+				map[string]interface{}{
+					"name":   "backend-1",
+					"addr":   "10.0.0.1",
+					"weight": 100,
+					"port":   8080,
+				},
+			},
+			"model_protocols": []string{"openai"},
+			"models":          []string{"deepseek-chat"},
+		})
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		if providerResp.ErrNum != 200 {
+			t.Fatalf("create provider failed: ErrNum=%d, ErrMsg=%s", providerResp.ErrNum, providerResp.ErrMsg)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		_, err = testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+			"time_zone": "Asia/Shanghai",
+			"tiers": []interface{}{
+				map[string]interface{}{
+					"name": "peak",
+					"time_ranges": []interface{}{
+						map[string]interface{}{
+							"weekdays": []int{1, 2, 3, 4, 5},
+							"start":    "09:00",
+							"end":      "12:00",
+						},
+						map[string]interface{}{
+							"weekdays": []int{1, 2, 3, 4, 5},
+							"start":    "14:00",
+							"end":      "18:00",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("setup pricing tiers failed: %v", err)
+		}
+
+		yamlContent := []byte(`version: v1.0
+default_currency: RMB
+models:
+  - provider: ` + providerName + `
+    model: deepseek-chat
+    base_model: deepseek-chat
+    mode: chat
+    prices:
+      input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000008
+      cache_read_input_token_cost: 0.0000005
+    tier_prices:
+      peak:
+        input_cost_per_token: 0.000004
+        output_cost_per_token: 0.000016
+        cache_read_input_token_cost: 0.000001
+`)
+		if err := testutil.ImportModelPrices(yamlContent, "replace"); err != nil {
+			t.Fatalf("import model prices failed: %v", err)
+		}
+		defer testutil.DeleteModelPriceByQuery(providerName, "deepseek-chat", "chat")
+
+		clusterName := testutil.UniqueClusterName()
+		createResp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name": clusterName,
+			"llm_config": map[string]interface{}{
+				"models":   []string{"deepseek-chat"},
+				"provider": providerName,
+			},
+		})
+		if err != nil {
+			t.Fatalf("setup cluster failed: %v", err)
+		}
+		if createResp.ErrNum != 200 {
+			t.Fatalf("create cluster failed: ErrNum=%d, ErrMsg=%s", createResp.ErrNum, createResp.ErrMsg)
+		}
+		defer testutil.DeleteCluster(clusterName)
+
+		resp, err := testutil.GetClient().Get("/inner-api/v1/configs/tls_conf/server_data_conf")
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		aiconf := extractAIConf(t, resp, clusterName)
+		modelTable, ok := aiconf["ModelTable"].(map[string]interface{})
+		if !assert.True(t, ok, "AIConf.ModelTable should be an object") {
+			return
+		}
+		assert.Equal(t, "RMB", modelTable["Currency"])
+		assert.Equal(t, "Asia/Shanghai", modelTable["TimeZone"])
+
+		tiers, ok := modelTable["Tiers"].([]interface{})
+		if !assert.True(t, ok, "ModelTable.Tiers should be an array") {
+			return
+		}
+		assert.Len(t, tiers, 1)
+		tier0, _ := tiers[0].(map[string]interface{})
+		assert.Equal(t, "peak", tier0["Name"])
+
+		models, ok := modelTable["Models"].([]interface{})
+		if !assert.True(t, ok, "ModelTable.Models should be an array") {
+			return
+		}
+		assert.Len(t, models, 1)
+		model0, _ := models[0].(map[string]interface{})
+		assert.Equal(t, "deepseek-chat", model0["Model"])
+
+		prices, ok := model0["Prices"].(map[string]interface{})
+		if !assert.True(t, ok, "ModelPrice.Prices should be an object") {
+			return
+		}
+		assert.Equal(t, 0.000002, prices["input_cost_per_token"])
+
+		tierPrices, ok := model0["TierPrices"].(map[string]interface{})
+		if !assert.True(t, ok, "ModelPrice.TierPrices should be an object") {
+			return
+		}
+		peak, ok := tierPrices["peak"].(map[string]interface{})
+		if !assert.True(t, ok, "TierPrices.peak should be an object") {
+			return
+		}
+		assert.Equal(t, 0.000004, peak["input_cost_per_token"])
+		assert.Equal(t, 0.000016, peak["output_cost_per_token"])
+		assert.Equal(t, 0.000001, peak["cache_read_input_token_cost"])
+	})
+
+	t.Run("IN-TIER-1-002 未配置时段规则时导出固定价格", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		providerResp, err := testutil.GetClient().Post("/open-api/v1/providers", map[string]interface{}{
+			"name": providerName,
+			"instance_pool": []interface{}{
+				map[string]interface{}{
+					"name":   "backend-1",
+					"addr":   "10.0.0.1",
+					"weight": 100,
+					"port":   8080,
+				},
+			},
+			"model_protocols": []string{"openai"},
+			"models":          []string{"deepseek-chat"},
+		})
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		if providerResp.ErrNum != 200 {
+			t.Fatalf("create provider failed: ErrNum=%d, ErrMsg=%s", providerResp.ErrNum, providerResp.ErrMsg)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		yamlContent := []byte(`version: v1.0
+default_currency: RMB
+models:
+  - provider: ` + providerName + `
+    model: deepseek-chat
+    base_model: deepseek-chat
+    mode: chat
+    prices:
+      input_cost_per_token: 0.0001
+`)
+		if err := testutil.ImportModelPrices(yamlContent, "replace"); err != nil {
+			t.Fatalf("import model prices failed: %v", err)
+		}
+		defer testutil.DeleteModelPriceByQuery(providerName, "deepseek-chat", "chat")
+
+		clusterName := testutil.UniqueClusterName()
+		createResp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name": clusterName,
+			"llm_config": map[string]interface{}{
+				"models":   []string{"deepseek-chat"},
+				"provider": providerName,
+			},
+		})
+		if err != nil {
+			t.Fatalf("setup cluster failed: %v", err)
+		}
+		if createResp.ErrNum != 200 {
+			t.Fatalf("create cluster failed: ErrNum=%d, ErrMsg=%s", createResp.ErrNum, createResp.ErrMsg)
+		}
+		defer testutil.DeleteCluster(clusterName)
+
+		resp, err := testutil.GetClient().Get("/inner-api/v1/configs/tls_conf/server_data_conf")
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		aiconf := extractAIConf(t, resp, clusterName)
+		modelTable, ok := aiconf["ModelTable"].(map[string]interface{})
+		if !assert.True(t, ok, "AIConf.ModelTable should be an object") {
+			return
+		}
+		assert.Equal(t, "RMB", modelTable["Currency"])
+
+		// Tiers 为空或不存在
+		tiers, ok := modelTable["Tiers"].([]interface{})
+		if ok {
+			assert.Empty(t, tiers)
+		}
+
+		models, ok := modelTable["Models"].([]interface{})
+		if !assert.True(t, ok, "ModelTable.Models should be an array") {
+			return
+		}
+		assert.Len(t, models, 1)
+		model0, _ := models[0].(map[string]interface{})
+		prices, ok := model0["Prices"].(map[string]interface{})
+		if !assert.True(t, ok, "ModelPrice.Prices should be an object") {
+			return
+		}
+		assert.Equal(t, 0.0001, prices["input_cost_per_token"])
+
+		// TierPrices 为空或不存在
+		tierPrices, ok := model0["TierPrices"].(map[string]interface{})
+		if ok {
+			assert.Empty(t, tierPrices)
+		}
+	})
+}
+

--- a/test/integration/tests/model_price/design.md
+++ b/test/integration/tests/model_price/design.md
@@ -7,8 +7,9 @@ Model Price 模块负责模型定价数据的管理，支持：
 - 通过 `model-list.yaml` 整表导入（`replace` / `merge` 两种模式）
 - 单条记录的增删改查
 - 按 `id` 或按 `(provider, model, mode)` 组合键查询/更新/删除
+- 分时段定价：在 `tier_prices` 中为特定 tier（如 `peak`）设置差异化价格
 
-本次新增该模块的集成测试，覆盖 OpenAPI `/model-prices` 下的全部接口。
+本次新增该模块的集成测试，覆盖 OpenAPI `/model-prices` 下的全部接口，以及 `tier_prices` 字段在创建、更新、导入场景下的正例与异常校验。
 
 ## 2. 接口列表
 
@@ -39,7 +40,8 @@ Model Price 模块负责模型定价数据的管理，支持：
 | 按 ID 删除单条 | 2 |
 | 按组合键删除单条 | 2 |
 | 查询 Provider 名称列表 | 2 |
-| **合计** | **38** |
+| tier_prices 字段场景 | 6 |
+| **合计** | **44** |
 
 ## 4. 认证方式
 
@@ -62,8 +64,10 @@ model_price/
 │   └── update_test.go
 ├── delete/
 │   └── delete_test.go
-└── get_providers/
-    └── get_providers_test.go
+├── get_providers/
+│   └── get_providers_test.go
+└── tier_prices/
+    └── tier_prices_test.go
 ```
 
 ## 6. 测试数据约定
@@ -87,6 +91,12 @@ model_price/
         "input_cost_per_token": 0.000002,
         "output_cost_per_token": 0.000008
     },
+    "tier_prices": {
+        "peak": {
+            "input_cost_per_token": 0.000004,
+            "output_cost_per_token": 0.000016
+        }
+    },
     "metadata": {
         "source": "https://platform.deepseek.com/pricing",
         "notes": "DeepSeek V3"
@@ -98,13 +108,25 @@ model_price/
 
 `(provider, model, mode)` 三元组必须唯一。
 
-### 6.3 测试用例编号规则
+### 6.3 分时段价格约束
+
+- `tier_prices` 为可选字段；键名（tier name）初期仅支持 `peak`。
+- 每个 tier 对应的价格对象键名须为 `prices` 的合法枚举键。
+- 价格值必须为非负数。
+
+### 6.4 测试用例编号规则
 
 ```
 MP-{接口编号}-{场景编号}
 ```
 
 例如：`MP-2-001` 表示 MP-2（新增单条记录）的第 1 个场景。
+
+分时段定价专项测试使用独立编号：
+
+```
+MTP-1-{场景编号}
+```
 
 ---
 
@@ -319,6 +341,7 @@ models:
 | supported_parameters | []string | N | 支持的请求参数 | 元素为枚举值 |
 | limits | object | N | 限制对象 | 键名为枚举值；值为非负整数 |
 | prices | object | Y | 价格对象 | 至少一个键；值为非负数；键名为枚举值 |
+| tier_prices | object | N | 分时段价格 | 键名为 tier 名称（初期仅 `peak`）；值为价格对象，键名须在 `prices` 枚举内 |
 | metadata | object | N | 元数据 | 键名为枚举值 |
 
 #### 返回数据字段
@@ -935,9 +958,73 @@ models:
 
 ---
 
-## 17. 附录
+## 17. 分时段价格字段测试（MTP-1）
 
-### 16.1 通用断言说明
+### 17.1 测试目标
+
+验证 `tier_prices` 在创建、查询、更新、`model-list.yaml` 导入等场景下能够正确写入、读取和校验。
+
+### 17.2 测试场景总览
+
+| 编号 | 场景 | 测试类型 | 简要说明 |
+|------|------|---------|---------|
+| MTP-1-001 | 创建含 tier_prices 的记录 | 正常参数 | 创建时携带 `tier_prices.peak`，查询返回一致 |
+| MTP-1-002 | tier_prices 含非法 tier name | 异常参数 | `tier_prices` 中出现非 `peak` 键名，返回 422 |
+| MTP-1-003 | tier_prices 含非法价格键 | 异常参数 | `tier_prices.peak` 中出现非 `prices` 枚举键，返回 422 |
+| MTP-1-004 | tier_prices 含负数价格 | 合法性条件 | `tier_prices.peak.input_cost_per_token=-0.001`，返回 422 |
+| MTP-1-005 | 更新 tier_prices | 正常参数 | PUT `/model-prices/{id}` 可单独更新 `tier_prices` |
+| MTP-1-006 | model-list.yaml 导入含 tier_prices | 正常参数 | 导入的 YAML 携带 `tier_prices`，列表查询返回一致 |
+
+### 17.3 请求参数示例
+
+#### 创建含 tier_prices 的记录
+
+```json
+{
+    "provider": "deepseek",
+    "model": "deepseek-v3",
+    "base_model": "deepseek-v3",
+    "mode": "chat",
+    "prices": {
+        "input_cost_per_token": 0.0000045,
+        "output_cost_per_token": 0.0000135
+    },
+    "tier_prices": {
+        "peak": {
+            "input_cost_per_token": 0.000009,
+            "output_cost_per_token": 0.000027
+        }
+    }
+}
+```
+
+#### model-list.yaml 导入示例
+
+```yaml
+version: v1.0
+default_currency: RMB
+models:
+  - provider: deepseek-tier-test
+    model: deepseek-v3
+    base_model: deepseek-v3
+    mode: chat
+    prices:
+      input_cost_per_token: 0.000002
+    tier_prices:
+      peak:
+        input_cost_per_token: 0.000004
+```
+
+### 17.4 预期返回结果
+
+- **MTP-1-001 / MTP-1-005 / MTP-1-006**：ErrNum=200，`tier_prices.peak` 与输入一致。
+- **MTP-1-002 / MTP-1-003 / MTP-1-004**：ErrNum=422，ErrMsg 包含对应字段校验错误。
+
+---
+
+## 18. 附录
+
+### 18.1 通用断言说明
 
 - `Equals`：字段值与预期值相等
 - `NotEmpty`：字段值非空
@@ -945,7 +1032,7 @@ models:
 - `Len=n`：数组/字符串长度等于 n
 - `IsArray` / `IsObject`：类型校验
 
-### 16.2 返回码约定
+### 18.2 返回码约定
 
 | ErrNum | 含义 |
 |--------|------|

--- a/test/integration/tests/model_price/tier_prices/tier_prices_test.go
+++ b/test/integration/tests/model_price/tier_prices/tier_prices_test.go
@@ -1,0 +1,246 @@
+package tier_prices_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+var sm *testutil.ServerManager
+
+func TestMain(m *testing.M) {
+	var err error
+	sm, err = testutil.StartServer()
+	if err != nil {
+		panic("failed to start server: " + err.Error())
+	}
+	code := m.Run()
+	sm.Shutdown()
+	os.Exit(code)
+}
+
+func TestModelPrice_TierPrices(t *testing.T) {
+	t.Run("MTP-1-001 创建含 tier_prices 的记录", func(t *testing.T) {
+		provider := testutil.UniqueName("provider")
+		model := testutil.UniqueName("model")
+
+		id, err := testutil.CreateModelPrice(map[string]interface{}{
+			"provider":   provider,
+			"model":      model,
+			"base_model": model,
+			"mode":       "chat",
+			"prices": map[string]interface{}{
+				"input_cost_per_token":  0.0000045,
+				"output_cost_per_token": 0.0000135,
+			},
+			"tier_prices": map[string]interface{}{
+				"peak": map[string]interface{}{
+					"input_cost_per_token":  0.000009,
+					"output_cost_per_token": 0.000027,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("create model price failed: %v", err)
+		}
+		defer testutil.DeleteModelPrice(id)
+
+		resp, err := testutil.GetClient().Get("/open-api/v1/model-prices/" + int64ToStr(id))
+		if err != nil {
+			t.Fatalf("get model price failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		var data map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		tierPrices, ok := data["tier_prices"].(map[string]interface{})
+		if !assert.True(t, ok, "tier_prices should be an object") {
+			return
+		}
+		peak, ok := tierPrices["peak"].(map[string]interface{})
+		if !assert.True(t, ok, "tier_prices.peak should be an object") {
+			return
+		}
+		assert.Equal(t, 0.000009, peak["input_cost_per_token"])
+		assert.Equal(t, 0.000027, peak["output_cost_per_token"])
+	})
+
+	t.Run("MTP-1-002 tier_prices 含非法 tier name", func(t *testing.T) {
+		provider := testutil.UniqueName("provider")
+		model := testutil.UniqueName("model")
+
+		resp, err := testutil.GetClient().Post("/open-api/v1/model-prices", map[string]interface{}{
+			"provider":   provider,
+			"model":      model,
+			"base_model": model,
+			"mode":       "chat",
+			"prices": map[string]interface{}{
+				"input_cost_per_token": 0.001,
+			},
+			"tier_prices": map[string]interface{}{
+				"off_peak": map[string]interface{}{
+					"input_cost_per_token": 0.002,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("MTP-1-003 tier_prices 含非法价格键", func(t *testing.T) {
+		provider := testutil.UniqueName("provider")
+		model := testutil.UniqueName("model")
+
+		resp, err := testutil.GetClient().Post("/open-api/v1/model-prices", map[string]interface{}{
+			"provider":   provider,
+			"model":      model,
+			"base_model": model,
+			"mode":       "chat",
+			"prices": map[string]interface{}{
+				"input_cost_per_token": 0.001,
+			},
+			"tier_prices": map[string]interface{}{
+				"peak": map[string]interface{}{
+					"invalid_price_key": 0.002,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("MTP-1-004 tier_prices 含负数价格", func(t *testing.T) {
+		provider := testutil.UniqueName("provider")
+		model := testutil.UniqueName("model")
+
+		resp, err := testutil.GetClient().Post("/open-api/v1/model-prices", map[string]interface{}{
+			"provider":   provider,
+			"model":      model,
+			"base_model": model,
+			"mode":       "chat",
+			"prices": map[string]interface{}{
+				"input_cost_per_token": 0.001,
+			},
+			"tier_prices": map[string]interface{}{
+				"peak": map[string]interface{}{
+					"input_cost_per_token": -0.001,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("MTP-1-005 更新 tier_prices", func(t *testing.T) {
+		provider := testutil.UniqueName("provider")
+		model := testutil.UniqueName("model")
+
+		id, err := testutil.CreateModelPrice(map[string]interface{}{
+			"provider":   provider,
+			"model":      model,
+			"base_model": model,
+			"mode":       "chat",
+			"prices": map[string]interface{}{
+				"input_cost_per_token": 0.001,
+			},
+		})
+		if err != nil {
+			t.Fatalf("create model price failed: %v", err)
+		}
+		defer testutil.DeleteModelPrice(id)
+
+		resp, err := testutil.GetClient().Put("/open-api/v1/model-prices/"+int64ToStr(id), map[string]interface{}{
+			"tier_prices": map[string]interface{}{
+				"peak": map[string]interface{}{
+					"input_cost_per_token": 0.002,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("update model price failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		var data map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		tierPrices, ok := data["tier_prices"].(map[string]interface{})
+		if !assert.True(t, ok, "tier_prices should be an object") {
+			return
+		}
+		peak, ok := tierPrices["peak"].(map[string]interface{})
+		if !assert.True(t, ok, "tier_prices.peak should be an object") {
+			return
+		}
+		assert.Equal(t, 0.002, peak["input_cost_per_token"])
+	})
+
+	t.Run("MTP-1-006 model-list.yaml 导入含 tier_prices", func(t *testing.T) {
+		yamlContent := []byte(`version: v1.0
+default_currency: RMB
+models:
+  - provider: deepseek-tier-test
+    model: deepseek-v3
+    base_model: deepseek-v3
+    mode: chat
+    prices:
+      input_cost_per_token: 0.000002
+    tier_prices:
+      peak:
+        input_cost_per_token: 0.000004
+`)
+		result, _, err := testutil.ImportModelPricesWithResult(yamlContent, "replace")
+		if err != nil {
+			t.Fatalf("import model prices failed: %v", err)
+		}
+		assert.Equal(t, 1, result.ImportedCount)
+		defer testutil.DeleteModelPriceByQuery("deepseek-tier-test", "deepseek-v3", "chat")
+
+		resp, err := testutil.GetClient().Get("/open-api/v1/model-prices")
+		if err != nil {
+			t.Fatalf("list model prices failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		list, err := testutil.GetDataListField(resp, "list")
+		if err != nil {
+			t.Fatalf("get list field: %v", err)
+		}
+		found := false
+		for _, item := range list {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if m["provider"] != "deepseek-tier-test" || m["model"] != "deepseek-v3" {
+				continue
+			}
+			found = true
+			tierPrices, ok := m["tier_prices"].(map[string]interface{})
+			if assert.True(t, ok, "tier_prices should be an object") {
+				peak, ok := tierPrices["peak"].(map[string]interface{})
+				if assert.True(t, ok, "tier_prices.peak should be an object") {
+					assert.Equal(t, 0.000004, peak["input_cost_per_token"])
+				}
+			}
+		}
+		assert.True(t, found, "imported model price should be listed")
+	})
+}
+
+func int64ToStr(v int64) string {
+	return fmt.Sprintf("%d", v)
+}

--- a/test/integration/tests/provider/design.md
+++ b/test/integration/tests/provider/design.md
@@ -20,7 +20,8 @@ Provider 与 Cluster 概念分离后：
 | PV-4 | 更新 Provider | PATCH | `/open-api/v1/providers/{provider_name}` | 全量替换 `keys`、`models` 等数组字段 |
 | PV-5 | 删除 Provider | DELETE | `/open-api/v1/providers/{provider_name}` | 删除前检查 cluster/model-price 引用 |
 | PV-6 | 触发模型发现 | POST | `/open-api/v1/providers/tools/discover-models` | 无状态工具接口，不绑定 Provider |
-| PV-7 | 获取所有 Provider 名称 | GET | `/open-api/v1/providers/actions/get-provider-names` | 返回全量 provider 名称列表 |
+| PV-7 | 获取所有 Provider 名称 | GET | `/providers/actions/get-provider-names` | 返回全量 provider 名称列表 |
+| PV-8 | 设置高峰/闲时模板 | PUT | `/providers/{provider_name}/pricing-tiers` | 支持 JSON / YAML / multipart 上传 |
 
 ## 3. 测试用例统计
 
@@ -33,7 +34,8 @@ Provider 与 Cluster 概念分离后：
 | 删除 Provider | 3 |
 | 触发模型发现 | 6 |
 | 获取所有 Provider 名称 | 1 |
-| **合计** | **27** |
+| 设置高峰/闲时模板 | 10 |
+| **合计** | **37** |
 
 ## 4. 认证方式
 
@@ -52,8 +54,10 @@ provider/
 │   └── one_test.go
 ├── update/
 │   └── update_test.go
-└── delete/
-    └── delete_test.go
+├── delete/
+│   └── delete_test.go
+└── pricing_tiers/
+    └── pricing_tiers_test.go
 ```
 
 ## 6. 创建 Provider
@@ -83,6 +87,8 @@ provider/
 | `keys` | []object | N | API-Key 列表，元素为 `{name, key}`；同一 Provider 内 `name` 唯一 |
 | `instance_pool` | []object | Y | 后端实例池，至少 1 个元素 |
 | `model_protocols` | []string | Y | 支持的模型访问协议，至少 1 个元素，枚举：`openai`、`anthropic` |
+| `time_zone` | string | N | 计算时段所使用的时区，默认 `Asia/Shanghai` |
+| `tiers` | []object | N | 时段 tier 定义列表，**初期 `name` 只支持 `peak`** |
 
 ##### `instance_pool` 元素结构
 
@@ -100,6 +106,21 @@ provider/
 | `name` | string | Y | Key 名称，同一 Provider 内唯一，长度 1-128 |
 | `key` | string | Y | API-Key 明文，长度 1-512 |
 
+##### `tiers` 元素结构
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| `name` | string | Y | Tier 名称，**初期只支持 `peak`** |
+| `time_ranges` | []object | Y | 时段范围列表，命中任意一个即属于该 tier |
+
+##### `time_ranges` 元素结构
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| `weekdays` | []int | N | 星期几，0=周日，...，6=周六；为空表示每天 |
+| `start` | string | Y | 开始时间，格式 `HH:MM` |
+| `end` | string | Y | 结束时间，格式 `HH:MM`；`end` 必须大于 `start` |
+
 #### 6.2.2 响应参数
 
 | 参数名 | 类型 | 说明 |
@@ -112,6 +133,8 @@ provider/
 | `keys` | []object | Key 列表（含明文） |
 | `instance_pool` | []object | 实例池 |
 | `model_protocols` | []string | 协议列表 |
+| `time_zone` | string | 时区 |
+| `tiers` | []object | 时段 tier 列表 |
 | `create_time` | int64 | 创建时间 |
 | `update_time` | int64 | 更新时间 |
 
@@ -242,16 +265,59 @@ provider/
 | PV-5-002 | 删除不存在的 Provider | 404 |
 | PV-5-003 | 删除被 Cluster 引用的 Provider | 409 |
 
-## 11. 依赖与数据准备
+## 11. 设置高峰/闲时模板（PV-8）
+
+### 11.1 接口信息
+
+| 项目 | 值 |
+|------|-----|
+| 模块 | Provider |
+| 接口名称 | 设置高峰/闲时模板 |
+| 方法 | PUT |
+| 路径 | `/providers/{provider_name}/pricing-tiers` |
+| 说明 | 单独维护 provider 的 `time_zone` 和 `tiers`；支持 JSON / YAML / multipart 上传 |
+
+### 11.2 请求参数
+
+#### URI 参数
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| `provider_name` | string | Y | Provider 名称，必须已存在 |
+
+#### Body 参数
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| `time_zone` | string | N | 时区，默认 `Asia/Shanghai`；须为合法 IANA 时区名 |
+| `tiers` | []object | N | 时段 tier 定义列表，结构与创建 Provider 的 `tiers` 一致 |
+
+### 11.3 测试用例
+
+| 用例编号 | 用例名称 | 预期结果 |
+|----------|----------|----------|
+| PT-1-001 | JSON 设置高峰模板 | 200，返回的 `time_zone`/`tiers` 与输入一致 |
+| PT-1-002 | text/yaml 设置高峰模板 | 200，返回的 `time_zone`/`tiers` 与输入一致 |
+| PT-1-003 | multipart/form-data YAML 设置高峰模板 | 200，返回的 `time_zone`/`tiers` 与输入一致 |
+| PT-1-004 | provider 不存在 | 404 |
+| PT-1-005 | 非法 `time_zone` | 422 |
+| PT-1-006 | 非法 tier name | 422 |
+| PT-1-007 | 同一 tier 时间重叠 | 422 |
+| PT-1-008 | `end <= start` | 422 |
+| PT-1-009 | `weekdays` 越界 | 422 |
+| PT-1-010 | GET provider 返回 tiers | 200，响应中包含 `time_zone`/`tiers` |
+
+## 12. 依赖与数据准备
 
 1. 测试环境数据库需包含产品线初始化数据，以支持 cluster 创建。
 2. 创建 Provider 后如需验证删除冲突，需先创建引用该 Provider 的 Cluster。
 3. 测试环境 `SkipTokenValidate=true`，无需认证头。
 
-## 12. 注意事项
+## 13. 注意事项
 
 1. Provider 名称全局唯一，测试中使用 `testutil.UniqueProviderName()` 生成唯一名称。
 2. `keys` 作为数组，按**全量替换**处理；更新时如需保留旧 Key，需传入完整列表。
 3. `instance_pool` 中 `(name, addr, port)` 组合不能重复；`name` 为空字符串时系统会默认填充为 `addr`。
 4. `model_protocols` 当前枚举值为 `openai`、`anthropic`。
 5. `/providers/tools/discover-models` 集成测试见 `discover/discover_test.go`，覆盖 OpenAI/Anthropic 协议、默认 URI、参数校验等场景。
+6. `PUT /providers/{provider_name}/pricing-tiers` 只更新 `time_zone`/`tiers`，不会覆盖 provider 的其他字段。

--- a/test/integration/tests/provider/pricing_tiers/pricing_tiers_test.go
+++ b/test/integration/tests/provider/pricing_tiers/pricing_tiers_test.go
@@ -1,0 +1,330 @@
+package pricing_tiers_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+var sm *testutil.ServerManager
+
+func TestMain(m *testing.M) {
+	var err error
+	sm, err = testutil.StartServer()
+	if err != nil {
+		panic("failed to start server: " + err.Error())
+	}
+	code := m.Run()
+	sm.Shutdown()
+	os.Exit(code)
+}
+
+func TestProvider_PricingTiers(t *testing.T) {
+	t.Run("PT-1-001 JSON 设置高峰模板", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		_, err := testutil.CreateProvider(providerName, nil)
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		resp, err := testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+			"time_zone": "Asia/Shanghai",
+			"tiers": []interface{}{
+				map[string]interface{}{
+					"name": "peak",
+					"time_ranges": []interface{}{
+						map[string]interface{}{
+							"weekdays": []int{1, 2, 3, 4, 5},
+							"start":    "09:00",
+							"end":      "12:00",
+						},
+						map[string]interface{}{
+							"weekdays": []int{1, 2, 3, 4, 5},
+							"start":    "14:00",
+							"end":      "18:00",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		testutil.AssertDataFieldEquals(t, resp, "time_zone", "Asia/Shanghai")
+		var data map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		tiers, ok := data["tiers"].([]interface{})
+		if !assert.True(t, ok, "tiers should be an array") {
+			return
+		}
+		assert.Len(t, tiers, 1)
+		tier0, _ := tiers[0].(map[string]interface{})
+		assert.Equal(t, "peak", tier0["name"])
+	})
+
+	t.Run("PT-1-002 text/yaml 设置高峰模板", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		_, err := testutil.CreateProvider(providerName, nil)
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		yamlContent := []byte(`time_zone: "Asia/Shanghai"
+tiers:
+  - name: "peak"
+    time_ranges:
+      - weekdays: [1, 2, 3, 4, 5]
+        start: "09:00"
+        end: "12:00"
+      - weekdays: [1, 2, 3, 4, 5]
+        start: "14:00"
+        end: "18:00"
+`)
+		resp, err := testutil.UpdatePricingTiersYAML(providerName, yamlContent)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+		testutil.AssertDataFieldEquals(t, resp, "time_zone", "Asia/Shanghai")
+	})
+
+	t.Run("PT-1-003 multipart/form-data YAML 设置高峰模板", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		_, err := testutil.CreateProvider(providerName, nil)
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		yamlContent := []byte(`time_zone: "Asia/Shanghai"
+tiers:
+  - name: "peak"
+    time_ranges:
+      - weekdays: [1, 2, 3, 4, 5]
+        start: "09:00"
+        end: "12:00"
+`)
+		resp, err := testutil.UpdatePricingTiersMultipartYAML(providerName, yamlContent)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+		testutil.AssertDataFieldEquals(t, resp, "time_zone", "Asia/Shanghai")
+	})
+
+	t.Run("PT-1-004 provider 不存在", func(t *testing.T) {
+		resp, err := testutil.UpdatePricingTiers(testutil.UniqueProviderName(), map[string]interface{}{
+			"time_zone": "Asia/Shanghai",
+			"tiers": []interface{}{
+				map[string]interface{}{
+					"name": "peak",
+					"time_ranges": []interface{}{
+						map[string]interface{}{
+							"weekdays": []int{1, 2, 3, 4, 5},
+							"start":    "09:00",
+							"end":      "12:00",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 404)
+	})
+
+	t.Run("PT-1-005 非法 time_zone", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		_, err := testutil.CreateProvider(providerName, nil)
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		resp, err := testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+			"time_zone": "Mars/Phobos",
+			"tiers": []interface{}{
+				map[string]interface{}{
+					"name": "peak",
+					"time_ranges": []interface{}{
+						map[string]interface{}{
+							"start": "09:00",
+							"end":   "12:00",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("PT-1-006 非法 tier name", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		_, err := testutil.CreateProvider(providerName, nil)
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		resp, err := testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+			"tiers": []interface{}{
+				map[string]interface{}{
+					"name": "off_peak",
+					"time_ranges": []interface{}{
+						map[string]interface{}{
+							"start": "09:00",
+							"end":   "12:00",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("PT-1-007 同一 tier 时间重叠", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		_, err := testutil.CreateProvider(providerName, nil)
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		resp, err := testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+			"tiers": []interface{}{
+				map[string]interface{}{
+					"name": "peak",
+					"time_ranges": []interface{}{
+						map[string]interface{}{
+							"start": "09:00",
+							"end":   "12:00",
+						},
+						map[string]interface{}{
+							"start": "10:00",
+							"end":   "11:00",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("PT-1-008 end <= start", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		_, err := testutil.CreateProvider(providerName, nil)
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		resp, err := testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+			"tiers": []interface{}{
+				map[string]interface{}{
+					"name": "peak",
+					"time_ranges": []interface{}{
+						map[string]interface{}{
+							"start": "12:00",
+							"end":   "09:00",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("PT-1-009 weekdays 越界", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		_, err := testutil.CreateProvider(providerName, nil)
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		resp, err := testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+			"tiers": []interface{}{
+				map[string]interface{}{
+					"name": "peak",
+					"time_ranges": []interface{}{
+						map[string]interface{}{
+							"weekdays": []int{7},
+							"start":    "09:00",
+							"end":      "12:00",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("PT-1-010 GET provider 返回 tiers", func(t *testing.T) {
+		providerName := testutil.UniqueProviderName()
+		_, err := testutil.CreateProvider(providerName, nil)
+		if err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		defer testutil.DeleteProvider(providerName)
+
+		_, err = testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+			"time_zone": "Asia/Shanghai",
+			"tiers": []interface{}{
+				map[string]interface{}{
+					"name": "peak",
+					"time_ranges": []interface{}{
+						map[string]interface{}{
+							"weekdays": []int{1, 2, 3, 4, 5},
+							"start":    "09:00",
+							"end":      "12:00",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("setup pricing tiers failed: %v", err)
+		}
+
+		resp, err := testutil.GetClient().Get("/open-api/v1/providers/" + providerName)
+		if err != nil {
+			t.Fatalf("get provider failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+		testutil.AssertDataFieldEquals(t, resp, "time_zone", "Asia/Shanghai")
+		var data map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		tiers, ok := data["tiers"].([]interface{})
+		if !assert.True(t, ok, "tiers should be an array") {
+			return
+		}
+		assert.Len(t, tiers, 1)
+	})
+}

--- a/test/integration/tests/schema/innerapi/innerapi_schema_test.go
+++ b/test/integration/tests/schema/innerapi/innerapi_schema_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,6 +26,7 @@ func TestMain(m *testing.M) {
 
 func TestInnerAPI_Schema(t *testing.T) {
 	t.Run("server_data_conf", testServerDataConfSchema)
+	t.Run("server_data_conf_tiered_pricing", testServerDataConfTieredPricingSchema)
 	t.Run("gslb", testGSLBSchema)
 	t.Run("cluster_table", testClusterTableSchema)
 	t.Run("server_cert_conf", testServerCertConfSchema)
@@ -142,6 +144,133 @@ func assertServerDataConfModelProtocols(t *testing.T, data []byte, clusterName s
 	if modelProtocols[0] != "anthropic" {
 		t.Fatalf("expected ModelProtocols[0]=anthropic for cluster %s, got %v", clusterName, modelProtocols[0])
 	}
+}
+
+func testServerDataConfTieredPricingSchema(t *testing.T) {
+	providerName := testutil.UniqueProviderName()
+	_, err := testutil.CreateProvider(providerName)
+	require.NoError(t, err)
+
+	tierResp, err := testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+		"time_zone": "Asia/Shanghai",
+		"tiers": []interface{}{
+			map[string]interface{}{
+				"name": "peak",
+				"time_ranges": []interface{}{
+					map[string]interface{}{"weekdays": []int{1, 2, 3, 4, 5}, "start": "09:00", "end": "12:00"},
+					map[string]interface{}{"weekdays": []int{1, 2, 3, 4, 5}, "start": "14:00", "end": "18:00"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 200, tierResp.ErrNum, tierResp.ErrMsg)
+
+	yamlContent := []byte(`version: v1.0
+default_currency: RMB
+models:
+  - provider: ` + providerName + `
+    model: deepseek-chat
+    base_model: deepseek-chat
+    mode: chat
+    prices:
+      input_cost_per_token: 0.000002
+      output_cost_per_token: 0.000008
+      cache_read_input_token_cost: 0.0000005
+    tier_prices:
+      peak:
+        input_cost_per_token: 0.000004
+        output_cost_per_token: 0.000016
+        cache_read_input_token_cost: 0.000001
+`)
+	err = testutil.ImportModelPrices(yamlContent, "replace")
+	require.NoError(t, err)
+
+	clusterName := testutil.UniqueClusterName()
+	_, err = testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+		"name": clusterName,
+		"llm_config": map[string]interface{}{
+			"models":   []string{"deepseek-chat"},
+			"provider": providerName,
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := testutil.GetClient().Get("/inner-api/v1/configs/tls_conf/server_data_conf")
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, resp)
+	if resp.Data != nil && string(resp.Data) != "null" {
+		testutil.AssertSchema(t, resp, ServerDataConfSchema)
+		assertServerDataConfTieredPricing(t, resp.Data, clusterName)
+	}
+
+	t.Cleanup(func() {
+		testutil.DeleteCluster(clusterName)
+		testutil.DeleteModelPriceByQuery(providerName, "deepseek-chat", "chat")
+		testutil.DeleteProvider(providerName)
+	})
+}
+
+// assertServerDataConfTieredPricing 校验导出结果中指定 cluster 的 AIConf.ModelTable 携带分时段定价。
+func assertServerDataConfTieredPricing(t *testing.T, data []byte, clusterName string) {
+	t.Helper()
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal server_data_conf data: %v", err)
+	}
+	clusterConf, ok := payload["ClusterConf"].(map[string]interface{})
+	if !ok {
+		t.Fatal("ClusterConf is not an object")
+	}
+	config, ok := clusterConf["Config"].(map[string]interface{})
+	if !ok {
+		t.Fatal("ClusterConf.Config is not an object")
+	}
+	cluster, ok := config[clusterName].(map[string]interface{})
+	if !ok {
+		t.Fatalf("cluster %s not found in ClusterConf.Config", clusterName)
+	}
+	aiconf, ok := cluster["AIConf"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("AIConf not found for cluster %s", clusterName)
+	}
+	modelTable, ok := aiconf["ModelTable"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("AIConf.ModelTable is not an object for cluster %s", clusterName)
+	}
+
+	modelTableJSON, err := json.Marshal(modelTable)
+	if err != nil {
+		t.Fatalf("marshal model table: %v", err)
+	}
+	testutil.AssertSchema(t, &testutil.APIResponse{Data: modelTableJSON}, ModelTableSchema)
+
+	assert.Equal(t, "RMB", modelTable["Currency"])
+	assert.Equal(t, "Asia/Shanghai", modelTable["TimeZone"])
+
+	tiers, ok := modelTable["Tiers"].([]interface{})
+	require.True(t, ok, "ModelTable.Tiers should be an array")
+	require.Len(t, tiers, 1)
+	tier0, _ := tiers[0].(map[string]interface{})
+	assert.Equal(t, "peak", tier0["Name"])
+
+	models, ok := modelTable["Models"].([]interface{})
+	require.True(t, ok, "ModelTable.Models should be an array")
+	require.Len(t, models, 1)
+	model0, _ := models[0].(map[string]interface{})
+	assert.Equal(t, "deepseek-chat", model0["Model"])
+
+	prices, ok := model0["Prices"].(map[string]interface{})
+	require.True(t, ok, "ModelPrice.Prices should be an object")
+	assert.Equal(t, 0.000002, prices["input_cost_per_token"])
+
+	tierPrices, ok := model0["TierPrices"].(map[string]interface{})
+	require.True(t, ok, "ModelPrice.TierPrices should be an object")
+	peak, ok := tierPrices["peak"].(map[string]interface{})
+	require.True(t, ok, "TierPrices.peak should be an object")
+	assert.Equal(t, 0.000004, peak["input_cost_per_token"])
+	assert.Equal(t, 0.000016, peak["output_cost_per_token"])
+	assert.Equal(t, 0.000001, peak["cache_read_input_token_cost"])
 }
 
 func testGSLBSchema(t *testing.T) {
@@ -444,10 +573,12 @@ func assertRuleRedisKey(t *testing.T, policyKey, ruleType string, rules map[stri
 			t.Errorf("RateLimitPolicies.%s.rules.%s[%d].redis_key should be non-empty string", policyKey, ruleType, i)
 			continue
 		}
-		wantPrefix := "RL_" + strings.ToUpper(ruleType) + "_" + policyKey + "_"
-		if !strings.HasPrefix(redisKey, wantPrefix) {
-			t.Errorf("RateLimitPolicies.%s.rules.%s[%d].redis_key format mismatch: got %s, want prefix %s",
-				policyKey, ruleType, i, redisKey, wantPrefix)
+		// redis_key 可能包含产品线/集群前缀（如 default_bfe_<policy>_RL_...），
+		// 因此校验关键片段而非严格前缀。
+		wantInfix := "RL_" + strings.ToUpper(ruleType) + "_" + policyKey + "_"
+		if !strings.Contains(redisKey, wantInfix) {
+			t.Errorf("RateLimitPolicies.%s.rules.%s[%d].redis_key format mismatch: got %s, want contain %s",
+				policyKey, ruleType, i, redisKey, wantInfix)
 		}
 	}
 }

--- a/test/integration/tests/schema/innerapi/schema.go
+++ b/test/integration/tests/schema/innerapi/schema.go
@@ -15,14 +15,53 @@ var InnerAPIBaseSchema = &testutil.ObjectSchema{
 	},
 }
 
+// ClusterConfSchema /configs/tls_conf/server_data_conf 中 ClusterConf 的 schema
+var ClusterConfSchema = &testutil.ObjectSchema{
+	Required: []string{"Version", "Config"},
+	Fields: map[string]testutil.FieldSpec{
+		"Version": {Type: testutil.TypeString},
+		"Config":  {Type: testutil.TypeObject},
+	},
+}
+
+// ModelPriceSchema AIConf.ModelTable.Models 中单个模型价格的 schema
+var ModelPriceSchema = &testutil.ObjectSchema{
+	Required: []string{"Provider", "Model", "BaseModel", "Mode", "Prices"},
+	Optional: []string{"Capabilities", "SupportedParameters", "Limits", "TierPrices", "Metadata"},
+	Fields: map[string]testutil.FieldSpec{
+		"Provider":            {Type: testutil.TypeString},
+		"Model":               {Type: testutil.TypeString},
+		"BaseModel":           {Type: testutil.TypeString},
+		"Mode":                {Type: testutil.TypeString},
+		"Capabilities":        {Type: testutil.TypeArray, Item: &testutil.FieldSpec{Type: testutil.TypeString}},
+		"SupportedParameters": {Type: testutil.TypeArray, Item: &testutil.FieldSpec{Type: testutil.TypeString}},
+		"Limits":              {Type: testutil.TypeObject},
+		"Prices":              {Type: testutil.TypeObject},
+		"TierPrices":          {Type: testutil.TypeObject},
+		"Metadata":            {Type: testutil.TypeObject},
+	},
+}
+
+// ModelTableSchema AIConf.ModelTable 的 schema
+var ModelTableSchema = &testutil.ObjectSchema{
+	Required: []string{"Currency", "Models"},
+	Optional: []string{"TimeZone", "Tiers"},
+	Fields: map[string]testutil.FieldSpec{
+		"Currency": {Type: testutil.TypeString},
+		"TimeZone": {Type: testutil.TypeString},
+		"Tiers":    {Type: testutil.TypeArray},
+		"Models":   {Type: testutil.TypeArray, Elem: ModelPriceSchema},
+	},
+}
+
 // ServerDataConfSchema /configs/tls_conf/server_data_conf 返回 schema
 var ServerDataConfSchema = &testutil.ObjectSchema{
 	Required: []string{"Version", "HostTable", "RouteTable", "ClusterConf"},
 	Fields: map[string]testutil.FieldSpec{
-		"Version":    {Type: testutil.TypeString},
-		"HostTable":  {Type: testutil.TypeObject},
-		"RouteTable": {Type: testutil.TypeObject},
-		"ClusterConf":{Type: testutil.TypeObject},
+		"Version":     {Type: testutil.TypeString},
+		"HostTable":   {Type: testutil.TypeObject},
+		"RouteTable":  {Type: testutil.TypeObject},
+		"ClusterConf": {Type: testutil.TypeObject, Nested: ClusterConfSchema},
 	},
 }
 

--- a/test/integration/tests/schema/openapi/model_price.go
+++ b/test/integration/tests/schema/openapi/model_price.go
@@ -11,6 +11,7 @@ var ModelPriceSchema = &testutil.ObjectSchema{
 		"limits", "prices", "price_currency",
 		"metadata", "create_time", "update_time",
 	},
+	Optional: []string{"tier_prices"},
 	Fields: map[string]testutil.FieldSpec{
 		"id":                   {Type: testutil.TypeInt},
 		"provider":             {Type: testutil.TypeString},
@@ -21,6 +22,7 @@ var ModelPriceSchema = &testutil.ObjectSchema{
 		"supported_parameters": {Type: testutil.TypeArray},
 		"limits":               {Type: testutil.TypeObject},
 		"prices":               {Type: testutil.TypeObject},
+		"tier_prices":          {Type: testutil.TypeObject},
 		"price_currency":       {Type: testutil.TypeString},
 		"metadata":             {Type: testutil.TypeObject},
 		"create_time":          {Type: testutil.TypeInt},

--- a/test/integration/tests/schema/openapi/openapi_schema_test.go
+++ b/test/integration/tests/schema/openapi/openapi_schema_test.go
@@ -253,10 +253,24 @@ func testProviderSchema(t *testing.T) {
 		},
 		"model_protocols": []string{"openai"},
 		"models":          []string{"deepseek-chat"},
+		"time_zone":       "Asia/Shanghai",
+		"tiers": []interface{}{
+			map[string]interface{}{
+				"name": "peak",
+				"time_ranges": []interface{}{
+					map[string]interface{}{
+						"weekdays": []int{1, 2, 3, 4, 5},
+						"start":    "09:00",
+						"end":      "12:00",
+					},
+				},
+			},
+		},
 	})
 	require.NoError(t, err)
 	testutil.AssertSuccess(t, createResp)
 	testutil.AssertSchema(t, createResp, ProviderSchema)
+	testutil.AssertDataFieldEquals(t, createResp, "time_zone", "Asia/Shanghai")
 
 	listResp, err := testutil.GetClient().Get("/open-api/v1/providers")
 	require.NoError(t, err)
@@ -492,6 +506,10 @@ models:
     prices:
       input_cost_per_token: 0.000002
       output_cost_per_token: 0.000008
+    tier_prices:
+      peak:
+        input_cost_per_token: 0.000004
+        output_cost_per_token: 0.000016
     metadata:
       source: test
 `)
@@ -515,6 +533,12 @@ models:
 		"prices": map[string]interface{}{
 			"input_cost_per_token":  0.000002,
 			"output_cost_per_token": 0.000008,
+		},
+		"tier_prices": map[string]interface{}{
+			"peak": map[string]interface{}{
+				"input_cost_per_token":  0.000004,
+				"output_cost_per_token": 0.000016,
+			},
 		},
 		"metadata": map[string]interface{}{
 			"source": "test",
@@ -551,6 +575,12 @@ models:
 		"prices": map[string]interface{}{
 			"input_cost_per_token":  0.000003,
 			"output_cost_per_token": 0.000009,
+		},
+		"tier_prices": map[string]interface{}{
+			"peak": map[string]interface{}{
+				"input_cost_per_token":  0.000006,
+				"output_cost_per_token": 0.000018,
+			},
 		},
 		"metadata": map[string]interface{}{
 			"source": "test",

--- a/test/integration/tests/schema/openapi/provider.go
+++ b/test/integration/tests/schema/openapi/provider.go
@@ -31,12 +31,32 @@ var ProviderInstanceSchema = &testutil.ObjectSchema{
 	},
 }
 
+// TimeRangeSchema provider tiers.time_ranges element schema
+var TimeRangeSchema = &testutil.ObjectSchema{
+	Required: []string{"start", "end"},
+	Fields: map[string]testutil.FieldSpec{
+		"weekdays": {Type: testutil.TypeArray, Item: &testutil.FieldSpec{Type: testutil.TypeInt}},
+		"start":    {Type: testutil.TypeString},
+		"end":      {Type: testutil.TypeString},
+	},
+}
+
+// PricingTierSchema provider tiers element schema
+var PricingTierSchema = &testutil.ObjectSchema{
+	Required: []string{"name", "time_ranges"},
+	Fields: map[string]testutil.FieldSpec{
+		"name":        {Type: testutil.TypeString},
+		"time_ranges": {Type: testutil.TypeArray, Elem: TimeRangeSchema},
+	},
+}
+
 // ProviderSchema Provider 数据模型 schema
 var ProviderSchema = &testutil.ObjectSchema{
 	Required: []string{
 		"id", "name", "description", "model_endpoint", "models", "keys",
 		"instance_pool", "model_protocols", "create_time", "update_time",
 	},
+	Optional: []string{"time_zone", "tiers"},
 	Fields: map[string]testutil.FieldSpec{
 		"id":              {Type: testutil.TypeInt},
 		"name":            {Type: testutil.TypeString},
@@ -46,6 +66,8 @@ var ProviderSchema = &testutil.ObjectSchema{
 		"keys":            {Type: testutil.TypeArray, Elem: ProviderKeySchema},
 		"instance_pool":   {Type: testutil.TypeArray, Elem: ProviderInstanceSchema},
 		"model_protocols": {Type: testutil.TypeArray, Item: &testutil.FieldSpec{Type: testutil.TypeString, Enum: []interface{}{"openai", "anthropic"}}},
+		"time_zone":       {Type: testutil.TypeString},
+		"tiers":           {Type: testutil.TypeArray, Elem: PricingTierSchema},
 		"create_time":     {Type: testutil.TypeInt},
 		"update_time":     {Type: testutil.TypeInt},
 	},

--- a/test/integration/testutil/api_helpers.go
+++ b/test/integration/testutil/api_helpers.go
@@ -122,6 +122,21 @@ func DeleteProvider(name string) error {
 	return nil
 }
 
+// UpdatePricingTiers 通过 JSON 设置 Provider 的高峰/闲时模板
+func UpdatePricingTiers(providerName string, body map[string]interface{}) (*APIResponse, error) {
+	return GetClient().Put("/open-api/v1/providers/"+providerName+"/pricing-tiers", body)
+}
+
+// UpdatePricingTiersYAML 通过 text/yaml 设置 Provider 的高峰/闲时模板
+func UpdatePricingTiersYAML(providerName string, yamlContent []byte) (*APIResponse, error) {
+	return GetClient().RawBody("PUT", "/open-api/v1/providers/"+providerName+"/pricing-tiers", string(yamlContent), "text/yaml")
+}
+
+// UpdatePricingTiersMultipartYAML 通过 multipart/form-data 上传 YAML 文件设置 Provider 的高峰/闲时模板
+func UpdatePricingTiersMultipartYAML(providerName string, yamlContent []byte) (*APIResponse, error) {
+	return GetClient().PutMultipartFile("/open-api/v1/providers/"+providerName+"/pricing-tiers", "file", "pricing-tiers.yaml", yamlContent, nil)
+}
+
 // CreateCluster 创建 Cluster，返回 name
 func CreateCluster(name string) (string, error) {
 	providerName := UniqueProviderName()

--- a/test/integration/testutil/client.go
+++ b/test/integration/testutil/client.go
@@ -130,6 +130,15 @@ func (c *Client) DeleteWithQuery(path string, queryParams map[string]string, bod
 
 // PostMultipartFile 发送带有文件上传的 multipart/form-data POST 请求
 func (c *Client) PostMultipartFile(path, fieldName, fileName string, fileContent []byte, extraFields map[string]string) (*APIResponse, error) {
+	return c.doMultipartRequest(http.MethodPost, path, fieldName, fileName, fileContent, extraFields)
+}
+
+// PutMultipartFile 发送带有文件上传的 multipart/form-data PUT 请求
+func (c *Client) PutMultipartFile(path, fieldName, fileName string, fileContent []byte, extraFields map[string]string) (*APIResponse, error) {
+	return c.doMultipartRequest(http.MethodPut, path, fieldName, fileName, fileContent, extraFields)
+}
+
+func (c *Client) doMultipartRequest(method, path, fieldName, fileName string, fileContent []byte, extraFields map[string]string) (*APIResponse, error) {
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 
@@ -151,7 +160,7 @@ func (c *Client) PostMultipartFile(path, fieldName, fileName string, fileContent
 		return nil, fmt.Errorf("close multipart writer: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, c.BaseURL+path, &body)
+	req, err := http.NewRequest(method, c.BaseURL+path, &body)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}


### PR DESCRIPTION
- provider 增加 time_zone / tiers，新增 PUT /providers/{name}/pricing-tiers
- model-prices 增加 tier_prices，导入/创建/更新均支持
- InnerAPI /configs/tls_conf/server_data_conf 导出 ModelTable.TimeZone/Tiers/TierPrices
- 补充 model_price/innerapi/provider 设计文档与 schema
- 新增 integration tests 并修复 redis_key 前缀断言