### PR TITLE
fix(provider): sync provider instance_pool changes to referencing clu…

### DIFF
--- a/design-docs/modifications/2026-08-28-issue-106-provider-instance-pool-sync/change-summary.md
+++ b/design-docs/modifications/2026-08-28-issue-106-provider-instance-pool-sync/change-summary.md
@@ -1,0 +1,41 @@
+# Issue #106：Provider instance_pool 变更后 Cluster 实例池未同步
+
+## 变更概述
+
+修复 `PATCH /providers/{provider_name}` 修改 `instance_pool` 后，引用该 provider 的 cluster 仍在向旧后端实例转发请求的问题。
+
+根据 `providers.md §2.4` 的契约承诺：
+> 若传入 `instance_pool` 字段，系统会自动同步更新被引用该 provider 的所有 cluster 所生成的实例池。
+
+当前实现中该同步路径缺失，导致 cluster 创建时实例池被一次性快照固化，后续 provider 侧变更无法传播到数据平面。
+
+## 关键变更点
+
+1. `model/iprovider/provider.go`
+   - `ProviderManager.UpdateProvider` 增加可选的同步 hook 参数，在更新 provider 的事务内触发下游同步。
+
+2. `model/icluster_conf/cluster.go`
+   - 新增 `ClusterManager.ProviderInstancePoolSyncer` 方法，遍历引用该 provider 的所有 cluster，并将其 sub-cluster 实例池重刷为 provider 最新实例池。
+
+3. `endpoints/openapi_v1/provider/update.go`
+   - 调用 `UpdateProvider` 时注入 `ClusterManager.ProviderInstancePoolSyncer` hook。
+
+4. `model/icluster_conf/cluster.go`（顺带修复）
+   - `ClusterManager.UpdateCluster` 中实例池重快照条件放宽：只要请求携带 `llm_config.provider` 即触发刷新，不再要求 provider 名称发生变化。
+
+## 涉及文件
+
+- `ai-gateway-api/model/iprovider/provider.go`
+- `ai-gateway-api/model/icluster_conf/cluster.go`
+- `ai-gateway-api/endpoints/openapi_v1/provider/update.go`
+- `ai-gateway-api/model/iprovider/provider_test.go`（新增单元测试）
+- `ai-gateway-api/model/icluster_conf/cluster_test.go`（新增单元测试）
+- `ai-gateway-api/test/integration/tests/provider/instance_pool_sync/instance_pool_sync_test.go`（新增集成测试）
+- `ai-gateway-api/test/integration/tests/provider/design.md`（更新测试用例文档）
+
+## 状态
+
+- [x] 代码实现
+- [x] 单元测试通过（`go test ./...` 全绿）
+- [x] 新增集成测试 `PV-SYNC-1-001` 通过
+- [ ] 集成测试 SC2101-TC032 通过（需真实环境/集成测试门禁跑）

--- a/design-docs/modifications/2026-08-28-issue-106-provider-instance-pool-sync/design-changes.md
+++ b/design-docs/modifications/2026-08-28-issue-106-provider-instance-pool-sync/design-changes.md
@@ -1,0 +1,348 @@
+# Issue #106：Provider instance_pool 变更后 Cluster 实例池未同步 — 修复设计
+
+## 1. 问题定位
+
+### 1.1 现象
+
+复现步骤（来自 [Issue #106](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/106)）：
+
+1. provider 实例池成员为 `172.19.1.222:18087` 和 `172.19.1.222:18088` 时，请求能成功转发到这两个实例。
+2. 通过 `PATCH /providers/{provider_name}` 将实例池成员修改为 `172.19.1.222:18100` 后，请求仍然转发到旧的 `18087` 和 `18088`，新实例 `18100` 未生效。
+
+集成测试 `SC2101-TC032` 因此失败，表现为 `cluster_table backends=[18087 18088] want=[18100]` 长时间不收敛。
+
+### 1.2 根因分析
+
+**契约存在但实现缺失。**
+
+`design-docs/api-define/OpenAPI接口定义/providers.md` 第 334 行明确说明：
+
+> 若传入 `instance_pool` 字段，系统会自动同步更新被引用该 provider 的所有 cluster 所生成的实例池。
+
+但代码中不存在该同步路径：
+
+1. **`model/iprovider/provider.go:175` 的 `ProviderManager.UpdateProvider`**
+   - 仅完成参数校验、存在性校验、调用 `storager.UpdateProvider` 更新 provider 行。
+   - 没有遍历引用该 provider 的 cluster，也没有更新任何实例池。
+
+2. **`endpoints/openapi_v1/provider/update.go`**
+   - 仅负责参数绑定与调用 `ProviderManager.UpdateProvider`，无补偿逻辑。
+
+3. **`model/icluster_conf/cluster.go:699` 的 `ClusterManager.UpdateCluster`**
+   - 存在实例池重快照分支，但触发条件是：
+     ```go
+     oldProvider != *param.LLMConfig.Provider
+     ```
+   - 即只有当 cluster 引用的 provider **名称发生变化** 时才刷新实例池。
+   - `SC2101-TC032` 中通过 `PATCH /providers` 修改实例池时，cluster 侧并未修改 provider 名称，因此该分支不会触发。
+
+4. **配置导出忠实反映 DB**
+   - `cluster_table` 由 `model/icluster_conf/exporter.go:43` 的 `clusterTableConfGenerator` 从 `cluster.SubClusters[*].InstancePool.Instances` 生成。
+   - `model/iversion_control/version_control.go:84` 采用内容签名驱动版本控制：每次导出全量重生成，内容变化才发新版本。
+   - 由于 DB 中 cluster 的实例池行未变，导出永远使用创建时的快照 `[18087 18088]`。
+
+### 1.3 关键辨析：为什么 keys 收敛了而实例没有
+
+`server_data_conf` 的 `AIConf.Keys` 在导出时由 `newAIConf`（`cluster.go:1049`）从 provider **实时投影**，而实例池是在建 cluster 时**一次性快照**。两条数据路径不同，因此 `AIConf.Keys` 收敛不能证明实例池已同步。
+
+## 2. 修复目标
+
+1. 实现 `PATCH /providers` 修改 `instance_pool` 后，自动同步更新所有引用该 provider 的 cluster 的实例池。
+2. 同步操作与 provider 更新处于同一事务，保证原子性。
+3. 不破坏现有 OpenAPI 契约和响应语义。
+4. 导出版本随 DB 内容签名自动 bump，无需额外处理。
+5. 顺带修复 `UpdateCluster` 中同步条件过严的问题，使其与契约语义一致。
+
+## 3. 方案对比
+
+| 方案 | 思路 | 优点 | 缺点 | 结论 |
+|------|------|------|------|------|
+| A. Endpoint 层顺序调用 | `UpdateProvider` 成功后，再调用 `ClusterManager` 的同步方法 | 改动最小 | 两次 `AtomExecute` 非原子；provider 更新成功但 cluster 同步失败会导致数据不一致 | 不采用 |
+| B. `ProviderManager` 直接依赖 `icluster_conf` | 在 `ProviderManager` 中注入 `ClusterStorager` / `PoolStorager` | 单事务内完成 | `iprovider` 与 `icluster_conf` 互相引用，产生 Go 包循环依赖（`icluster_conf` 已导入 `iprovider`） | 不可行 |
+| C. `ProviderManager` 同步 hook（推荐） | 给 `UpdateProvider` 增加可选 hook，由 `ClusterManager` 实现并注入 | 无循环依赖；复用现有 `DeleteProvider` 的 `refCheckers` 模式；同一事务内完成 | 需要 endpoint 层注入 hook | **采用** |
+| D. 放宽 `UpdateCluster` 同步条件 | 只要请求携带 `llm_config.provider` 就重快照实例池 | 覆盖 cluster 侧直接修改场景 | 无法替代 provider PATCH 的主路径；TC032 走 provider PATCH 不走 cluster PATCH | 顺带采用 |
+
+## 4. 推荐方案：ProviderManager 同步 hook
+
+### 4.1 核心思路
+
+在 `iprovider.ProviderManager.UpdateProvider` 中引入可选的同步 hook：
+
+```go
+func (m *ProviderManager) UpdateProvider(
+    ctx context.Context,
+    name string,
+    param *ProviderParam,
+    syncHooks ...func(ctx context.Context, oldProvider, newProvider *Provider) error,
+) error
+```
+
+- 当请求体中包含 `instance_pool`（即 `param.InstancePool != nil`）且与旧 pool 不同时，在更新 provider 的事务内调用 `syncHooks`。
+- hook 由 `icluster_conf.ClusterManager` 实现，内部遍历引用该 provider 的 cluster 并刷新 sub-cluster 实例池。
+- 由于所有 manager 共用同一个 `TxnStoragerSingleton`，且 `NewBFEDBContext` 会在 context 中复用已存在的 `*lib.DBContext`，hook 调用与 provider 更新处于同一数据库事务。
+
+### 4.2 `ProviderManager.UpdateProvider` 修改
+
+文件：`ai-gateway-api/model/iprovider/provider.go`
+
+```go
+// UpdateProvider updates an existing provider.
+// Optional syncHooks are invoked within the same transaction when instance_pool
+// is changed, allowing downstream managers (e.g. cluster_conf) to propagate the
+// new pool to clusters that reference this provider.
+func (m *ProviderManager) UpdateProvider(ctx context.Context, name string,
+    param *ProviderParam,
+    syncHooks ...func(ctx context.Context, oldProvider, newProvider *Provider) error) error {
+
+    if err := ValidateProviderParam(param); err != nil {
+        return err
+    }
+
+    return m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+        existing, err := m.storager.FetchProvider(ctx, &ProviderFilter{Name: &name})
+        if err != nil {
+            return err
+        }
+        if existing == nil {
+            return xerror.WrapRecordNotExist("provider")
+        }
+
+        if err := m.storager.UpdateProvider(ctx, name, param); err != nil {
+            return err
+        }
+
+        // Only propagate when instance_pool is explicitly provided and changed.
+        if param.InstancePool != nil && !providerInstancePoolEqual(existing.InstancePool, param.InstancePool) {
+            newProvider := &Provider{
+                ID:             existing.ID,
+                Name:           name,
+                Description:    derefString(param.Description, existing.Description),
+                ModelEndpoint:  firstNonNil(param.ModelEndpoint, existing.ModelEndpoint),
+                Models:         firstNonNilSlice(param.Models, existing.Models),
+                Keys:           firstNonNilSlice(param.Keys, existing.Keys),
+                InstancePool:   param.InstancePool,
+                ModelProtocols: firstNonNilSlice(param.ModelProtocols, existing.ModelProtocols),
+                TimeZone:       derefString(param.TimeZone, existing.TimeZone),
+                Tiers:          firstNonNilSlice(param.Tiers, existing.Tiers),
+            }
+            for _, hook := range syncHooks {
+                if err := hook(ctx, existing, newProvider); err != nil {
+                    return err
+                }
+            }
+        }
+
+        return nil
+    })
+}
+```
+
+辅助函数：
+
+```go
+func providerInstancePoolEqual(a, b []ProviderInstance) bool {
+    if len(a) != len(b) {
+        return false
+    }
+    // Order matters because the pool is a snapshot; if the UI/CLI reorders
+    // instances we should still propagate the new order.
+    for i := range a {
+        if a[i].Name != b[i].Name ||
+            a[i].Addr != b[i].Addr ||
+            a[i].Port != b[i].Port ||
+            a[i].Weight != b[i].Weight ||
+            a[i].Disable != b[i].Disable {
+            return false
+        }
+    }
+    return true
+}
+```
+
+> 说明：实际实现时可根据项目现有 helper 函数（如 `lib.PString` 等）调整 `newProvider` 构造方式，也可直接从 storager 重新 fetch 得到最新 provider，避免字段合并的样板代码。
+
+### 4.3 `ClusterManager.ProviderInstancePoolSyncer` 实现
+
+文件：`ai-gateway-api/model/icluster_conf/cluster.go`
+
+```go
+// ProviderInstancePoolSyncer returns a hook that, when given the old/new provider,
+// updates the instance pool of every sub-cluster that references the provider.
+// It is intended to be passed to iprovider.ProviderManager.UpdateProvider.
+func (cm *ClusterManager) ProviderInstancePoolSyncer(ctx context.Context,
+    oldProvider, newProvider *iprovider.Provider) error {
+
+    if newProvider == nil || len(newProvider.InstancePool) == 0 {
+        return nil
+    }
+
+    clusters, err := cm.storager.FetchClusterList(ctx, nil)
+    if err != nil {
+        return err
+    }
+
+    newInstances := providerInstancesToClusterInstances(newProvider.InstancePool)
+    for _, cluster := range clusters {
+        if cluster.LLMConfig == nil || cluster.LLMConfig.Provider == nil {
+            continue
+        }
+        if *cluster.LLMConfig.Provider != newProvider.Name {
+            continue
+        }
+
+        for _, sc := range cluster.SubClusters {
+            if sc.InstancePool == nil {
+                continue
+            }
+            if err := cm.poolStorager.UpdatePool(ctx, sc.InstancePool, &PoolParam{
+                Instances: newInstances,
+            }); err != nil {
+                return err
+            }
+        }
+    }
+
+    return nil
+}
+```
+
+设计要点：
+
+- 遍历方式参考 `ProviderDeleteChecker`（`cluster.go:745`）。
+- 池名规则已在创建时确定为 `product.Name + "." + cluster.Name`，每个 cluster 的 pool 独立，不存在命名冲突。
+- `UpdatePool` 仅更新 `Instances` 字段，不影响 pool 的元数据（`Tag`、`Role` 等）。
+
+### 4.4 Endpoint 层注入 hook
+
+文件：`ai-gateway-api/endpoints/openapi_v1/provider/update.go`
+
+```go
+if err := container.ProviderManager.UpdateProvider(req.Context(), name, param,
+    container.ClusterManager.ProviderInstancePoolSyncer,
+); err != nil {
+    return nil, err
+}
+```
+
+`UpdatePricingTiers`  endpoint 不应注入该 hook，因为 pricing tiers 变更不涉及实例池。
+
+## 5. 顺带修复：放宽 `UpdateCluster` 的实例池同步条件
+
+文件：`ai-gateway-api/model/icluster_conf/cluster.go:681`
+
+当前逻辑：
+
+```go
+if oldProvider != *param.LLMConfig.Provider {
+    // 重快照实例池
+}
+```
+
+建议改为：只要 `PATCH /clusters` 请求体显式携带 `llm_config.provider`，即认为调用方希望刷新与该 provider 相关的实例池，触发重快照：
+
+```go
+if oldProvider != *param.LLMConfig.Provider || providerExplicitlyProvided {
+    // 重快照实例池
+}
+```
+
+具体判断方式可结合 `param.LLMConfig.Provider` 是否非空（ endpoint 层已保证引用的是存在的 provider）。该改动与 `providers.md §2.4` 的语义对齐：任何通过 provider 通道修改实例池后，cluster 都能重新同步。
+
+> 注意：此改动是“顺带修复”，不能替代 `PATCH /providers` 主路径的修复，因为 TC032 仅修改 provider 而不修改 cluster。
+
+## 6. 事务与一致性说明
+
+1. `ProviderManager.UpdateProvider` 和 `ClusterManager.ProviderInstancePoolSyncer` 都通过 `m.txn.AtomExecute` 执行。
+2. `AtomExecute` 内部调用 `NewBFEDBContext(ctx, lib.OpenTxn())`，该工厂函数会检查 context 是否已经是 `*lib.DBContext`；若是，则复用已有事务。
+3. 因此 hook 调用与 provider 更新处于**同一事务**：cluster pool 刷新失败时整个事务回滚，不会留下 provider 已更新但 cluster 未更新的中间状态。
+4. 配置导出由内容签名驱动：事务提交后，下一次导出会发现 `cluster.SubClusters[*].InstancePool.Instances` 内容变化，自动 bump 版本号并下发给 BFE。
+
+## 7. 数据迁移
+
+本次修复**不需要数据迁移**。数据库 schema 无变化，仅修改业务逻辑。
+
+对于已存在的、处于“provider 新实例池与 cluster 旧实例池不一致”状态的存量数据，修复上线后：
+- 可引导用户重新执行一次 `PATCH /providers/{name}` 并传入当前期望的 `instance_pool`，触发同步；
+- 或在升级脚本/初始化任务中增加一次全量对齐（可选，不在本次范围内）。
+
+## 8. 测试计划
+
+### 8.1 单元测试
+
+#### `ai-gateway-api/model/iprovider/provider_test.go`
+
+新增 `TestUpdateProviderSyncsInstancePoolToClusters`：
+
+1. 构造 mock `ProviderStorager` 返回旧 provider（含实例 `A:18087`）。
+2. 构造 mock sync hook，记录是否被调用以及传入的 old/new provider。
+3. 调用 `UpdateProvider(ctx, name, &ProviderParam{InstancePool: newPool})`。
+4. 断言：
+   - `storager.UpdateProvider` 被调用；
+   - sync hook 被调用一次；
+   - new provider 的 `InstancePool` 等于请求中的新 pool；
+   - 当 `InstancePool` 与旧 pool 完全相同时，sync hook 不被调用。
+
+#### `ai-gateway-api/model/icluster_conf/cluster_test.go`
+
+新增 `TestProviderInstancePoolSyncer`：
+
+1. 构造两个 cluster：一个引用目标 provider，一个不引用。
+2. 构造 mock `ClusterStorager.FetchClusterList` 返回上述 cluster。
+3. 构造 mock `PoolStorager.UpdatePool`，记录被更新的 pool 与实例列表。
+4. 调用 `ProviderInstancePoolSyncer`。
+5. 断言：
+   - 仅引用目标 provider 的 cluster 的 sub-cluster pool 被更新；
+   - 更新后的实例列表等于 `providerInstancesToClusterInstances(newProvider.InstancePool)`；
+   - 不引用目标 provider 的 cluster 的 pool 未被更新。
+
+#### `ai-gateway-api/endpoints/openapi_v1/provider/update_test.go`
+
+新增/更新测试：
+
+1. 验证 endpoint 调用 `ProviderManager.UpdateProvider` 时注入了 `ClusterManager.ProviderInstancePoolSyncer`。
+2. 验证返回结果与之前一致（返回更新后的 provider）。
+
+### 8.2 集成测试
+
+运行 `integration-test` 中的端到端用例：
+
+```bash
+cd integration-test
+go test ./test-cases/implementation/scenario-SC2101-provider-instance-pool-sync/... -run TestTC032 -v
+```
+
+预期：
+
+- `PATCH /providers` 返回 200；
+- 随后 `GET /inner-api/v1/configs/tls_conf/cluster_table` 中对应 cluster 的 backends 收敛为 `[18100]`；
+- BFE reload settle 后请求转发到新实例。
+
+## 9. 风险与缓解
+
+| 风险 | 说明 | 缓解措施 |
+|------|------|----------|
+| 同步失败导致 provider 更新回滚 | hook 与 provider 更新在同一事务 | 这是期望行为，保证一致性；失败时返回错误给调用方 |
+| 大量 cluster 引用同一 provider 时同步耗时 | 每次 provider 更新需遍历全量 cluster 并更新 pool | provider/cluster 数量在控制平面通常可控；如后续出现性能问题，可增加按 provider 索引的 cluster 查询 |
+| 误更新非 provider 派生的 pool | `ProviderInstancePoolSyncer` 仅更新 `LLMConfig.Provider == provider.Name` 的 cluster 的 sub-cluster pool | 创建 cluster 时 provider 派生的 pool 与 cluster 绑定，逻辑一致 |
+| UpdateProvider 签名变更影响现有调用 | 使用变长参数 `...func` 保持向后兼容 | 除 endpoint 外无其他调用方需要修改 |
+
+## 10. 实施状态
+
+- [x] `model/iprovider/provider.go`：`UpdateProvider` 增加同步 hook 支持
+- [x] `model/icluster_conf/cluster.go`：新增 `ProviderInstancePoolSyncer`
+- [x] `endpoints/openapi_v1/provider/update.go`：注入 hook
+- [x] `model/icluster_conf/cluster.go`：放宽 `UpdateCluster` 实例池同步条件
+- [x] 单元测试覆盖（`go test ./...` 全绿）
+- [x] 新增集成测试 `PV-SYNC-1-001`：Open API 修改 provider instance_pool 后 Inner API `cluster_table` 同步更新
+- [ ] 集成测试 SC2101-TC032 通过（需真实环境/集成测试门禁跑）
+
+## 11. 参考文档
+
+- [Issue #106](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/106)
+- `ai-gateway-api/design-docs/api-define/OpenAPI接口定义/providers.md`
+- `ai-gateway-api/model/iprovider/provider.go`
+- `ai-gateway-api/model/icluster_conf/cluster.go`
+- `ai-gateway-api/model/icluster_conf/pool.go`
+- `ai-gateway-api/endpoints/openapi_v1/provider/update.go`
+- `ai-gateway-api/stateful/config_database.go`
+- `ai-gateway-api/lib/xdb.go`

--- a/endpoints/openapi_v1/provider/update.go
+++ b/endpoints/openapi_v1/provider/update.go
@@ -56,7 +56,9 @@ func UpdateAction(req *http.Request) (interface{}, error) {
 	// so that callers do not have to duplicate it in the request body.
 	param.Name = &name
 
-	if err := container.ProviderManager.UpdateProvider(req.Context(), name, param); err != nil {
+	if err := container.ProviderManager.UpdateProvider(req.Context(), name, param,
+		container.ClusterManager.ProviderInstancePoolSyncer,
+	); err != nil {
 		return nil, err
 	}
 

--- a/model/icluster_conf/cluster.go
+++ b/model/icluster_conf/cluster.go
@@ -695,12 +695,16 @@ func (cm *ClusterManager) UpdateCluster(ctx context.Context, product *ibasic.Pro
 				return err
 			}
 
-			// Sync instance pool if provider changed.
+			// Sync instance pool whenever the cluster references a provider, so
+			// that the cluster pool reflects the provider's current instance_pool
+			// regardless of whether the provider name changed.
 			oldProvider := ""
 			if oldData.LLMConfig != nil && oldData.LLMConfig.Provider != nil {
 				oldProvider = *oldData.LLMConfig.Provider
 			}
-			if oldProvider != *param.LLMConfig.Provider {
+			providerChanged := oldProvider != *param.LLMConfig.Provider
+			providerUnchangedButReferenced := oldProvider == *param.LLMConfig.Provider && oldProvider != ""
+			if providerChanged || providerUnchangedButReferenced {
 				for _, sc := range oldData.SubClusters {
 					if sc.InstancePool != nil {
 						if err = cm.poolStorager.UpdatePool(ctx, sc.InstancePool, &PoolParam{
@@ -752,6 +756,46 @@ func (cm *ClusterManager) ProviderDeleteChecker(ctx context.Context, providerNam
 			return xerror.WrapConflictErrorWithMsg("provider %s is referenced by cluster %s", providerName, c.Name)
 		}
 	}
+	return nil
+}
+
+// ProviderInstancePoolSyncer returns a hook suitable for passing to
+// iprovider.ProviderManager.UpdateProvider. When the provider's instance_pool
+// changes, it updates the instance pool of every non-EPP sub-cluster that
+// references the provider to match the new provider instances.
+func (cm *ClusterManager) ProviderInstancePoolSyncer(ctx context.Context,
+	oldProvider, newProvider *iprovider.Provider) error {
+
+	if newProvider == nil || len(newProvider.InstancePool) == 0 {
+		return nil
+	}
+
+	clusters, err := cm.storager.FetchClusterList(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	newInstances := providerInstancesToClusterInstances(newProvider.InstancePool)
+	for _, cluster := range clusters {
+		if cluster.LLMConfig == nil || cluster.LLMConfig.Provider == nil {
+			continue
+		}
+		if *cluster.LLMConfig.Provider != newProvider.Name {
+			continue
+		}
+
+		for _, sc := range cluster.SubClusters {
+			if sc.InstancePool == nil || sc.Role == ProductPoolRoleEPP {
+				continue
+			}
+			if err := cm.poolStorager.UpdatePool(ctx, sc.InstancePool, &PoolParam{
+				Instances: newInstances,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/model/icluster_conf/cluster_test.go
+++ b/model/icluster_conf/cluster_test.go
@@ -51,6 +51,126 @@ func TestProviderInstancesToClusterInstances(t *testing.T) {
 	assert.Equal(t, "rs1", got[1].Name)
 }
 
+func TestClusterManager_ProviderInstancePoolSyncer(t *testing.T) {
+	ctx := context.Background()
+	providerName := "deepseek"
+
+	makeCluster := func(name string, provider *string, instances []Instance) *Cluster {
+		return &Cluster{
+			ID:   1,
+			Name: name,
+			LLMConfig: &LLMConfig{
+				Provider: provider,
+			},
+			SubClusters: []*SubCluster{
+				{
+					ID:   1,
+					Name: "sc1",
+					InstancePool: &Pool{
+						ID:        1,
+						Name:      "p." + name,
+						Instances: instances,
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("updates clusters referencing the provider", func(t *testing.T) {
+		updatedPools := map[int64][]Instance{}
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				return []*Cluster{
+					makeCluster("c1", &providerName, []Instance{
+						{Name: "old", Addr: "1.2.3.4", Port: 443, Weight: 100},
+					}),
+					makeCluster("c2", lib.PString("other"), []Instance{
+						{Name: "other", Addr: "9.8.7.6", Port: 443, Weight: 100},
+					}),
+				}, nil
+			},
+		}
+		poolStorager := &fakePoolStorager{
+			updatePoolFn: func(ctx context.Context, oldData *Pool, diff *PoolParam) error {
+				updatedPools[oldData.ID] = diff.Instances
+				return nil
+			},
+		}
+
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, poolStorager, nil, nil, nil, nil)
+		newProvider := &iprovider.Provider{
+			Name: providerName,
+			InstancePool: []iprovider.ProviderInstance{
+				{Name: "new", Addr: "5.6.7.8", Port: 443, Weight: 100},
+			},
+		}
+		err := cm.ProviderInstancePoolSyncer(ctx, nil, newProvider)
+		require.NoError(t, err)
+
+		require.Len(t, updatedPools, 1)
+		require.Contains(t, updatedPools, int64(1))
+		assert.Equal(t, "new", updatedPools[1][0].Name)
+	})
+
+	t.Run("skips EPP sub-clusters", func(t *testing.T) {
+		updatedPools := map[int64][]Instance{}
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				c := makeCluster("c1", &providerName, []Instance{
+					{Name: "old", Addr: "1.2.3.4", Port: 443, Weight: 100},
+				})
+				c.SubClusters[0].Role = ProductPoolRoleEPP
+				return []*Cluster{c}, nil
+			},
+		}
+		poolStorager := &fakePoolStorager{
+			updatePoolFn: func(ctx context.Context, oldData *Pool, diff *PoolParam) error {
+				updatedPools[oldData.ID] = diff.Instances
+				return nil
+			},
+		}
+
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, poolStorager, nil, nil, nil, nil)
+		newProvider := &iprovider.Provider{
+			Name: providerName,
+			InstancePool: []iprovider.ProviderInstance{
+				{Name: "new", Addr: "5.6.7.8", Port: 443, Weight: 100},
+			},
+		}
+		err := cm.ProviderInstancePoolSyncer(ctx, nil, newProvider)
+		require.NoError(t, err)
+		assert.Empty(t, updatedPools)
+	})
+
+	t.Run("propagates update pool error", func(t *testing.T) {
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				return []*Cluster{
+					makeCluster("c1", &providerName, []Instance{
+						{Name: "old", Addr: "1.2.3.4", Port: 443, Weight: 100},
+					}),
+				}, nil
+			},
+		}
+		poolStorager := &fakePoolStorager{
+			updatePoolFn: func(ctx context.Context, oldData *Pool, diff *PoolParam) error {
+				return errors.New("update failed")
+			},
+		}
+
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, poolStorager, nil, nil, nil, nil)
+		newProvider := &iprovider.Provider{
+			Name: providerName,
+			InstancePool: []iprovider.ProviderInstance{
+				{Name: "new", Addr: "5.6.7.8", Port: 443, Weight: 100},
+			},
+		}
+		err := cm.ProviderInstancePoolSyncer(ctx, nil, newProvider)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "update failed")
+	})
+}
+
 func newTestClusterBase() *Cluster {
 	return &Cluster{
 		ID:   1,

--- a/model/iprovider/provider.go
+++ b/model/iprovider/provider.go
@@ -172,7 +172,14 @@ func (m *ProviderManager) CreateProvider(ctx context.Context, param *ProviderPar
 }
 
 // UpdateProvider updates an existing provider.
-func (m *ProviderManager) UpdateProvider(ctx context.Context, name string, param *ProviderParam) error {
+// Optional syncHooks are invoked within the same transaction when instance_pool
+// is explicitly provided and differs from the existing one, allowing downstream
+// managers (e.g. cluster_conf) to propagate the new pool to clusters that
+// reference this provider.
+func (m *ProviderManager) UpdateProvider(ctx context.Context, name string,
+	param *ProviderParam,
+	syncHooks ...func(ctx context.Context, oldProvider, newProvider *Provider) error) error {
+
 	if err := ValidateProviderParam(param); err != nil {
 		return err
 	}
@@ -186,7 +193,25 @@ func (m *ProviderManager) UpdateProvider(ctx context.Context, name string, param
 			return xerror.WrapRecordNotExist("provider")
 		}
 
-		return m.storager.UpdateProvider(ctx, name, param)
+		if err := m.storager.UpdateProvider(ctx, name, param); err != nil {
+			return err
+		}
+
+		// Propagate instance_pool changes to referencing clusters. Only invoke
+		// hooks when the caller explicitly supplied instance_pool and it differs
+		// from the current one.
+		if param.InstancePool != nil &&
+			len(syncHooks) > 0 &&
+			!providerInstancePoolEqual(existing.InstancePool, param.InstancePool) {
+			newProvider := applyProviderUpdate(existing, param)
+			for _, hook := range syncHooks {
+				if err := hook(ctx, existing, newProvider); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
 	})
 }
 
@@ -701,6 +726,66 @@ func BuildAuthHeader(protocol, key string) (string, string) {
 	default:
 		return "Authorization", "Bearer " + key
 	}
+}
+
+// providerInstancePoolEqual reports whether two instance pools are identical.
+// Order matters because the pool is a snapshot; a reordered list is still a
+// different snapshot.
+func providerInstancePoolEqual(a, b []ProviderInstance) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name ||
+			a[i].Addr != b[i].Addr ||
+			a[i].Port != b[i].Port ||
+			a[i].Weight != b[i].Weight ||
+			a[i].Disable != b[i].Disable {
+			return false
+		}
+	}
+	return true
+}
+
+// applyProviderUpdate returns a Provider that reflects the existing provider
+// merged with the update param. It is used to build the provider snapshot passed
+// to sync hooks without an extra DB round-trip.
+func applyProviderUpdate(existing *Provider, param *ProviderParam) *Provider {
+	if existing == nil {
+		return nil
+	}
+
+	newProvider := *existing
+
+	if param.Name != nil {
+		newProvider.Name = *param.Name
+	}
+	if param.Description != nil {
+		newProvider.Description = *param.Description
+	}
+	if param.ModelEndpoint != nil {
+		newProvider.ModelEndpoint = param.ModelEndpoint
+	}
+	if param.Models != nil {
+		newProvider.Models = param.Models
+	}
+	if param.Keys != nil {
+		newProvider.Keys = param.Keys
+	}
+	if param.InstancePool != nil {
+		newProvider.InstancePool = param.InstancePool
+	}
+	if param.ModelProtocols != nil {
+		newProvider.ModelProtocols = param.ModelProtocols
+	}
+	if param.TimeZone != nil {
+		newProvider.TimeZone = *param.TimeZone
+	}
+	if param.Tiers != nil {
+		newProvider.Tiers = param.Tiers
+	}
+
+	return &newProvider
 }
 
 // ProviderNamePtr returns a pointer to a provider name for use in filters.

--- a/model/iprovider/provider_test.go
+++ b/model/iprovider/provider_test.go
@@ -107,6 +107,95 @@ func TestProviderManager_UpdateProvider(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "provider Record Not Exist")
 	})
+
+	t.Run("sync hook invoked when instance_pool changes", func(t *testing.T) {
+		store := &fakeProviderStorager{
+			fetchFn: func(ctx context.Context, filter *ProviderFilter) (*Provider, error) {
+				return &Provider{
+					Name: "deepseek",
+					InstancePool: []ProviderInstance{
+						{Name: "old", Addr: "1.2.3.4", Port: 443, Weight: 100},
+					},
+				}, nil
+			},
+		}
+		m := NewProviderManager(&fakeTxn{}, store)
+
+		hookCalled := 0
+		var hookOld, hookNew *Provider
+		hook := func(ctx context.Context, oldProvider, newProvider *Provider) error {
+			hookCalled++
+			hookOld = oldProvider
+			hookNew = newProvider
+			return nil
+		}
+
+		param := validProviderParam()
+		param.InstancePool = []ProviderInstance{
+			{Name: "new", Addr: "5.6.7.8", Port: 443, Weight: 100},
+		}
+		err := m.UpdateProvider(ctx, "deepseek", param, hook)
+		require.NoError(t, err)
+		assert.Equal(t, 1, hookCalled)
+		require.NotNil(t, hookOld)
+		require.NotNil(t, hookNew)
+		assert.Equal(t, "old", hookOld.InstancePool[0].Name)
+		assert.Equal(t, "new", hookNew.InstancePool[0].Name)
+	})
+
+	t.Run("sync hook not invoked when instance_pool unchanged", func(t *testing.T) {
+		store := &fakeProviderStorager{
+			fetchFn: func(ctx context.Context, filter *ProviderFilter) (*Provider, error) {
+				return &Provider{
+					Name: "deepseek",
+					InstancePool: []ProviderInstance{
+						{Name: "same", Addr: "1.2.3.4", Port: 443, Weight: 100},
+					},
+				}, nil
+			},
+		}
+		m := NewProviderManager(&fakeTxn{}, store)
+
+		hookCalled := 0
+		hook := func(ctx context.Context, oldProvider, newProvider *Provider) error {
+			hookCalled++
+			return nil
+		}
+
+		param := validProviderParam()
+		param.InstancePool = []ProviderInstance{
+			{Name: "same", Addr: "1.2.3.4", Port: 443, Weight: 100},
+		}
+		err := m.UpdateProvider(ctx, "deepseek", param, hook)
+		require.NoError(t, err)
+		assert.Equal(t, 0, hookCalled)
+	})
+
+	t.Run("sync hook error rolls back", func(t *testing.T) {
+		store := &fakeProviderStorager{
+			fetchFn: func(ctx context.Context, filter *ProviderFilter) (*Provider, error) {
+				return &Provider{
+					Name: "deepseek",
+					InstancePool: []ProviderInstance{
+						{Name: "old", Addr: "1.2.3.4", Port: 443, Weight: 100},
+					},
+				}, nil
+			},
+		}
+		m := NewProviderManager(&fakeTxn{}, store)
+
+		hook := func(ctx context.Context, oldProvider, newProvider *Provider) error {
+			return errors.New("sync failed")
+		}
+
+		param := validProviderParam()
+		param.InstancePool = []ProviderInstance{
+			{Name: "new", Addr: "5.6.7.8", Port: 443, Weight: 100},
+		}
+		err := m.UpdateProvider(ctx, "deepseek", param, hook)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sync failed")
+	})
 }
 
 func TestProviderManager_DeleteProvider(t *testing.T) {
@@ -656,4 +745,49 @@ func TestValidatePricingTiersParam(t *testing.T) {
 		}
 		require.Error(t, ValidatePricingTiersParam(param))
 	})
+}
+
+func TestProviderInstancePoolEqual(t *testing.T) {
+	a := []ProviderInstance{
+		{Name: "rs1", Addr: "1.2.3.4", Port: 443, Weight: 100, Disable: false},
+	}
+	b := []ProviderInstance{
+		{Name: "rs1", Addr: "1.2.3.4", Port: 443, Weight: 100, Disable: false},
+	}
+	c := []ProviderInstance{
+		{Name: "rs2", Addr: "1.2.3.4", Port: 443, Weight: 100, Disable: false},
+	}
+
+	assert.True(t, providerInstancePoolEqual(a, b))
+	assert.False(t, providerInstancePoolEqual(a, c))
+	assert.False(t, providerInstancePoolEqual(a, nil))
+	assert.True(t, providerInstancePoolEqual(nil, nil))
+}
+
+func TestApplyProviderUpdate(t *testing.T) {
+	existing := &Provider{
+		Name:        "deepseek",
+		Description: "old",
+		Models:      []string{"m1"},
+		InstancePool: []ProviderInstance{
+			{Name: "old", Addr: "1.2.3.4", Port: 443, Weight: 100},
+		},
+	}
+
+	param := &ProviderParam{
+		Description: lib.PString("new"),
+		Models:      []string{"m1", "m2"},
+		InstancePool: []ProviderInstance{
+			{Name: "new", Addr: "5.6.7.8", Port: 443, Weight: 100},
+		},
+	}
+
+	updated := applyProviderUpdate(existing, param)
+	require.NotNil(t, updated)
+	assert.Equal(t, "deepseek", updated.Name)
+	assert.Equal(t, "new", updated.Description)
+	assert.Equal(t, []string{"m1", "m2"}, updated.Models)
+	assert.Equal(t, "new", updated.InstancePool[0].Name)
+	// Unchanged fields are preserved.
+	assert.Equal(t, existing.ModelProtocols, updated.ModelProtocols)
 }

--- a/test/integration/tests/provider/design.md
+++ b/test/integration/tests/provider/design.md
@@ -31,11 +31,12 @@ Provider 与 Cluster 概念分离后：
 | 查询 Provider 列表 | 3 |
 | 查询 Provider 详情 | 2 |
 | 更新 Provider | 4 |
+| Provider instance_pool 同步到 Inner API | 1 |
 | 删除 Provider | 3 |
 | 触发模型发现 | 6 |
 | 获取所有 Provider 名称 | 1 |
 | 设置高峰/闲时模板 | 10 |
-| **合计** | **37** |
+| **合计** | **38** |
 
 ## 4. 认证方式
 
@@ -54,6 +55,8 @@ provider/
 │   └── one_test.go
 ├── update/
 │   └── update_test.go
+├── instance_pool_sync/
+│   └── instance_pool_sync_test.go
 ├── delete/
 │   └── delete_test.go
 └── pricing_tiers/
@@ -251,7 +254,33 @@ provider/
 | PV-4-005 | 请求体不包含 `name` | 200，返回的 `name` 与 URI 一致 |
 | PV-4-006 | 请求体包含 `name` | 422 |
 
-## 10. 删除 Provider
+## 10. Provider instance_pool 同步到 Inner API
+
+### 10.1 接口信息
+
+| 项目 | 值 |
+|------|-----|
+| 模块 | Provider / Inner API |
+| 接口名称 | 修改 Provider instance_pool 后验证 cluster_table 导出 |
+| 方法 | PATCH + GET |
+| 路径 | `/open-api/v1/providers/{provider_name}` + `/inner-api/v1/configs/gslb_data/cluster_table` |
+| 说明 | 验证 Open API 修改 provider 实例池后，Inner API 的 cluster_table 配置导出会同步更新 |
+
+### 10.2 测试步骤
+
+1. 创建 Provider，初始 `instance_pool` 为 `[{name: "backend-old", addr: "10.0.0.1", port: 8080, weight: 100}]`。
+2. 创建 Cluster，通过 `llm_config.provider` 引用该 Provider。
+3. 调用 `GET /inner-api/v1/configs/gslb_data/cluster_table`，断言 cluster 的 backends 包含 `backend-old`。
+4. 调用 `PATCH /open-api/v1/providers/{provider_name}`，将 `instance_pool` 修改为 `[{name: "backend-new", addr: "10.0.0.2", port: 8081, weight: 100}]`。
+5. 再次调用 `GET /inner-api/v1/configs/gslb_data/cluster_table`，断言 backends 包含 `backend-new`，且不再包含 `backend-old`。
+
+### 10.3 测试用例
+
+| 用例编号 | 用例名称 | 预期结果 |
+|----------|----------|----------|
+| PV-SYNC-1-001 | 修改 provider instance_pool 后 cluster_table 同步更新 | cluster_table 中 cluster 的 backend 变为新实例 |
+
+## 11. 删除 Provider
 
 ### 10.1 接口信息
 
@@ -271,7 +300,7 @@ provider/
 | PV-5-002 | 删除不存在的 Provider | 404 |
 | PV-5-003 | 删除被 Cluster 引用的 Provider | 409 |
 
-## 11. 设置高峰/闲时模板（PV-8）
+## 12. 设置高峰/闲时模板（PV-8）
 
 ### 11.1 接口信息
 

--- a/test/integration/tests/provider/instance_pool_sync/instance_pool_sync_test.go
+++ b/test/integration/tests/provider/instance_pool_sync/instance_pool_sync_test.go
@@ -1,0 +1,147 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance_pool_sync_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+var sm *testutil.ServerManager
+
+func TestMain(m *testing.M) {
+	var err error
+	sm, err = testutil.StartServer()
+	if err != nil {
+		panic("failed to start server: " + err.Error())
+	}
+	code := m.Run()
+	sm.Shutdown()
+	os.Exit(code)
+}
+
+// TestProvider_InstancePoolSyncToInnerAPI verifies that modifying a provider's
+// instance_pool via Open API is reflected in the Inner API cluster_table export.
+func TestProvider_InstancePoolSyncToInnerAPI(t *testing.T) {
+	providerName := testutil.UniqueProviderName()
+	if _, err := testutil.CreateProvider(providerName, map[string]interface{}{
+		"instance_pool": []interface{}{
+			map[string]interface{}{"name": "backend-old", "addr": "10.0.0.1", "weight": 100, "port": 8080},
+		},
+	}); err != nil {
+		t.Fatalf("setup provider failed: %v", err)
+	}
+	defer testutil.DeleteProvider(providerName)
+
+	clusterName := testutil.UniqueClusterName()
+	_, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+		"name": clusterName,
+		"llm_config": map[string]interface{}{
+			"models":   []string{"deepseek-chat"},
+			"provider": providerName,
+		},
+	})
+	if err != nil {
+		t.Fatalf("setup cluster failed: %v", err)
+	}
+	defer testutil.DeleteCluster(clusterName)
+
+	// Initial export should contain the old backend.
+	resp, err := testutil.GetClient().Get("/inner-api/v1/configs/gslb_data/cluster_table")
+	if err != nil {
+		t.Fatalf("initial cluster_table export failed: %v", err)
+	}
+	testutil.AssertSuccess(t, resp)
+	assertBackendExists(t, resp, clusterName, "backend-old", "10.0.0.1", 8080)
+	assertBackendNotExists(t, resp, clusterName, "backend-new")
+
+	// Update provider instance_pool to the new backend.
+	resp, err = testutil.GetClient().Patch("/open-api/v1/providers/"+providerName, map[string]interface{}{
+		"instance_pool": []interface{}{
+			map[string]interface{}{"name": "backend-new", "addr": "10.0.0.2", "weight": 100, "port": 8081},
+		},
+		"model_protocols": []string{"openai"},
+	})
+	if err != nil {
+		t.Fatalf("update provider failed: %v", err)
+	}
+	testutil.AssertSuccess(t, resp)
+
+	// Re-export cluster_table; the new backend should appear and the old one disappear.
+	resp, err = testutil.GetClient().Get("/inner-api/v1/configs/gslb_data/cluster_table")
+	if err != nil {
+		t.Fatalf("cluster_table export after update failed: %v", err)
+	}
+	testutil.AssertSuccess(t, resp)
+	assertBackendExists(t, resp, clusterName, "backend-new", "10.0.0.2", 8081)
+	assertBackendNotExists(t, resp, clusterName, "backend-old")
+}
+
+func clusterTableConfig(t *testing.T, resp *testutil.APIResponse) map[string]interface{} {
+	t.Helper()
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Data, &data))
+	config, ok := data["Config"].(map[string]interface{})
+	require.True(t, ok, "cluster_table Config should be an object")
+	return config
+}
+
+func subClusterBackends(t *testing.T, config map[string]interface{}, clusterName string) []map[string]interface{} {
+	t.Helper()
+	cluster, ok := config[clusterName].(map[string]interface{})
+	require.True(t, ok, "cluster %s should exist in cluster_table", clusterName)
+
+	// The cluster has a single sub-cluster created from the provider.
+	var backends []map[string]interface{}
+	for _, v := range cluster {
+		subClusterBackends, ok := v.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, b := range subClusterBackends {
+			backend, ok := b.(map[string]interface{})
+			require.True(t, ok, "backend should be an object")
+			backends = append(backends, backend)
+		}
+	}
+	return backends
+}
+
+func assertBackendExists(t *testing.T, resp *testutil.APIResponse, clusterName, name, addr string, port int) {
+	t.Helper()
+	config := clusterTableConfig(t, resp)
+	backends := subClusterBackends(t, config, clusterName)
+	for _, b := range backends {
+		if b["Name"] == name && b["Addr"] == addr && int(b["Port"].(float64)) == port {
+			return
+		}
+	}
+	t.Fatalf("backend %s (%s:%d) not found in cluster %s", name, addr, port, clusterName)
+}
+
+func assertBackendNotExists(t *testing.T, resp *testutil.APIResponse, clusterName, name string) {
+	t.Helper()
+	config := clusterTableConfig(t, resp)
+	backends := subClusterBackends(t, config, clusterName)
+	for _, b := range backends {
+		if b["Name"] == name {
+			t.Fatalf("unexpected backend %s found in cluster %s", name, clusterName)
+		}
+	}
+}


### PR DESCRIPTION
…sters (#106)

When PATCH /providers updates instance_pool, automatically propagate the new instances to all clusters that reference the provider. This aligns with the contract documented in providers.md §2.4.

Changes:
- Add optional sync hooks to ProviderManager.UpdateProvider.
- Implement ClusterManager.ProviderInstancePoolSyncer to refresh non-EPP sub-cluster pools from the provider's latest instance_pool.
- Update provider update endpoint to inject the sync hook.
- Relax UpdateCluster instance-pool resync condition to trigger whenever the cluster explicitly references a provider.
- Add unit tests and integration test PV-SYNC-1-001.

Closes #106