### PR TITLE
fix: return all providers when page/page_size are omitted in GET /pro…

### DIFF
--- a/design-docs/api-define/OpenAPI接口定义/providers.md
+++ b/design-docs/api-define/OpenAPI接口定义/providers.md
@@ -234,11 +234,27 @@
 
 | 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
 | - | - | - | - | - | - |
+| page | int | 页码 | N | 未传且 `page_size` 也未传时，返回全部记录 | 大于 0 |
+| page_size | int | 每页条数 | N | 未传且 `page` 也未传时，返回全部记录；最大 1000 | 大于 0 |
 | model_protocol | string | 按协议过滤 | N | - | 须为 `model_protocols` 枚举值 |
 
 **返回数据（Data内容）**
 
-数组，单元素同创建接口。
+```json
+{
+  "list": [...],
+  "pagination": {
+    "page": 1,
+    "page_size": 50,
+    "total": 100
+  }
+}
+```
+
+- 未携带 `page`/`page_size` 时，`list` 返回全部匹配记录，`pagination.page=1`，`pagination.page_size=total`；
+- 携带分页参数时，按对应页码返回。
+
+数组元素同创建接口。
 
 ### 2.3 Provider 详情
 

--- a/endpoints/openapi_v1/provider/list.go
+++ b/endpoints/openapi_v1/provider/list.go
@@ -46,13 +46,23 @@ type listResponse struct {
 // ListAction handles GET /providers.
 func ListAction(req *http.Request) (interface{}, error) {
 	filter := queryFilter(req)
-	page, pageSize := pageFilter(req)
-	filter.Page = &page
-	filter.PageSize = &pageSize
+	page, pageSize, isPagination := pageFilter(req)
+	if isPagination {
+		filter.Page = &page
+		filter.PageSize = &pageSize
+	}
 
 	list, total, err := container.ProviderManager.FetchProviderList(req.Context(), filter)
 	if err != nil {
 		return nil, err
+	}
+
+	if !isPagination {
+		page = 1
+		pageSize = int(total)
+		if pageSize < 1 {
+			pageSize = 0
+		}
 	}
 
 	return &listResponse{
@@ -74,22 +84,28 @@ func queryFilter(req *http.Request) *iprovider.ProviderFilter {
 	return filter
 }
 
-func pageFilter(req *http.Request) (page int, pageSize int) {
+func pageFilter(req *http.Request) (page int, pageSize int, isPagination bool) {
 	q := req.URL.Query()
+	pageStr := q.Get("page")
+	pageSizeStr := q.Get("page_size")
+	if pageStr == "" && pageSizeStr == "" {
+		return 0, 0, false
+	}
+
 	page = 1
 	pageSize = 50
-	if v := q.Get("page"); v != "" {
-		if p, err := strconv.Atoi(v); err == nil && p > 0 {
+	if pageStr != "" {
+		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
 			page = p
 		}
 	}
-	if v := q.Get("page_size"); v != "" {
-		if ps, err := strconv.Atoi(v); err == nil && ps > 0 {
+	if pageSizeStr != "" {
+		if ps, err := strconv.Atoi(pageSizeStr); err == nil && ps > 0 {
 			if ps > 1000 {
 				ps = 1000
 			}
 			pageSize = ps
 		}
 	}
-	return page, pageSize
+	return page, pageSize, true
 }

--- a/model/iprovider/provider.go
+++ b/model/iprovider/provider.go
@@ -261,10 +261,7 @@ func (m *ProviderManager) FetchProviderList(ctx context.Context, filter *Provide
 	// filter in memory for correctness and portability. This is acceptable
 	// because the provider table is small.
 	proto := *filter.ModelProtocol
-	storageFilter := &ProviderFilter{
-		Page:     intPtr(1),
-		PageSize: intPtr(1000),
-	}
+	storageFilter := &ProviderFilter{}
 	all, _, err := m.storager.FetchProviderList(ctx, storageFilter)
 	if err != nil {
 		return nil, 0, err
@@ -278,6 +275,11 @@ func (m *ProviderManager) FetchProviderList(ctx context.Context, filter *Provide
 				break
 			}
 		}
+	}
+
+	// No pagination requested: return all matched records.
+	if filter.Page == nil && filter.PageSize == nil {
+		return matched, int64(len(matched)), nil
 	}
 
 	page := 1

--- a/model/iprovider/provider_test.go
+++ b/model/iprovider/provider_test.go
@@ -223,6 +223,25 @@ func TestProviderManager_FetchProviderList(t *testing.T) {
 		assert.Equal(t, "openai-provider", list[0].Name)
 		assert.Equal(t, "multi-provider", list[1].Name)
 	})
+
+	t.Run("no pagination returns all", func(t *testing.T) {
+		all := []*Provider{
+			{Name: "deepseek"},
+			{Name: "openai"},
+			{Name: "anthropic"},
+		}
+		store := &fakeProviderStorager{
+			fetchListFn: func(ctx context.Context, filter *ProviderFilter) ([]*Provider, int64, error) {
+				return all, int64(len(all)), nil
+			},
+		}
+		m := NewProviderManager(&fakeTxn{}, store)
+		list, total, err := m.FetchProviderList(ctx, &ProviderFilter{})
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), total)
+		assert.Equal(t, all, list)
+	})
+
 }
 
 func TestProviderManager_DiscoverModels(t *testing.T) {

--- a/storage/rdb/internal/dao/table_providers.go
+++ b/storage/rdb/internal/dao/table_providers.go
@@ -67,6 +67,21 @@ func TProviderList(dbCtx lib.DBContexter, where *TProviderParam) ([]*TProvider, 
 	return nil, err
 }
 
+// TProviderListAll queries all providers without pagination.
+func TProviderListAll(dbCtx lib.DBContexter, where *TProviderParam) ([]*TProvider, error) {
+	orderBy := "id"
+	where.OrderBy = &orderBy
+	t := []*TProvider{}
+	err := internal.QueryList(dbCtx, tProviderTableName, where, &t)
+	if err == nil {
+		return t, nil
+	}
+	if xerror.Cause(err) == internal.ErrRecordNotFound {
+		return nil, nil
+	}
+	return nil, err
+}
+
 // TProviderListWithPagination queries providers with pagination.
 func TProviderListWithPagination(dbCtx lib.DBContexter, where *TProviderParam, page, pageSize int) ([]*TProvider, error) {
 	whereMap := internal.Struct2Where(where)

--- a/storage/rdb/provider/provider.go
+++ b/storage/rdb/provider/provider.go
@@ -110,17 +110,29 @@ func (s *RDBProviderStorager) FetchProviderList(ctx context.Context, filter *ipr
 
 	where := filterToDAOParam(filter)
 
+	// No pagination requested: return all matched records.
+	if filter == nil || (filter.Page == nil && filter.PageSize == nil) {
+		list, err := dao.TProviderListAll(dbCtx, where)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		rst := make([]*iprovider.Provider, 0, len(list))
+		for _, one := range list {
+			rst = append(rst, fromDAO(one))
+		}
+		return rst, int64(len(rst)), nil
+	}
+
 	page := 1
 	pageSize := 50
-	if filter != nil {
-		if filter.Page != nil && *filter.Page > 0 {
-			page = *filter.Page
-		}
-		if filter.PageSize != nil && *filter.PageSize > 0 {
-			pageSize = *filter.PageSize
-			if pageSize > 1000 {
-				pageSize = 1000
-			}
+	if filter.Page != nil && *filter.Page > 0 {
+		page = *filter.Page
+	}
+	if filter.PageSize != nil && *filter.PageSize > 0 {
+		pageSize = *filter.PageSize
+		if pageSize > 1000 {
+			pageSize = 1000
 		}
 	}
 

--- a/test/integration/tests/provider/design.md
+++ b/test/integration/tests/provider/design.md
@@ -15,7 +15,7 @@ Provider 与 Cluster 概念分离后：
 | 编号 | 接口名称 | 方法 | 路径 | 说明 |
 |------|----------|------|------|------|
 | PV-1 | 创建 Provider | POST | `/open-api/v1/providers` | 创建模型提供商 |
-| PV-2 | 查询 Provider 列表 | GET | `/open-api/v1/providers` | 支持分页与 `model_protocol` 过滤 |
+| PV-2 | 查询 Provider 列表 | GET | `/open-api/v1/providers` | 未携带 `page`/`page_size` 时返回全部；携带时按分页返回；支持 `model_protocol` 过滤 |
 | PV-3 | 查询 Provider 详情 | GET | `/open-api/v1/providers/{provider_name}` | - |
 | PV-4 | 更新 Provider | PATCH | `/open-api/v1/providers/{provider_name}` | 全量替换 `keys`、`models` 等数组字段 |
 | PV-5 | 删除 Provider | DELETE | `/open-api/v1/providers/{provider_name}` | 删除前检查 cluster/model-price 引用 |
@@ -175,13 +175,16 @@ provider/
 
 | 参数名 | 类型 | 必填 | 说明 |
 |--------|------|------|------|
-| `page` | int | N | 页码，默认 1 |
-| `page_size` | int | N | 每页条数，默认 50，最大 1000 |
+| `page` | int | N | 页码；未传时与 `page_size` 同时缺失，返回全部记录 |
+| `page_size` | int | N | 每页条数，最大 1000；未传时与 `page` 同时缺失，返回全部记录 |
 | `model_protocol` | string | N | 按协议过滤，须为 `model_protocols` 枚举值 |
 
 ### 7.3 响应参数
 
-返回分页结构：
+始终返回 `{ list, pagination }` 结构：
+
+- 未携带 `page`/`page_size` 时，`list` 包含全部匹配记录，`pagination.page=1`，`pagination.page_size=total`；
+- 携带分页参数时，`list` 包含当前页记录，`pagination` 为对应分页信息。
 
 ```json
 {
@@ -198,7 +201,7 @@ provider/
 
 | 用例编号 | 用例名称 | 预期结果 |
 |----------|----------|----------|
-| PV-2-001 | 默认分页 | 200，`pagination.total >= 2`，`list` 非空 |
+| PV-2-001 | 无分页参数返回全部 | 200，`pagination.total >= 2`，`list` 长度等于 `pagination.total` |
 | PV-2-002 | 自定义分页 | 200，`list` 长度为 1 |
 | PV-2-003 | 按 `model_protocol` 过滤 | 200，返回的 Provider 都包含 `openai` 协议 |
 

--- a/test/integration/tests/provider/list/list_test.go
+++ b/test/integration/tests/provider/list/list_test.go
@@ -46,7 +46,7 @@ func TestProvider_List(t *testing.T) {
 		t.Fatalf("setup failed: %v", err)
 	}
 
-	t.Run("PV-2-001 默认分页", func(t *testing.T) {
+	t.Run("PV-2-001 无分页参数返回全部", func(t *testing.T) {
 		resp, err := testutil.GetClient().Get("/open-api/v1/providers")
 		if err != nil {
 			t.Fatalf("request failed: %v", err)
@@ -58,7 +58,7 @@ func TestProvider_List(t *testing.T) {
 			t.Fatalf("unmarshal: %v", err)
 		}
 		assert.GreaterOrEqual(t, list.Pagination.Total, int64(2))
-		assert.NotEmpty(t, list.List)
+		assert.Len(t, list.List, int(list.Pagination.Total))
 	})
 
 	t.Run("PV-2-002 自定义分页", func(t *testing.T) {


### PR DESCRIPTION
…viders

Fixes #89

GET /open-api/v1/providers was always paginated, making it impossible to fetch all provider records at once.

Changes:
- endpoints/openapi_v1/provider/list.go: detect missing page/page_size and do not set pagination filters.
- model/iprovider/provider.go: when no pagination requested, return all matched providers (both normal and model_protocol filtered paths).
- storage/rdb/provider/provider.go: use TProviderListAll when no pagination params are provided.
- storage/rdb/internal/dao/table_providers.go: add TProviderListAll.
- tests & docs updated accordingly.

The response shape stays { list, pagination }; when no pagination is requested, pagination.page=1, pagination.page_size=total.