### PR TITLE
feat: ensure GET /providers/{name} returns time_zone and tiers

### DIFF
--- a/design-docs/api-define/OpenAPI接口定义/providers.md
+++ b/design-docs/api-define/OpenAPI接口定义/providers.md
@@ -275,7 +275,42 @@
 
 **返回数据（Data内容）**
 
-同创建接口。
+同创建接口，包含完整的 Provider 数据模型，其中包括：
+
+- `time_zone`：计算时段所使用的时区（创建时未传则默认 `Asia/Shanghai`）。
+- `tiers`：该 provider 的高峰/闲时 tier 定义列表（若未设置则为空数组 `[]`）。
+
+**成功返回示例**
+
+```json
+{
+    "ErrNum": 200,
+    "ErrMsg": "success",
+    "Data": {
+        "name": "deepseek",
+        "description": "DeepSeek 官方 API",
+        "model_endpoint": { "schema": "https", "uri": "/v1/models" },
+        "models": ["deepseek-v4-pro", "deepseek-v4-flash"],
+        "keys": [...],
+        "instance_pool": [...],
+        "model_protocols": ["openai"],
+        "time_zone": "Asia/Shanghai",
+        "tiers": [
+            {
+                "name": "peak",
+                "time_ranges": [
+                    { "weekdays": [1, 2, 3, 4, 5], "start": "09:00", "end": "12:00" },
+                    { "weekdays": [1, 2, 3, 4, 5], "start": "14:00", "end": "18:00" }
+                ]
+            }
+        ],
+        "create_time": 1716883200,
+        "update_time": 1716883200
+    }
+}
+```
+
+> 说明：若 provider 未通过 `PUT /providers/{provider_name}/pricing-tiers` 设置过高峰/闲时模板，则 `tiers` 返回空数组，`time_zone` 返回默认值 `Asia/Shanghai`。
 
 ### 2.4 更新 Provider
 

--- a/model/iprovider/provider.go
+++ b/model/iprovider/provider.go
@@ -90,7 +90,7 @@ type Provider struct {
 	InstancePool   []ProviderInstance `json:"instance_pool"`
 	ModelProtocols []string           `json:"model_protocols"`
 	TimeZone       string             `json:"time_zone"`
-	Tiers          []PricingTier      `json:"tiers,omitempty"`
+	Tiers          []PricingTier      `json:"tiers"`
 	CreateTime     int64              `json:"create_time"`
 	UpdateTime     int64              `json:"update_time"`
 }

--- a/storage/rdb/provider/provider.go
+++ b/storage/rdb/provider/provider.go
@@ -217,6 +217,16 @@ func fromDAO(one *dao.TProvider) *iprovider.Provider {
 	createTime := one.CreatedAt.Unix()
 	updateTime := one.UpdatedAt.Unix()
 
+	timeZone := one.TimeZone
+	if timeZone == "" {
+		timeZone = "Asia/Shanghai"
+	}
+
+	tiers := unmarshalTiers(one.Tiers)
+	if tiers == nil {
+		tiers = []iprovider.PricingTier{}
+	}
+
 	return &iprovider.Provider{
 		ID:             one.ID,
 		Name:           one.Name,
@@ -226,8 +236,8 @@ func fromDAO(one *dao.TProvider) *iprovider.Provider {
 		Keys:           unmarshalKeys(one.Keys),
 		InstancePool:   unmarshalInstancePool(one.InstancePool),
 		ModelProtocols: unmarshalStringSlice(one.ModelProtocols),
-		TimeZone:       one.TimeZone,
-		Tiers:          unmarshalTiers(one.Tiers),
+		TimeZone:       timeZone,
+		Tiers:          tiers,
 		CreateTime:     createTime,
 		UpdateTime:     updateTime,
 	}
@@ -295,7 +305,7 @@ func unmarshalInstancePool(s string) []iprovider.ProviderInstance {
 }
 
 func unmarshalTiers(s string) []iprovider.PricingTier {
-	if s == "" || s == "null" {
+	if s == "" || s == "null" || s == "{}" {
 		return nil
 	}
 	var rst []iprovider.PricingTier

--- a/test/integration/tests/provider/design.md
+++ b/test/integration/tests/provider/design.md
@@ -220,8 +220,9 @@ provider/
 
 | 用例编号 | 用例名称 | 预期结果 |
 |----------|----------|----------|
-| PV-3-001 | 查询存在的 Provider | 200，返回的 `name` 与请求一致 |
+| PV-3-001 | 查询存在的 Provider | 200，返回的 `name` 与请求一致；`time_zone` 为 `Asia/Shanghai`；`tiers` 为 `[]` |
 | PV-3-002 | 查询不存在的 Provider | 404 |
+| PV-3-003 | 查询已设置 pricing-tiers 的 Provider | 200，返回的 `time_zone` 和 `tiers` 与设置一致 |
 
 ## 9. 更新 Provider
 

--- a/test/integration/tests/provider/one/one_test.go
+++ b/test/integration/tests/provider/one/one_test.go
@@ -1,10 +1,13 @@
 package provider_test
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var sm *testutil.ServerManager
@@ -33,6 +36,11 @@ func TestProvider_One(t *testing.T) {
 		}
 		testutil.AssertSuccess(t, resp)
 		testutil.AssertDataFieldEquals(t, resp, "name", providerName)
+
+		var data map[string]interface{}
+		require.NoError(t, json.Unmarshal(resp.Data, &data))
+		assert.Equal(t, "Asia/Shanghai", data["time_zone"])
+		assert.Equal(t, []interface{}{}, data["tiers"])
 	})
 
 	t.Run("PV-3-002 查询不存在的 Provider", func(t *testing.T) {
@@ -41,6 +49,38 @@ func TestProvider_One(t *testing.T) {
 			t.Fatalf("request failed: %v", err)
 		}
 		testutil.AssertErrCode(t, resp, 404)
+	})
+
+	t.Run("PV-3-003 查询已设置 pricing-tiers 的 Provider", func(t *testing.T) {
+		_, err := testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+			"time_zone": "America/New_York",
+			"tiers": []map[string]interface{}{
+				{
+					"name": "peak",
+					"time_ranges": []map[string]interface{}{
+						{"weekdays": []int{1, 2, 3, 4, 5}, "start": "09:00", "end": "12:00"},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		resp, err := testutil.GetClient().Get("/open-api/v1/providers/" + providerName)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		var data map[string]interface{}
+		require.NoError(t, json.Unmarshal(resp.Data, &data))
+		assert.Equal(t, "America/New_York", data["time_zone"])
+
+		tiers, ok := data["tiers"].([]interface{})
+		require.True(t, ok, "tiers should be an array")
+		require.Len(t, tiers, 1)
+		tier0, ok := tiers[0].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "peak", tier0["name"])
 	})
 
 	t.Cleanup(func() {

--- a/test/integration/tests/schema/openapi/provider.go
+++ b/test/integration/tests/schema/openapi/provider.go
@@ -54,9 +54,9 @@ var PricingTierSchema = &testutil.ObjectSchema{
 var ProviderSchema = &testutil.ObjectSchema{
 	Required: []string{
 		"id", "name", "description", "model_endpoint", "models", "keys",
-		"instance_pool", "model_protocols", "create_time", "update_time",
+		"instance_pool", "model_protocols", "time_zone", "tiers",
+		"create_time", "update_time",
 	},
-	Optional: []string{"time_zone", "tiers"},
 	Fields: map[string]testutil.FieldSpec{
 		"id":              {Type: testutil.TypeInt},
 		"name":            {Type: testutil.TypeString},


### PR DESCRIPTION
The Provider detail endpoint already returned the Provider struct, but the JSON response omitted empty tiers due to omitempty and could return an empty time_zone when unset in the database.

Changes:
- model/iprovider/provider.go: remove omitempty from Tiers so an empty slice serializes as [] instead of being omitted.
- storage/rdb/provider/provider.go: default time_zone to Asia/Shanghai and tiers to [] when loading from DAO; handle {} stored in DB.
- test/integration/tests/provider/one: add PV-3-003 to verify a provider with explicit pricing tiers returns them correctly; assert defaults in PV-3-001.
- test/integration/tests/schema/openapi/provider.go: make time_zone and tiers required in ProviderSchema.
- docs: update providers.md section 2.3 and provider design.md.