### PR TITLE
fix(model-prices): preserve 8-decimal precision in JSON serialization…

### DIFF
--- a/design-docs/api-define/OpenAPI接口定义/model-prices.md
+++ b/design-docs/api-define/OpenAPI接口定义/model-prices.md
@@ -50,8 +50,8 @@
 | `capabilities` | []string | 模型支持的能力列表 | 默认空数组；元素应为枚举值 |
 | `supported_parameters` | []string | 支持的请求参数列表 | 默认空数组；元素应为枚举值 |
 | `limits` | object | 限制对象 | 默认空对象；键名应为枚举值；所有限制字段必须为非负整数 |
-| `prices` | object | 价格对象 | 必填；至少包含一个价格字段；所有价格字段必须为非负数；键名应为枚举值；未命中 tier 时作为 fallback 价格 |
-| `tier_prices` | object | 分时段价格对象 | 非必填；键为 tier name（**初期只支持 `peak`**），值为价格对象；内部键名应为 `prices` 枚举；与 provider 的 `tiers` 不做强制引用校验 |
+| `prices` | object | 价格对象 | 必填；至少包含一个价格字段；所有价格字段必须为非负数；键名应为枚举值；未命中 tier 时作为 fallback 价格；支持 8 位及以上小数精度，JSON 序列化使用十进制表示法（如 `0.0000015`），不使用科学计数法 |
+| `tier_prices` | object | 分时段价格对象 | 非必填；键为 tier name（**初期只支持 `peak`**），值为价格对象；内部键名应为 `prices` 枚举；与 provider 的 `tiers` 不做强制引用校验；同样支持 8 位及以上小数精度与十进制表示法 |
 | `price_currency` | string | 价格货币 | 固定为 `RMB`，请求体中无需传入 |
 | `metadata` | object | 元数据 | 默认空对象；键名应为枚举值 |
 | `create_time` | int64 | 创建时间 | Unix 时间戳（秒） |
@@ -166,6 +166,37 @@
 
 > **说明**：`capabilities`、`supported_parameters`、`limits`、`prices`、`metadata` 若传入非枚举值，系统可接收但建议告警或记录，便于后续收敛。
 
+### 1.2 价格精度与 JSON 序列化
+
+`prices` 与 `tier_prices.<tier>` 中的价格字段为浮点数，业务上支持 8 位及更多小数精度（例如 `0.0000015`、`0.00000075`）。
+
+为避免默认 JSON encoder 将小数值输出为科学计数法（如 `1.5e-6`），系统在序列化时使用十进制表示法：
+
+- 请求体、响应体、InnerAPI 导出的 `cluster_conf.data` 中，价格均显示为 `"0.0000015"`、`"0.00000075"` 等形式；
+- 该表示方式仅影响 JSON 文本，不改变 `float64` 数值语义与 BFE 定点整数扣减逻辑；
+- YAML 导入（`model-list.yaml`）与 OpenAPI CRUD 均按原浮点数值解析，无需额外处理。
+
+示例：
+
+```json
+{
+  "prices": {
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 0.0000005
+  },
+  "tier_prices": {
+    "peak": {
+      "input_cost_per_token": 0.000003,
+      "output_cost_per_token": 0.000009,
+      "cache_read_input_token_cost": 0.000001
+    }
+  }
+}
+```
+
+序列化后文本保持十进制表示，不包含 `1.5e-6`、`4.5e-6` 等科学计数法。
+
 ---
 
 ## 2. `model-list.yaml` 源格式说明
@@ -220,8 +251,8 @@ models:
 | `capabilities` | N | 能力列表，枚举值同第 1 节 `capabilities` 枚举 |
 | `supported_parameters` | N | 支持的请求参数列表，枚举值同第 1 节 `supported_parameters` 枚举 |
 | `limits` | N | 限制对象，键名枚举值同第 1 节 `limits` 枚举；所有限制字段必须为非负整数 |
-| `prices` | Y | 价格对象，键名枚举值同第 1 节 `prices` 枚举；至少包含一个价格字段；未命中 tier 时作为 fallback 价格 |
-| `tier_prices` | N | 分时段价格对象，键为 tier name（**初期只支持 `peak`**），值为价格对象；内部键名枚举值同第 1 节 `prices` 枚举 |
+| `prices` | Y | 价格对象，键名枚举值同第 1 节 `prices` 枚举；至少包含一个价格字段；未命中 tier 时作为 fallback 价格；支持 8 位及以上小数精度 |
+| `tier_prices` | N | 分时段价格对象，键为 tier name（**初期只支持 `peak`**），值为价格对象；内部键名枚举值同第 1 节 `prices` 枚举；支持 8 位及以上小数精度 |
 | `metadata` | N | 元数据，键名枚举值同第 1 节 `metadata` 枚举 |
 
 > **唯一性约束**：`(provider, model, mode)` 三元组必须唯一。
@@ -624,7 +655,7 @@ Data 为 null。
 2. `provider` 仅作为价格归集标识，不强制引用 `/providers` 中已存在的 provider；
 3. `(provider, model, mode)` 组合不能重复；
 4. `prices` 必填，至少包含一个价格字段；
-5. 所有价格字段必须为非负数；
+5. 所有价格字段必须为非负数；支持 8 位及以上小数精度；
 6. `tier_prices` 非必填；若传入：
    - **初期 tier name 只支持 `peak`**；
    - 每个 tier 对应的价格对象中，键名须为 `prices` 枚举；

--- a/design-docs/modifications/2026-08-27-issue-102-eight-decimal-price-precision/change-summary.md
+++ b/design-docs/modifications/2026-08-27-issue-102-eight-decimal-price-precision/change-summary.md
@@ -1,0 +1,54 @@
+# Issue #102：model-prices 8 位小数价格在配置导出时精度丢失
+
+## 1. 问题来源
+
+[rainway-ai-gateway/ai-gateway-api/issues/102](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/102)
+
+> 在 `ai-gateway-api` 上提交 8 位小数的 model-prices（如 `input_cost_per_token = 0.0000015`），经 InnerAPI 导出到 `bfe` 后，价格被序列化为科学计数法或截断为 6 位有效数字，导致 BFE 按错误价格扣减 RMB 配额。
+
+## 2. 目标
+
+1. 保证 `ai-gateway-api` 在 OpenAPI 响应、InnerAPI 导出、`ImportModelPrices` YAML/JSON 序列化时，8 位小数价格均使用十进制表示法，不丢失精度。
+2. 保证 `bfe` 在重新导出/回写 `AIConf.ModelTable` 时，同样使用十进制表示法。
+3. 保持对现有 6 位及以内小数价格的完全向后兼容。
+4. 不改动 OpenAPI / InnerAPI 的接口契约、请求/响应字段名或数据类型。
+
+## 3. 范围
+
+| 范围 | 说明 |
+|------|------|
+| 涉及仓库 | `ai-gateway-api`、`bfe` |
+| 主要文件 | `ai-gateway-api/model/imodel_price/model_price.go`、`bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go` |
+| 数据库 | 无需迁移；浮点数值本身存储不变 |
+| 接口契约 | 不变；仅 JSON 文本表示方式调整 |
+| 数据面影响 | BFE 解析到的 `float64` 数值不变，配置文本可读性提升 |
+
+## 4. 最终方案概览
+
+为 `PriceMap` 与 `TierPriceMap` 添加自定义 `MarshalJSON`，使用 `strconv.FormatFloat(v, 'f', -1, 64)` 替代默认 JSON encoder。
+
+- Go 标准 `encoding/json` 对 `float64` 默认使用 6 位有效数字，小数值（如 `0.0000015`）会被序列化为 `1.5e-6`，在部分场景下造成可读性与精度混淆。
+- `strconv.FormatFloat(v, 'f', -1, 64)` 按所需的最小小数位输出十进制字符串：`0.0000015` 保持为 `"0.0000015"`，`0.00000005` 保持为 `"0.00000005"`。
+- 该改动同时作用于 `ai-gateway-api` 控制面与 `bfe` 数据面，确保整条链路的配置文本一致。
+
+## 5. 预期收益与风险
+
+| 项目 | 说明 |
+|------|------|
+| 收益 | 8 位小数价格在 OpenAPI、InnerAPI、BFE 配置文件中均以十进制表示，避免科学计数法导致的精度误解；RMB 配额扣减按精确固定点整数执行 |
+| 主要风险 | 自定义 `MarshalJSON` 后 JSON 文本长度略有增加；无功能回退 |
+| 兼容性 | 数值反序列化仍由标准库完成，`float64` 解析结果不变；现有测试无需修改即可通过 |
+
+## 6. 上线前检查清单
+
+1. `ai-gateway-api` 单元测试 `TestParseModelListYAMLEightDecimalPlaces` 通过；
+2. `bfe` 单元测试 `TestModelTableCheck` 及含 8 位小数价格的子用例通过；
+3. 运行 `integration-test` 中 SC19 `TestTC08_EightDecimalPlaces` 与 SC25 `TestTC06_RMBQuotaDeduction_Peak_8DecimalPlaces`，确认端到端 RMB 扣减精度正确。
+
+## 7. 参考文档
+
+- [Issue #102](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/102)
+- `ai-gateway-api/model/imodel_price/model_price.go`
+- `bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go`
+- `integration-test/test-cases/测试设计文档/scenario-SC19-RMB配额扣减/TC-08-8位小数价格端到端精度.md`
+- `integration-test/test-cases/测试设计文档/scenario-SC25-RMB分时段计费/TC-06-8位小数分时段价格端到端精度.md`

--- a/design-docs/modifications/2026-08-27-issue-102-eight-decimal-price-precision/design-changes.md
+++ b/design-docs/modifications/2026-08-27-issue-102-eight-decimal-price-precision/design-changes.md
@@ -1,0 +1,351 @@
+# Issue #102：model-prices 8 位小数价格序列化精度设计变更说明
+
+## 1. 当前问题定位
+
+### 1.1 错误表象
+
+在 `ai-gateway-api` 上提交如下 model-prices 记录：
+
+```json
+{
+  "provider": "mock-provider-8-decimal",
+  "model": "deepseek-chat",
+  "base_model": "deepseek-chat",
+  "mode": "chat",
+  "prices": {
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000045
+  }
+}
+```
+
+经 InnerAPI `/inner-api/v1/configs/tls_conf/server_data_conf` 导出后，BFE 侧 `cluster_conf.data` 中对应字段可能被表示为：
+
+```json
+"prices": {
+    "input_cost_per_token": 1.5e-6,
+    "output_cost_per_token": 4.5e-6
+}
+```
+
+虽然 `encoding/json` 反序列化后 `float64` 值仍为 `0.0000015`，但：
+
+1. 配置文本可读性差，运维排查时容易误判为精度丢失；
+2. 当链路中存在中间层再次序列化时，科学计数法可能被进一步截断或解析错误；
+3. BFE 若对配置做文本对比/签名，相同语义的不同表示会导致不必要的 diff。
+
+### 1.2 根因分析
+
+Go 标准库 `encoding/json` 对 `float64` 编码时默认使用 6 位有效数字（`fmt` 的 `%g` 默认精度）。当数值绝对值很小（如 `0.0000015`）时，`%g` 会自动切换为科学计数法 `1.5e-6`，以控制输出长度。
+
+`PriceMap map[string]float64` 与 `TierPriceMap map[string]map[string]float64` 原本依赖默认 encoder，因此所有经过 JSON 序列化的路径（OpenAPI 响应、InnerAPI 导出、`ImportModelPrices` 导入后回写、BFE 重新导出）都会受影响。
+
+### 1.3 为什么单元测试没发现
+
+早期测试用例价格多使用 `0.000001`、`0.000002` 等 6 位有效数字以内的值，这些值在默认 encoder 下仍以十进制输出（`1e-6` 被表示为 `0.000001`），未触发科学计数法。直到引入 8 位小数价格（`0.0000015`、`0.00000005`）后问题才暴露。
+
+## 2. 目标
+
+1. 保证 `ai-gateway-api` 中 `PriceMap` / `TierPriceMap` 序列化时使用十进制表示法；
+2. 保证 `bfe` 中同名类型序列化时使用十进制表示法；
+3. 保持数值语义不变，反序列化结果与修改前完全一致；
+4. 不引入新的依赖或复杂的数值类型。
+
+## 3. 方案对比
+
+| 方案 | 思路 | 优点 | 缺点 | 结论 |
+|------|------|------|------|------|
+| A. 自定义 `MarshalJSON`（推荐） | 为 `PriceMap` / `TierPriceMap` 实现 `MarshalJSON`，使用 `strconv.FormatFloat(v, 'f', -1, 64)` | 改动小、无依赖、语义不变、同时适用于 ai-gateway-api 与 bfe | 需要为两个仓库的同构类型分别实现 | **采用** |
+| B. 使用 `json.Number` 或字符串存储价格 | 将价格改为字符串类型 | 彻底避免浮点问题 | 需改动 OpenAPI 契约、数据库、BFE 解析，影响面大 | 不采用 |
+| C. 使用 `math/big.Float` | 高精度浮点类型 | 精度更高 | 引入复杂类型，与现有 `float64` 定点转换逻辑不兼容 | 不采用 |
+| D. 调整 `json.Encoder` 精度 | 全局设置 `SetEscapeHTML` 等无法解决；`fmt` 精度参数不能兼顾所有小数位 | 全局生效 | 会改变所有 float64 输出格式，风险不可控 | 不采用 |
+
+## 4. 推荐方案：自定义 `MarshalJSON`
+
+### 4.1 核心思路
+
+在 `PriceMap` 和 `TierPriceMap` 上实现 `json.Marshaler` 接口，手动拼接 JSON 对象，数值部分使用 `strconv.FormatFloat(v, 'f', -1, 64)`。
+
+`FormatFloat` 参数说明：
+
+- `'f'`：普通十进制表示法，非科学计数法；
+- `-1`：按必要精度输出，不截断也不补零；
+- `64`：按 `float64` 精度处理。
+
+示例：
+
+| 原始值 | 默认 JSON 输出 | `FormatFloat('f', -1, 64)` |
+|--------|----------------|----------------------------|
+| `0.0000015` | `1.5e-6` | `0.0000015` |
+| `0.0000045` | `4.5e-6` | `0.0000045` |
+| `0.00000005` | `5e-8` | `0.00000005` |
+| `0.000001` | `0.000001` | `0.000001` |
+
+### 4.2 `ai-gateway-api` 实现
+
+文件：`ai-gateway-api/model/imodel_price/model_price.go`
+
+```go
+// PriceMap is a map of price keys to their numeric values.
+// It marshals to JSON using decimal notation instead of scientific notation.
+type PriceMap map[string]float64
+
+// MarshalJSON serializes PriceMap using decimal notation for all values.
+func (p PriceMap) MarshalJSON() ([]byte, error) {
+    if p == nil {
+        return []byte("null"), nil
+    }
+    var buf bytes.Buffer
+    buf.WriteByte('{')
+    first := true
+    for k, v := range p {
+        if !first {
+            buf.WriteByte(',')
+        }
+        first = false
+        keyBytes, err := json.Marshal(k)
+        if err != nil {
+            return nil, err
+        }
+        buf.Write(keyBytes)
+        buf.WriteByte(':')
+        buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+    }
+    buf.WriteByte('}')
+    return buf.Bytes(), nil
+}
+
+// TierPriceMap is a map of tier names to PriceMap values.
+// It marshals to JSON using decimal notation instead of scientific notation.
+type TierPriceMap map[string]map[string]float64
+
+// MarshalJSON serializes TierPriceMap using decimal notation for all nested values.
+func (t TierPriceMap) MarshalJSON() ([]byte, error) {
+    if t == nil {
+        return []byte("null"), nil
+    }
+    var buf bytes.Buffer
+    buf.WriteByte('{')
+    first := true
+    for tier, prices := range t {
+        if !first {
+            buf.WriteByte(',')
+        }
+        first = false
+        tierBytes, err := json.Marshal(tier)
+        if err != nil {
+            return nil, err
+        }
+        buf.Write(tierBytes)
+        buf.WriteByte(':')
+        if prices == nil {
+            buf.WriteString("null")
+            continue
+        }
+        innerFirst := true
+        buf.WriteByte('{')
+        for k, v := range prices {
+            if !innerFirst {
+                buf.WriteByte(',')
+            }
+            innerFirst = false
+            keyBytes, err := json.Marshal(k)
+            if err != nil {
+                return nil, err
+            }
+            buf.Write(keyBytes)
+            buf.WriteByte(':')
+            buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+        }
+        buf.WriteByte('}')
+    }
+    buf.WriteByte('}')
+    return buf.Bytes(), nil
+}
+```
+
+### 4.3 `bfe` 实现
+
+文件：`bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go`
+
+BFE 侧同构类型 `PriceMap` / `TierPriceMap` 采用与 `ai-gateway-api` 完全一致的实现，确保 BFE 重新导出配置时不会把已修正的十进制表示再变回科学计数法。
+
+```go
+// PriceMap is a map of price keys to their numeric values.
+// It marshals to JSON using decimal notation instead of scientific notation.
+type PriceMap map[string]float64
+
+// MarshalJSON serializes PriceMap using decimal notation for all values.
+func (p PriceMap) MarshalJSON() ([]byte, error) {
+    if p == nil {
+        return []byte("null"), nil
+    }
+    var buf bytes.Buffer
+    buf.WriteByte('{')
+    first := true
+    for k, v := range p {
+        if !first {
+            buf.WriteByte(',')
+        }
+        first = false
+        keyBytes, err := stdjson.Marshal(k)
+        if err != nil {
+            return nil, err
+        }
+        buf.Write(keyBytes)
+        buf.WriteByte(':')
+        buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+    }
+    buf.WriteByte('}')
+    return buf.Bytes(), nil
+}
+
+// TierPriceMap is a map of tier names to PriceMap values.
+// It marshals to JSON using decimal notation instead of scientific notation.
+type TierPriceMap map[string]map[string]float64
+
+// MarshalJSON serializes TierPriceMap using decimal notation for all nested values.
+func (t TierPriceMap) MarshalJSON() ([]byte, error) {
+    if t == nil {
+        return []byte("null"), nil
+    }
+    var buf bytes.Buffer
+    buf.WriteByte('{')
+    first := true
+    for tier, prices := range t {
+        if !first {
+            buf.WriteByte(',')
+        }
+        first = false
+        tierBytes, err := stdjson.Marshal(tier)
+        if err != nil {
+            return nil, err
+        }
+        buf.Write(tierBytes)
+        buf.WriteByte(':')
+        if prices == nil {
+            buf.WriteString("null")
+            continue
+        }
+        innerFirst := true
+        buf.WriteByte('{')
+        for k, v := range prices {
+            if !innerFirst {
+                buf.WriteByte(',')
+            }
+            innerFirst = false
+            keyBytes, err := stdjson.Marshal(k)
+            if err != nil {
+                return nil, err
+            }
+            buf.Write(keyBytes)
+            buf.WriteByte(':')
+            buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+        }
+        buf.WriteByte('}')
+    }
+    buf.WriteByte('}')
+    return buf.Bytes(), nil
+}
+```
+
+> 注：BFE 侧将标准库 json 包导入别名 `stdjson`，以避免与本地类型或变量命名冲突。
+
+### 4.4 定点整数转换不受影响
+
+BFE 在配置加载阶段仍按原有逻辑将 `float64` 价格转换为定点整数（1e-8 元/单位、1e-12 / token 等）：
+
+```go
+// 示意
+func toFixedPoint(price float64) int64 {
+    return int64(price*1e12 + 0.5)
+}
+```
+
+`MarshalJSON` 只影响配置文本输出，不影响 `float64` 解析后的数值，因此运行时扣减精度不变。
+
+## 5. 数据迁移
+
+本次修复**不需要数据迁移**。数据库中价格仍以 `float64` / `REAL` 存储，数值本身未发生变化。仅在序列化到 JSON 文本时使用十进制表示法。
+
+## 6. 测试计划
+
+### 6.1 单元测试
+
+#### `ai-gateway-api/model/imodel_price/import_test.go`
+
+新增/保留 `TestParseModelListYAMLEightDecimalPlaces`：
+
+1. 解析含 8 位小数价格的 YAML；
+2. 断言 `Prices` / `TierPrices` 中 `float64` 值正确；
+3. `json.Marshal` 后断言输出包含 `"0.00000005"`、`"0.0000001"`；
+4. 断言输出不包含 `"5e-"`、`"1e-"`；
+5. `json.Unmarshal` 回 `ModelPrice` 后验证数值往返一致。
+
+#### `bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load_test.go`
+
+保留现有 `TestModelTableCheck` 中含 8 位小数的子用例，如 `0.000004525`、`0.000022625`、`0.0000004525`、`0.00000565625`，验证：
+
+1. `ModelTableCheck` 通过；
+2. `GetPriceInt` 返回预期定点整数（如 45、565）。
+
+### 6.2 集成测试
+
+运行 `integration-test` 中的端到端用例：
+
+```bash
+# SC19：普通 RMB 配额 8 位小数精度
+go test ./test-cases/implementation/scenario-SC19-rmb-quota-deduction/... -run TestTC08 -v
+
+# SC25：分时段 tier 价格 8 位小数精度
+go test ./test-cases/implementation/scenario-SC25-rmb-tiered-pricing/... -run TestTC06 -v
+```
+
+预期：
+
+- 请求成功返回 200；
+- RMB 余额按精确固定点整数扣减；
+- 导出到 BFE 的 `cluster_conf.data` 中价格为十进制表示法。
+
+### 6.3 回归验证命令
+
+```bash
+# ai-gateway-api
+cd ai-gateway-api
+go test ./model/imodel_price/...
+
+# bfe
+cd bfe
+go test ./bfe_config/bfe_cluster_conf/cluster_conf/...
+
+# integration-test
+cd integration-test
+go test ./test-cases/implementation/scenario-SC19-rmb-quota-deduction/... -run TestTC08
+go test ./test-cases/implementation/scenario-SC25-rmb-tiered-pricing/... -run TestTC06
+```
+
+## 7. 风险与缓解
+
+| 风险 | 说明 | 缓解措施 |
+|------|------|----------|
+| JSON 文本长度增加 | 十进制表示比科学计数法更长 | 价格字段数量有限，对整体配置大小影响可忽略 |
+| 自定义 Marshal 引入新 bug | 手动拼接 JSON 可能遗漏转义 | key 仍使用 `json.Marshal` 生成，确保转义正确；测试覆盖 nil、空 map、嵌套 map 场景 |
+| 反序列化行为变化 | 自定义 Marshal 不影响 Unmarshal | 保留标准 `float64` 解析，已有单元测试验证 |
+
+## 8. 实施状态
+
+- [x] `ai-gateway-api/model/imodel_price/model_price.go` 增加 `PriceMap.MarshalJSON` 与 `TierPriceMap.MarshalJSON`；
+- [x] `bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go` 增加同名自定义序列化；
+- [x] `ai-gateway-api` 单元测试 `TestParseModelListYAMLEightDecimalPlaces` 通过；
+- [x] `bfe` 单元测试 `TestModelTableCheck` 含 8 位小数子用例通过；
+- [x] `integration-test` SC19 TC-08 与 SC25 TC-06 端到端通过。
+
+## 9. 参考文档
+
+- [Issue #102](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/102)
+- `ai-gateway-api/model/imodel_price/model_price.go`
+- `ai-gateway-api/model/imodel_price/import_test.go`
+- `bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go`
+- `bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load_test.go`
+- `integration-test/test-cases/测试设计文档/scenario-SC19-RMB配额扣减/TC-08-8位小数价格端到端精度.md`
+- `integration-test/test-cases/测试设计文档/scenario-SC25-RMB分时段计费/TC-06-8位小数分时段价格端到端精度.md`

--- a/design-docs/sys-design/details/RMB配额分时段定价.md
+++ b/design-docs/sys-design/details/RMB配额分时段定价.md
@@ -11,6 +11,7 @@
 3. 结合 provider/cluster 分离，时段模板放在 `/providers`，分时段价格放在 `/model-prices`。
 4. 保持对现有固定价格的向后兼容。
 5. 运行时成本计算仍保持纯整数运算，不引入浮点误差。
+6. `prices` / `tier_prices` 中的浮点价格在 JSON 序列化时使用十进制表示法，支持 8 位及更多小数精度，避免科学计数法导致可读性问题或中间层截断。
 
 ## 2. 核心概念
 
@@ -79,6 +80,14 @@ type PriceTier struct {
     TimeRanges []TimeRange // 命中任意一个即属于该 Tier
 }
 
+// PriceMap maps price keys to float64 values.
+// It marshals to JSON using decimal notation instead of scientific notation,
+// so values like 0.0000015 remain readable in exported configs.
+type PriceMap map[string]float64
+
+// TierPriceMap maps tier names to PriceMap values with the same decimal notation.
+type TierPriceMap map[string]map[string]float64
+
 type ModelPrice struct {
     Provider            string
     Model               string
@@ -87,8 +96,8 @@ type ModelPrice struct {
     Capabilities        []string
     SupportedParameters []string
     Limits              map[string]interface{}
-    Prices              map[string]float64            // 默认价格
-    TierPrices          map[string]map[string]float64 // tier name -> 价格表
+    Prices              PriceMap     // 默认价格
+    TierPrices          TierPriceMap // tier name -> 价格表
     Metadata            map[string]interface{}
 }
 
@@ -117,6 +126,7 @@ type ModelTable struct {
 - `model/imodel_price`：
   - `ModelPrice` / `ModelPriceParam` 新增 `tier_prices`。
   - CRUD 与 YAML 导入增加对 `tier_prices` 的校验（tier name、价格键名、非负价格）。
+  - `PriceMap` 与 `TierPriceMap` 实现自定义 `MarshalJSON`，使用 `strconv.FormatFloat(v, 'f', -1, 64)` 输出十进制表示法，避免 8 位小数价格被序列化为科学计数法。
 - `model/icluster_conf/exporter.go`：
   - 导出 `AIConf` 时，根据 `cluster.llm_config.provider` 查询 Provider，将 `time_zone` / `tiers` 填入 `ModelTable`。
   - 按同一 `provider` 查询 `model_prices`，将 `prices` / `tier_prices` 填入对应 `ModelPrice`。
@@ -129,7 +139,7 @@ type ModelTable struct {
 
 ## 6. BFE 数据面行为
 
-BFE 侧与 v0.4 方案基本一致，`AIConf.ModelTable` 结构未变，仅配置来源发生变化。
+BFE 侧与 v0.4 方案基本一致，`AIConf.ModelTable` 结构未变，仅配置来源发生变化。为保持整条链路配置文本一致，BFE 侧同构的 `PriceMap` / `TierPriceMap` 也实现了自定义 `MarshalJSON`，使用相同的十进制表示法。
 
 ### 6.1 加载阶段
 
@@ -199,6 +209,7 @@ func (table *ModelTable) ActiveTierName(now time.Time) string {
 
 | 风险 | 影响 | 缓解措施 |
 |------|------|----------|
+| 浮点价格 JSON 序列化精度/可读性 | 默认 encoder 对 8 位小数会输出科学计数法，配置可读性差，中间层可能误解析 | `ai-gateway-api` 与 `bfe` 的 `PriceMap` / `TierPriceMap` 均自定义 `MarshalJSON`，使用 `strconv.FormatFloat(v, 'f', -1, 64)` 强制十进制表示。 |
 | tier name 首期约束 | 仅支持 `peak` | 设计时已通过 `Weekdays` 预留扩展能力，后续只需放开命名约束。 |
 | provider 与 model-prices 的 tier 松耦合 | `tier_prices` 可能引用 provider 未定义的 tier | 可记录告警，但不做强制引用校验以保持灵活性。 |
 | 时区解析依赖系统时区数据库 | 部署环境需包含 IANA 时区数据 | 使用 Go 标准库 `time.LoadLocation`，确保容器镜像包含时区数据。 |
@@ -209,6 +220,8 @@ func (table *ModelTable) ActiveTierName(now time.Time) string {
 
 本设计已于 `2026-08-25` 完成编码并全量测试通过（`go build ./...`、`go test ./...`）。
 
+后续于 `2026-08-27` 针对 Issue #102 补充了 8 位小数价格 JSON 序列化精度修复：为 `ai-gateway-api` 与 `bfe` 两侧的 `PriceMap` / `TierPriceMap` 增加自定义 `MarshalJSON`，使用十进制表示法替代科学计数法。
+
 主要落地文件：
 
 | 层次 | 文件 | 说明 |
@@ -217,10 +230,10 @@ func (table *ModelTable) ActiveTierName(now time.Time) string {
 | 存储层 | `storage/rdb/internal/dao/table_providers.go`、`table_model_prices.go` | DAO 字段 |
 | 存储层 | `storage/rdb/provider/provider.go`、`storage/rdb/model_price/model_price.go` | JSON 序列化 |
 | 模型层 | `model/iprovider/provider.go`、`validate.go` | provider 时区/时段模型与校验 |
-| 模型层 | `model/imodel_price/model_price.go`、`validate.go` | model price tier 价格模型与校验 |
+| 模型层 | `model/imodel_price/model_price.go`、`validate.go` | model price tier 价格模型与校验；含 `PriceMap`/`TierPriceMap` 自定义 `MarshalJSON` |
 | 导出层 | `model/icluster_conf/cluster.go`、`model/iroute_conf/exporter.go` | `AIConf.ModelTable` 拼接 |
 | 接口层 | `endpoints/openapi_v1/provider/pricing_tiers.go` | `PUT /providers/{provider_name}/pricing-tiers` |
-| BFE 数据面 | `bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go` | 已有 `TimeZone`/`Tiers`/`TierPrices`/`ActiveTierName`，无需额外改动 |
+| BFE 数据面 | `bfe/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go` | 已有 `TimeZone`/`Tiers`/`TierPrices`/`ActiveTierName`；含 `PriceMap`/`TierPriceMap` 自定义 `MarshalJSON` |
 
 BFE 数据面保持原有 v0.4 实现，仅配置来源由 ai-gateway-api 控制面按本设计拼接后下发。
 
@@ -228,5 +241,5 @@ BFE 数据面保持原有 v0.4 实现，仅配置来源由 ai-gateway-api 控制
 
 - API 定义：`design-docs/api-define/OpenAPI接口定义/providers.md`、`design-docs/api-define/OpenAPI接口定义/model-prices.md`
 - Inner API 定义：`design-docs/api-define/InnerAPI接口定义/server-data-conf.md`
-- 修改说明：`design-docs/modifications/2026-08-25-rmb-tiered-pricing/`
+- 修改说明：`design-docs/modifications/2026-08-25-rmb-tiered-pricing/`、`design-docs/modifications/2026-08-27-issue-102-eight-decimal-price-precision/`
 - 上游设计来源：`document-ai-gateway/迭代系统设计/v0.5/计费能力扩展/bfe-rmb-tiered-pricing-design.md`

--- a/model/icluster_conf/cluster.go
+++ b/model/icluster_conf/cluster.go
@@ -1014,8 +1014,8 @@ func NewBfeClusterConf(version string, clusters []*Cluster,
 								Capabilities:        e.Capabilities,
 								SupportedParameters: e.SupportedParameters,
 								Limits:              e.Limits,
-								Prices:              e.Prices,
-								TierPrices:          e.TierPrices,
+								Prices:              cluster_conf.PriceMap(e.Prices),
+								TierPrices:          cluster_conf.TierPriceMap(e.TierPrices),
 								Metadata:            e.Metadata,
 							})
 						}

--- a/model/icluster_conf/cluster_test.go
+++ b/model/icluster_conf/cluster_test.go
@@ -864,12 +864,12 @@ func TestNewBfeClusterConf(t *testing.T) {
 					Model:     "deepseek-v4-pro",
 					BaseModel: "deepseek-v4-pro",
 					Mode:      "chat",
-					Prices: map[string]float64{
+					Prices: imodel_price.PriceMap{
 						"input_cost_per_token":        0.0000045,
 						"output_cost_per_token":       0.0000135,
 						"cache_read_input_token_cost": 0.00000015,
 					},
-					TierPrices: map[string]map[string]float64{
+					TierPrices: imodel_price.TierPriceMap{
 						"peak": {
 							"input_cost_per_token":        0.000009,
 							"output_cost_per_token":       0.000027,

--- a/model/imodel_price/import_test.go
+++ b/model/imodel_price/import_test.go
@@ -15,6 +15,7 @@
 package imodel_price
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"strings"
@@ -256,3 +257,49 @@ func (e *errReader) Read(p []byte) (int, error) {
 }
 
 var _ io.Reader = (*errReader)(nil)
+
+func TestParseModelListYAMLEightDecimalPlaces(t *testing.T) {
+	yaml := `
+version: v1.0
+default_currency: RMB
+models:
+  - provider: deepseek
+    model: deepseek-v3
+    base_model: deepseek-v3
+    mode: chat
+    prices:
+      input_cost_per_token: 0.0000015
+      output_cost_per_token: 0.0000045
+      cache_read_input_token_cost: 0.00000005
+    tier_prices:
+      peak:
+        input_cost_per_token: 0.000003
+        output_cost_per_token: 0.000009
+        cache_read_input_token_cost: 0.0000001
+`
+	file, err := ParseModelListYAML(strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.Len(t, file.Models, 1)
+
+	m := file.Models[0]
+	assert.Equal(t, 0.0000015, m.Prices["input_cost_per_token"])
+	assert.Equal(t, 0.0000045, m.Prices["output_cost_per_token"])
+	assert.Equal(t, 0.00000005, m.Prices["cache_read_input_token_cost"])
+	assert.Equal(t, 0.000003, m.TierPrices["peak"]["input_cost_per_token"])
+	assert.Equal(t, 0.000009, m.TierPrices["peak"]["output_cost_per_token"])
+	assert.Equal(t, 0.0000001, m.TierPrices["peak"]["cache_read_input_token_cost"])
+
+	// JSON should use decimal notation, not scientific notation.
+	data, err := json.Marshal(m)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "0.00000005")
+	assert.Contains(t, string(data), "0.0000001")
+	assert.NotContains(t, string(data), "5e-")
+	assert.NotContains(t, string(data), "1e-")
+
+	// Round-trip preserves values.
+	var back ModelPrice
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, 0.00000005, back.Prices["cache_read_input_token_cost"])
+	assert.Equal(t, 0.0000001, back.TierPrices["peak"]["cache_read_input_token_cost"])
+}

--- a/model/imodel_price/model_price.go
+++ b/model/imodel_price/model_price.go
@@ -15,12 +15,92 @@
 package imodel_price
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/itxn"
 )
+
+// PriceMap is a map of price keys to their numeric values.
+// It marshals to JSON using decimal notation instead of scientific notation.
+type PriceMap map[string]float64
+
+// MarshalJSON serializes PriceMap using decimal notation for all values.
+func (p PriceMap) MarshalJSON() ([]byte, error) {
+	if p == nil {
+		return []byte("null"), nil
+	}
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	first := true
+	for k, v := range p {
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		keyBytes, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(keyBytes)
+		buf.WriteByte(':')
+		buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// TierPriceMap is a map of tier names to PriceMap values.
+// It marshals to JSON using decimal notation instead of scientific notation.
+type TierPriceMap map[string]map[string]float64
+
+// MarshalJSON serializes TierPriceMap using decimal notation for all nested values.
+func (t TierPriceMap) MarshalJSON() ([]byte, error) {
+	if t == nil {
+		return []byte("null"), nil
+	}
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	first := true
+	for tier, prices := range t {
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		tierBytes, err := json.Marshal(tier)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(tierBytes)
+		buf.WriteByte(':')
+		if prices == nil {
+			buf.WriteString("null")
+			continue
+		}
+		innerFirst := true
+		buf.WriteByte('{')
+		for k, v := range prices {
+			if !innerFirst {
+				buf.WriteByte(',')
+			}
+			innerFirst = false
+			keyBytes, err := json.Marshal(k)
+			if err != nil {
+				return nil, err
+			}
+			buf.Write(keyBytes)
+			buf.WriteByte(':')
+			buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+		}
+		buf.WriteByte('}')
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
 
 // ModelPrice represents a single model pricing/capability record.
 type ModelPrice struct {
@@ -32,8 +112,8 @@ type ModelPrice struct {
 	Capabilities        []string                    `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 	SupportedParameters []string                    `json:"supported_parameters,omitempty" yaml:"supported_parameters,omitempty"`
 	Limits              map[string]interface{}      `json:"limits,omitempty" yaml:"limits,omitempty"`
-	Prices              map[string]float64          `json:"prices,omitempty" yaml:"prices,omitempty"`
-	TierPrices          map[string]map[string]float64 `json:"tier_prices,omitempty" yaml:"tier_prices,omitempty"`
+	Prices              PriceMap                    `json:"prices,omitempty" yaml:"prices,omitempty"`
+	TierPrices          TierPriceMap                `json:"tier_prices,omitempty" yaml:"tier_prices,omitempty"`
 	PriceCurrency       string                      `json:"price_currency,omitempty" yaml:"price_currency,omitempty"`
 	Metadata            map[string]interface{}      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 	CreateTime          *int64                      `json:"create_time,omitempty" yaml:"create_time,omitempty"`

--- a/model/imodel_price/validate_test.go
+++ b/model/imodel_price/validate_test.go
@@ -26,7 +26,7 @@ func validModelPrice() *ModelPrice {
 		Model:     "gpt-4",
 		BaseModel: "gpt-4",
 		Mode:      "chat",
-		Prices: map[string]float64{
+		Prices: PriceMap{
 			"input_cost_per_token":  0.001,
 			"output_cost_per_token": 0.002,
 		},
@@ -48,8 +48,8 @@ func TestValidateModelPrice(t *testing.T) {
 		{"missing mode", func() *ModelPrice { p := validModelPrice(); p.Mode = ""; return p }(), true},
 		{"invalid mode", func() *ModelPrice { p := validModelPrice(); p.Mode = "unknown"; return p }(), true},
 		{"missing prices", func() *ModelPrice { p := validModelPrice(); p.Prices = nil; return p }(), true},
-		{"empty prices", func() *ModelPrice { p := validModelPrice(); p.Prices = map[string]float64{}; return p }(), true},
-		{"invalid price key", func() *ModelPrice { p := validModelPrice(); p.Prices = map[string]float64{"invalid_key": 1}; return p }(), true},
+		{"empty prices", func() *ModelPrice { p := validModelPrice(); p.Prices = PriceMap{}; return p }(), true},
+		{"invalid price key", func() *ModelPrice { p := validModelPrice(); p.Prices = PriceMap{"invalid_key": 1}; return p }(), true},
 		{"negative price", func() *ModelPrice { p := validModelPrice(); p.Prices["input_cost_per_token"] = -1; return p }(), true},
 		{"invalid currency", func() *ModelPrice { p := validModelPrice(); p.PriceCurrency = "USD"; return p }(), true},
 		{"valid empty currency", func() *ModelPrice { p := validModelPrice(); p.PriceCurrency = ""; return p }(), false},
@@ -66,35 +66,35 @@ func TestValidateModelPrice(t *testing.T) {
 		{"invalid metadata key", func() *ModelPrice { p := validModelPrice(); p.Metadata = map[string]interface{}{"unknown": 1}; return p }(), true},
 		{"valid tier prices", func() *ModelPrice {
 			p := validModelPrice()
-			p.TierPrices = map[string]map[string]float64{
+			p.TierPrices = TierPriceMap{
 				"peak": {"input_cost_per_token": 0.002},
 			}
 			return p
 		}(), false},
 		{"invalid tier name", func() *ModelPrice {
 			p := validModelPrice()
-			p.TierPrices = map[string]map[string]float64{
+			p.TierPrices = TierPriceMap{
 				"off_peak": {"input_cost_per_token": 0.002},
 			}
 			return p
 		}(), true},
 		{"invalid tier price key", func() *ModelPrice {
 			p := validModelPrice()
-			p.TierPrices = map[string]map[string]float64{
+			p.TierPrices = TierPriceMap{
 				"peak": {"invalid_key": 0.002},
 			}
 			return p
 		}(), true},
 		{"negative tier price", func() *ModelPrice {
 			p := validModelPrice()
-			p.TierPrices = map[string]map[string]float64{
+			p.TierPrices = TierPriceMap{
 				"peak": {"input_cost_per_token": -0.002},
 			}
 			return p
 		}(), true},
 		{"empty tier prices", func() *ModelPrice {
 			p := validModelPrice()
-			p.TierPrices = map[string]map[string]float64{
+			p.TierPrices = TierPriceMap{
 				"peak": {},
 			}
 			return p
@@ -174,9 +174,9 @@ func TestNormalizeCurrency(t *testing.T) {
 }
 
 func TestGroupByProvider(t *testing.T) {
-	a := &ModelPrice{Provider: "p1", Model: "m1", BaseModel: "m1", Mode: "chat", Prices: map[string]float64{"input_cost_per_token": 1}}
-	b := &ModelPrice{Provider: "p2", Model: "m2", BaseModel: "m2", Mode: "chat", Prices: map[string]float64{"input_cost_per_token": 1}}
-	c := &ModelPrice{Provider: "p1", Model: "m3", BaseModel: "m3", Mode: "chat", Prices: map[string]float64{"input_cost_per_token": 1}}
+	a := &ModelPrice{Provider: "p1", Model: "m1", BaseModel: "m1", Mode: "chat", Prices: PriceMap{"input_cost_per_token": 1}}
+	b := &ModelPrice{Provider: "p2", Model: "m2", BaseModel: "m2", Mode: "chat", Prices: PriceMap{"input_cost_per_token": 1}}
+	c := &ModelPrice{Provider: "p1", Model: "m3", BaseModel: "m3", Mode: "chat", Prices: PriceMap{"input_cost_per_token": 1}}
 
 	groups := GroupByProvider([]*ModelPrice{a, b, c})
 	assert.Len(t, groups["p1"], 2)

--- a/storage/rdb/model_price/model_price.go
+++ b/storage/rdb/model_price/model_price.go
@@ -286,22 +286,22 @@ func unmarshalMap(s string) map[string]interface{} {
 	return rst
 }
 
-func unmarshalPriceMap(s string) map[string]float64 {
+func unmarshalPriceMap(s string) imodel_price.PriceMap {
 	if s == "" || s == "null" {
 		return nil
 	}
-	var rst map[string]float64
+	var rst imodel_price.PriceMap
 	if err := json.Unmarshal([]byte(s), &rst); err != nil {
 		return nil
 	}
 	return rst
 }
 
-func unmarshalTierPrices(s string) map[string]map[string]float64 {
+func unmarshalTierPrices(s string) imodel_price.TierPriceMap {
 	if s == "" || s == "null" {
 		return nil
 	}
-	var rst map[string]map[string]float64
+	var rst imodel_price.TierPriceMap
 	if err := json.Unmarshal([]byte(s), &rst); err != nil {
 		return nil
 	}


### PR DESCRIPTION
… (#102)

- Add custom MarshalJSON for PriceMap/TierPriceMap in ai-gateway-api
- Add custom MarshalJSON for PriceMap/TierPriceMap in bfe
- Update sys-design and api-define docs for 8-decimal price precision
- Add modification docs under design-docs/modifications/

Fixes https://github.com/rainway-ai-gateway/ai-gateway-api/issues/102