### PR TITLE
fix(provider): rename providers.keys to api_keys to avoid MySQL reser…

### DIFF
--- a/db_ddl.sql
+++ b/db_ddl.sql
@@ -425,7 +425,7 @@ CREATE TABLE `providers` (
   `description` VARCHAR(1024) NOT NULL DEFAULT '' COMMENT '描述',
   `model_endpoint` JSON COMMENT '模型发现端点配置',
   `models` JSON COMMENT '支持的模型列表',
-  `keys` JSON COMMENT 'API key 列表',
+  `api_keys` JSON COMMENT 'API key 列表',
   `instance_pool` JSON NOT NULL COMMENT '实例池列表',
   `model_protocols` JSON NOT NULL COMMENT '支持的模型协议列表',
   `time_zone` VARCHAR(255) NOT NULL DEFAULT 'Asia/Shanghai' COMMENT '计算时段所使用的时区',

--- a/db_ddl_sqlite.sql
+++ b/db_ddl_sqlite.sql
@@ -443,7 +443,7 @@ CREATE TABLE providers (
   description TEXT NOT NULL DEFAULT '',
   model_endpoint TEXT,
   models TEXT,
-  keys TEXT,
+  api_keys TEXT,
   instance_pool TEXT NOT NULL,
   model_protocols TEXT NOT NULL,
   time_zone TEXT NOT NULL DEFAULT 'Asia/Shanghai',

--- a/design-docs/modifications/2026-08-26-fix-provider-keys-reserved-word/change-summary.md
+++ b/design-docs/modifications/2026-08-26-fix-provider-keys-reserved-word/change-summary.md
@@ -1,0 +1,69 @@
+# issue-95：provider 表 `keys` 列 MySQL 保留字冲突修复
+
+## 背景与目标
+
+在 `POST /open-api/v1/providers` 创建 provider 时，服务端始终返回 HTTP 500，错误为 MySQL Error 1064（SQL 语法错误）。
+
+根因：`providers` 表存在名为 `keys` 的列，而 `keys` 是 MySQL 保留关键字。建表语句使用反引号将列名括起，因此建表成功；但 DAO 使用 gendry/builder 生成 INSERT/UPDATE 时不给列名加反引号，导致任何写入 `providers` 表的操作都确定性地触发语法错误。
+
+本次修复目标：
+
+1. 将 `providers` 表的列名从 MySQL 保留字 `keys` 改为非保留字 `api_keys`。
+2. 同步更新 DAO 层字段 tag，使 SQL 生成合法。
+3. 保持 OpenAPI/InnerAPI 的 JSON 字段名仍为 `keys`，不破坏接口契约。
+4. 提供存量 MySQL 库的迁移脚本。
+
+## 主要改动点
+
+### 1. 数据库 schema 变更
+
+- `db_ddl.sql`：`providers.keys` → `providers.api_keys`。
+- `db_ddl_sqlite.sql`：`providers.keys TEXT` → `providers.api_keys TEXT`。
+
+### 2. DAO 层字段 tag 变更
+
+- `storage/rdb/internal/dao/table_providers.go`：
+  - `TProvider.Keys` 的 tag 由 `db:"keys"` 改为 `db:"api_keys"`。
+  - `TProviderParam.Keys` 的 tag 由 `db:"keys"` 改为 `db:"api_keys"`。
+
+### 3. 存储转换层无需改动
+
+- `storage/rdb/provider/provider.go` 中 `TProvider.Keys` / `TProviderParam.Keys` 仍通过 `marshalJSON` / `unmarshalKeys` 与 `[]iprovider.ProviderKey` 转换，字段名不变，仅依赖 db tag 映射到新列名。
+- `model/iprovider/provider.go` 中 JSON tag 保持 `json:"keys"`，API 契约不变。
+
+### 4. 存量数据迁移
+
+上线前对已有 MySQL 实例执行：
+
+```sql
+ALTER TABLE providers CHANGE COLUMN `keys` `api_keys` JSON COMMENT 'API key 列表';
+```
+
+SQLite 为新建库场景，直接重新执行 `db_ddl_sqlite.sql` 即可。
+
+## 兼容性说明
+
+- **OpenAPI/InnerAPI 契约不变**：请求/响应 JSON 中字段名仍为 `keys`。
+- **数据库列名变化**：新增环境按新 DDL 建表；存量环境需执行一次 `ALTER TABLE`。
+- **BFE 数据面影响**：provider 导出字段名仍为 `keys`，数据面无感知。
+- **集成测试**：现有 provider 创建/更新/查询用例无需修改，修复后应直接通过。
+
+## 影响范围
+
+- 修复 `POST /open-api/v1/providers` 500 错误。
+- 修复 `PUT /open-api/v1/providers/{id}` 等所有对 `providers` 表的写入/更新操作。
+- 修复按 `keys` 列过滤/查询时可能触发的语法错误。
+- 解除 0.5.0 legacy-contract provider 迁移 120 个 E2E 用例的阻塞。
+
+## 未选择的替代方案
+
+**给 DAO 生成器统一加反引号**：gendry/builder 不自动转义列名，若要在 DAO 层统一包裹反引号，需要改动 `storage/rdb/internal/dao/internal/builder.go` 中所有表的构建逻辑，影响面大、回归成本高；且当前全库仅 `keys` 一个列名命中 MySQL 保留字，因此采用最小改动——重命名列名。
+
+## 验证结果
+
+- [ ] 本地使用 MySQL 8.0 启动服务，执行最小 payload 创建 provider，返回 HTTP 201（需本地 MySQL 环境，未执行）。
+- [ ] 执行 provider 更新、列表查询、详情查询，均返回 200（需本地 MySQL 环境，未执行）。
+- [x] `go test ./model/iprovider/...` 通过。
+- [x] `go test ./...` 通过（ai-gateway-api 全量单元测试；环境无 `make`，使用 `go test ./...` 替代）。
+- [ ] 集成测试 `test/integration/tests/provider/create/...` 与 `test/integration/tests/provider/update/...` 通过（需完整依赖环境，未执行）。
+- [ ] 存量 MySQL 执行迁移脚本后，旧数据可正常读取、新 provider 可正常创建（需本地 MySQL 环境，未执行）。

--- a/design-docs/modifications/2026-08-26-fix-provider-keys-reserved-word/design-changes.md
+++ b/design-docs/modifications/2026-08-26-fix-provider-keys-reserved-word/design-changes.md
@@ -1,0 +1,183 @@
+# issue-95：provider 表 `keys` 列保留字冲突——设计变更说明
+
+## 问题定位
+
+### 复现路径
+
+```bash
+curl -X POST http://<gateway>:8183/open-api/v1/providers \
+  -H "Authorization: Token <system_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "provider-demo",
+    "instance_pool": [{"name": "b1", "addr": "127.0.0.1", "port": 8080, "weight": 100}],
+    "model_protocols": ["openai"]
+  }'
+```
+
+响应：
+
+```json
+{"ErrNum":500,"ErrMsg":"Database Exception: Error 1064: You have an error in your SQL syntax; ... near 'keys,model_endpoint,...' at line 1"}
+```
+
+### 代码路径
+
+1. `endpoints/openapi_v1/provider/create.go` 接收请求并调用 `model/iprovider`。
+2. `model/iprovider/provider.go` 校验后调用 `storage/rdb/provider/provider.go`。
+3. `storage/rdb/provider/provider.go` 将 `iprovider.ProviderParam` 转换为 `dao.TProviderParam`。
+4. `storage/rdb/internal/dao/internal/builder.go` 使用 `github.com/didi/gendry/builder.BuildInsert` 生成 SQL：
+
+```sql
+INSERT INTO providers (keys, model_endpoint, model_protocols, models, name, tiers, time_zone, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+```
+
+其中 `keys` 未加反引号，触发 MySQL 语法错误。
+
+## 数据模型变更
+
+### 数据库 schema
+
+#### MySQL (`db_ddl.sql`)
+
+变更前：
+
+```sql
+CREATE TABLE `providers` (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '主键ID',
+  `name` VARCHAR(255) NOT NULL COMMENT 'Provider 标识',
+  ...
+  `keys` JSON COMMENT 'API key 列表',
+  ...
+);
+```
+
+变更后：
+
+```sql
+CREATE TABLE `providers` (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '主键ID',
+  `name` VARCHAR(255) NOT NULL COMMENT 'Provider 标识',
+  ...
+  `api_keys` JSON COMMENT 'API key 列表',
+  ...
+);
+```
+
+#### SQLite (`db_ddl_sqlite.sql`)
+
+变更前：
+
+```sql
+CREATE TABLE providers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  ...
+  keys TEXT,
+  ...
+);
+```
+
+变更后：
+
+```sql
+CREATE TABLE providers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  ...
+  api_keys TEXT,
+  ...
+);
+```
+
+### DAO 结构体
+
+`storage/rdb/internal/dao/table_providers.go`：
+
+变更前：
+
+```go
+type TProvider struct {
+    ...
+    Keys           string    `db:"keys"`
+    ...
+}
+
+type TProviderParam struct {
+    ...
+    Keys           *string    `db:"keys"`
+    ...
+}
+```
+
+变更后：
+
+```go
+type TProvider struct {
+    ...
+    Keys           string    `db:"api_keys"`
+    ...
+}
+
+type TProviderParam struct {
+    ...
+    Keys           *string    `db:"api_keys"`
+    ...
+}
+```
+
+## 分层映射关系
+
+| 层级 | 字段名 | 说明 |
+|------|--------|------|
+| OpenAPI/InnerAPI JSON | `keys` | 保持对外契约不变 |
+| `model/iprovider.Provider` / `ProviderParam` | `Keys` (`json:"keys"`) | 业务模型不变 |
+| `storage/rdb/internal/dao.TProvider` / `TProviderParam` | `Keys` (`db:"api_keys"`) | Go 字段名不变，仅 tag 映射到新列名 |
+| MySQL/SQLite 列 | `api_keys` | 非保留字，避免语法错误 |
+
+## 存量迁移
+
+MySQL：
+
+```sql
+ALTER TABLE providers CHANGE COLUMN `keys` `api_keys` JSON COMMENT 'API key 列表';
+```
+
+说明：
+
+- `CHANGE COLUMN` 会保留原有 JSON 数据。
+- 不需要更新记录，因为只是列名变更，数据类型/约束不变。
+- 执行前建议备份 `providers` 表。
+
+SQLite：
+
+SQLite 通常用于本地开发/测试，直接重新初始化数据库即可。若需保留数据，可：
+
+```sql
+ALTER TABLE providers RENAME COLUMN keys TO api_keys;
+```
+
+（需 SQLite 3.25.0+）
+
+## 设计权衡
+
+### 方案 A：重命名列名（本次采用）
+
+- **优点**：改动最小，只影响 `providers` 表；不改动 DAO 生成器，回归风险低。
+- **缺点**：需要存量库迁移。
+
+### 方案 B：在 DAO 生成器中统一包裹反引号
+
+- **优点**：无需改列名，未来新增保留字列也不怕。
+- **缺点**：`gendry/builder` 本身不输出反引号，需要手写包装层或在 BuildInsert 前后处理，影响全库所有表；改动面大、回归成本高。
+
+结论：当前仅 `keys` 一个列命中保留字，采用方案 A。
+
+## 回归检查项
+
+- [ ] `db_ddl.sql` 中 `providers` 表仅 `api_keys` 一处出现，无残留 `keys` 列定义。
+- [ ] `db_ddl_sqlite.sql` 中 `providers` 表仅 `api_keys` 一处出现。
+- [ ] `storage/rdb/internal/dao/table_providers.go` 中 `TProvider` 与 `TProviderParam` 的 `Keys` tag 均为 `db:"api_keys"`。
+- [ ] 全仓搜索 `db:"keys"` 无残留（其他表如有同名 tag 需确认是否为 `providers` 表）。
+- [ ] 启动服务后，MySQL 下 provider CRUD 全部成功。

--- a/storage/rdb/internal/dao/table_providers.go
+++ b/storage/rdb/internal/dao/table_providers.go
@@ -32,7 +32,7 @@ type TProvider struct {
 	Description    string    `db:"description"`
 	ModelEndpoint  string    `db:"model_endpoint"`
 	Models         string    `db:"models"`
-	Keys           string    `db:"keys"`
+	Keys           string    `db:"api_keys"`
 	InstancePool   string    `db:"instance_pool"`
 	ModelProtocols string    `db:"model_protocols"`
 	TimeZone       string    `db:"time_zone"`
@@ -179,7 +179,7 @@ type TProviderParam struct {
 	Description    *string    `db:"description"`
 	ModelEndpoint  *string    `db:"model_endpoint"`
 	Models         *string    `db:"models"`
-	Keys           *string    `db:"keys"`
+	Keys           *string    `db:"api_keys"`
 	InstancePool   *string    `db:"instance_pool"`
 	ModelProtocols *string    `db:"model_protocols"`
 	TimeZone       *string    `db:"time_zone"`


### PR DESCRIPTION
…ved word conflict

MySQL treats 'keys' as a reserved keyword. The DAO uses gendry/builder which does not quote column names, so INSERT/UPDATE on providers always fails with Error 1064.

Changes:

- db_ddl.sql: providers.keys -> api_keys

- db_ddl_sqlite.sql: providers.keys -> api_keys

- storage/rdb/internal/dao/table_providers.go: update db tag to api_keys

OpenAPI JSON field remains 'keys', so API contract is unchanged.

Existing MySQL deployments should run:

  ALTER TABLE providers CHANGE COLUMN `keys` `api_keys` JSON COMMENT 'API key 列表';

Fixes rainway-ai-gateway/ai-gateway-api#95