### PR TITLE
fix(provider,cluster): enforce provider keys/models reference integri…

### DIFF
--- a/design-docs/api-define/OpenAPI接口定义/providers.md
+++ b/design-docs/api-define/OpenAPI接口定义/providers.md
@@ -333,7 +333,9 @@
 
 可修改字段含义同创建接口，但**输入参数不包括 `name`，即不能修改 provider 的 name**（名称由 URI 中的 `provider_name` 指定）。若请求体中仍包含 `name`，返回 422。若传入 `instance_pool` 字段，系统会自动同步更新被引用该 provider 的所有 cluster 所生成的实例池。
 
-> **注意**：`keys` 作为数组，按**全量替换**处理，即调用方需传入完整的最新 Key 列表。Key 的 `name` 变更会影响所有引用该 provider 的 cluster。
+> **注意**：
+> - `keys` 作为数组，按**全量替换**处理，即调用方需传入完整的最新 Key 列表。Key 的 `name` 删除/重命名会校验无 cluster 仍引用旧 name；若被引用，返回 `409 Conflict`。
+> - `models` 作为数组，按**全量替换**处理。删除 model 会校验无 cluster 仍引用该 model；若被引用，返回 `409 Conflict`。
 
 **HTTP BODY 参数示例**
 

--- a/design-docs/modifications/2026-08-28-issue-106-followup-provider-keys-models-integrity/change-summary.md
+++ b/design-docs/modifications/2026-08-28-issue-106-followup-provider-keys-models-integrity/change-summary.md
@@ -1,0 +1,37 @@
+# Issue #106 后续：Provider keys/models 变更对 Cluster 的引用完整性影响
+
+## 变更概述
+
+在修复 `PATCH /providers` 修改 `instance_pool` 后 cluster 实例池未同步的问题后，进一步检查发现：provider 的 `keys` 和 `models` 字段在更新时也存在类似的同步/引用完整性隐患——删除或重命名 provider 的 key、删除 provider 的 model 会导致引用该 provider 的 cluster 配置失效或产生无效导出。
+
+本目录记录问题分析、影响面评估与推荐修复方案，为后续实现提供设计依据。
+
+## 关键发现
+
+1. **Provider `keys` 删除/重命名**：cluster 通过 `llm_config.keys[].name` 引用 provider key。provider 更新后若旧 name 不存在，导出时 `AIConf.Keys` 中对应条目的 `Key` 字段为空字符串，导致请求无法正常鉴权。
+2. **Provider `models` 删除**：cluster `llm_config.models` 必须是 provider `models` 的子集（`clusters.md` 约束）。provider 删除 model 后，已有 cluster 可能违反该约束，且导出仍包含无效 model。
+3. **Route rules 间接影响**：route rule 引用 `(cluster, model)` 对，cluster model 越界会间接导致路由规则失效；修复 provider 层校验可同时拦截此类风险。
+4. **其它字段无影响**：`model_protocols`、`tiers`、`time_zone` 均为导出时实时投影；`description`、`model_endpoint` 不影响 cluster；model-prices 允许孤儿记录（`PV-5-004` 已确认）。
+
+## 推荐方案
+
+在 `ProviderManager.UpdateProvider` 中新增两类引用完整性校验 hook（风格同 `ProviderDeleteChecker`）：
+
+- `ClusterManager.ProviderKeyRefChecker`：provider `keys` 变更时，校验所有引用 cluster 的 `llm_config.keys` name 仍存在于新 provider keys 中。
+- `ClusterManager.ProviderModelRefChecker`：provider `models` 变更时，校验所有引用 cluster 的 `llm_config.models` 仍是新 provider models 的子集。
+
+任一校验失败返回 `409 Conflict`，阻止会导致 cluster 配置失效的 provider 更新。
+
+## 涉及文件（预期）
+
+- `ai-gateway-api/model/icluster_conf/cluster.go`（新增两个 checker）
+- `ai-gateway-api/endpoints/openapi_v1/provider/update.go`（注入 hook）
+- `ai-gateway-api/model/iprovider/provider.go`（如 hook 签名需调整）
+- `ai-gateway-api/model/icluster_conf/cluster_test.go`（单元测试）
+- `ai-gateway-api/test/integration/tests/provider/update/update_test.go` 或新目录（集成测试）
+
+## 状态
+
+- [x] 代码实现
+- [x] 单元测试通过
+- [x] 集成测试通过（目标用例通过；全量集成测试中仅有既有的 `innerapi/rate_limit_policy` 用例失败，与本变更无关）

--- a/design-docs/modifications/2026-08-28-issue-106-followup-provider-keys-models-integrity/design-changes.md
+++ b/design-docs/modifications/2026-08-28-issue-106-followup-provider-keys-models-integrity/design-changes.md
@@ -1,0 +1,347 @@
+# Issue #106 后续：Provider keys/models 变更对 Cluster 的引用完整性影响
+
+## 1. 背景
+
+[Issue #106](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/106) 及其修复解决了 `PATCH /providers` 修改 `instance_pool` 后，引用该 provider 的 cluster 实例池未同步的问题。修复采用 **ProviderManager 同步 hook** 机制：在 `UpdateProvider` 事务内调用 `ClusterManager.ProviderInstancePoolSyncer`，将 provider 的最新实例池刷新到所有引用 cluster 的 sub-cluster pool。
+
+完成该修复后，进一步检查 provider 其余字段对 cluster 及导出配置的影响，发现 `keys` 和 `models` 字段在更新时存在类似的引用完整性风险。
+
+## 2. 问题定位
+
+### 2.1 Provider 字段与 Cluster/导出关系总览
+
+| Provider 字段 | 是否已同步/实时投影 | 说明 |
+|---------------|--------------------|------|
+| `instance_pool` | ✅ 已修复 | 通过 `ProviderInstancePoolSyncer` 同步到 cluster sub-cluster pool |
+| `model_protocols` | ✅ 实时投影 | `newAIConf` 导出时直接取 provider 当前 `model_protocols` |
+| `keys`（仅改 key 值，name 不变） | ✅ 实时投影 | `newAIConf` 按 name 从 provider 取最新 key 值 |
+| `keys`（删除/重命名 name） | ❌ **存在隐患** | cluster 仍引用旧 name，导出后对应 `AIConf.Keys[].Key` 为空字符串 |
+| `models`（新增） | ✅ 无影响 | cluster 原本就是 provider models 子集，新增不破坏约束 |
+| `models`（删除） | ❌ **存在隐患** | cluster `llm_config.models` 可能包含已被移除的 model，违反子集约束 |
+| `tiers` / `time_zone` | ✅ 实时投影 | 通过 `providerPricingTable` 实时填充到 `ModelTable` |
+| `model_endpoint` | 无影响 | 仅用于模型发现工具 `/providers/tools/discover-models` |
+| `description` | 无影响 | 纯展示字段 |
+
+### 2.2 Provider `keys` 删除/重命名导致 cluster key 悬空
+
+#### 复现路径
+
+1. 创建 provider：
+   ```json
+   {
+     "name": "deepseek",
+     "keys": [{"name": "k1", "key": "sk-old"}],
+     "instance_pool": [...],
+     "model_protocols": ["openai"]
+   }
+   ```
+2. 创建 cluster：
+   ```json
+   {
+     "name": "c1",
+     "llm_config": {
+       "provider": "deepseek",
+       "models": ["deepseek-chat"],
+       "keys": [{"name": "k1", "weight": 100}]
+     }
+   }
+   ```
+3. 更新 provider，将 keys 改为 `[{"name": "k2", "key": "sk-new"}]`（删除/重命名 k1）。
+4. 调用 `GET /inner-api/v1/configs/tls_conf/server_data_conf` 导出。
+
+#### 导出结果
+
+cluster `c1` 的 `AIConf.Keys` 会变成：
+
+```json
+[{"Name": "k1", "Key": "", "Weight": 100}]
+```
+
+#### 根因
+
+`model/icluster_conf/cluster.go:1119-1130` 的 `newAIConf` 函数：
+
+```go
+keyMap := map[string]string{}
+for _, k := range providerKeys {
+    keyMap[k.Name] = k.Key
+}
+for _, k := range llmConfig.Keys {
+    name := derefString(k.Name, "")
+    aiConf.Keys = append(aiConf.Keys, cluster_conf.AIKey{
+        Name:   name,
+        Key:    keyMap[name],  // name 不在 provider keys 中时，Key 为空字符串
+        Weight: derefInt(k.Weight, 0),
+    })
+}
+```
+
+当 cluster 引用的 key name 已从 provider 中删除时，`keyMap[name]` 返回空字符串，导致 BFE 侧无法构造有效鉴权头。
+
+### 2.3 Provider `models` 删除导致 cluster model 越界
+
+#### 复现路径
+
+1. 创建 provider：
+   ```json
+   {"models": ["deepseek-chat", "deepseek-coder"], ...}
+   ```
+2. 创建 cluster：
+   ```json
+   {"llm_config": {"models": ["deepseek-coder"], "provider": "deepseek"}}
+   ```
+3. 更新 provider：
+   ```json
+   {"models": ["deepseek-chat"], ...}
+   ```
+4. 导出配置仍包含 `deepseek-coder`。
+
+#### 根因
+
+- `model/icluster_conf/cluster.go:526` 的 `validateClusterLLMConfigAgainstProvider` 仅在 **cluster 创建/更新** 时校验 model 子集关系。
+- `ProviderManager.UpdateProvider` 更新 provider models 时，不会重新校验引用该 provider 的 cluster。
+- cluster 的 `LLMConfig.Models` 是持久化快照，provider 变更不会触发清理或校验。
+
+### 2.4 Route rules 的间接影响
+
+`model/route_rules/route_rules.go:226` 提供了 `ClusterModelUpdateChecker`，用于在 cluster 更新时阻止删除被路由规则引用的 model。但该 checker 仅在 cluster 更新路径触发；当 provider 删除 model 导致 cluster model 越界时，没有对应机制拦截。
+
+因此，provider 删除 model 可能产生级联失效：
+
+```
+provider.models --(remove)--> cluster.llm_config.models 越界
+                                    |
+                                    v
+                          route rules 引用的 (cluster, model) 失效
+```
+
+在 provider 层增加 `ProviderModelRefChecker` 可同时覆盖该级联风险。
+
+## 3. 目标
+
+1. 防止 provider `keys` 更新导致 cluster 引用悬空的 key name。
+2. 防止 provider `models` 更新导致 cluster 引用已被移除的 model。
+3. 保持与现有 `ProviderDeleteChecker` 一致的校验风格。
+4. 不破坏 `instance_pool` 已修复的同步路径。
+
+## 4. 方案对比
+
+| 方案 | 思路 | 优点 | 缺点 | 结论 |
+|------|------|------|------|------|
+| A. Provider 更新时拦截（推荐） | 在 `UpdateProvider` 事务内校验所有引用 cluster，若 key/model 引用失效则返回 409 | 与删除 provider 的引用检查一致；不会静默修改用户显式配置的 cluster | 用户需先修改 cluster 再改 provider | **采用** |
+| B. 自动清理 cluster 引用 | provider 删除 key/model 时，自动从引用 cluster 的 `llm_config.keys` / `models` 中移除 | 对用户透明 | 会静默丢失用户配置；多 sub-cluster/路由规则场景难以一致处理 | 不采用 |
+| C. 导出时忽略无效引用 | `newAIConf` 中跳过无效的 key/model | 不修改 provider 更新逻辑 | 导致配置与 DB 不一致，排查困难；key 为空仍可能产生请求 | 不采用 |
+
+## 5. 推荐方案：引用完整性校验 hook
+
+### 5.1 核心思路
+
+复用 `ProviderManager.UpdateProvider` 的 hook 机制（已为 `instance_pool` 同步引入），新增两个**校验型 hook**：
+
+```go
+func (cm *ClusterManager) ProviderKeyRefChecker(
+    ctx context.Context,
+    oldProvider, newProvider *iprovider.Provider,
+) error
+
+func (cm *ClusterManager) ProviderModelRefChecker(
+    ctx context.Context,
+    oldProvider, newProvider *iprovider.Provider,
+) error
+```
+
+在 `UpdateProvider` 中，当请求体显式包含 `keys` / `models` 且内容发生变化时调用对应 checker；任一 checker 失败则整个事务回滚，返回 `409 Conflict`。
+
+### 5.2 `ProviderKeyRefChecker` 实现
+
+文件：`ai-gateway-api/model/icluster_conf/cluster.go`
+
+```go
+// ProviderKeyRefChecker returns a hook that verifies all clusters referencing
+// the provider still have valid llm_config.keys names after a provider update.
+func (cm *ClusterManager) ProviderKeyRefChecker(ctx context.Context,
+    oldProvider, newProvider *iprovider.Provider) error {
+
+    if newProvider == nil {
+        return nil
+    }
+
+    newKeyNames := map[string]bool{}
+    for _, k := range newProvider.Keys {
+        newKeyNames[k.Name] = true
+    }
+
+    clusters, err := cm.storager.FetchClusterList(ctx, nil)
+    if err != nil {
+        return err
+    }
+
+    for _, cluster := range clusters {
+        if cluster.LLMConfig == nil || cluster.LLMConfig.Provider == nil {
+            continue
+        }
+        if *cluster.LLMConfig.Provider != newProvider.Name {
+            continue
+        }
+        for _, k := range cluster.LLMConfig.Keys {
+            if k.Name == nil || *k.Name == "" {
+                continue
+            }
+            if !newKeyNames[*k.Name] {
+                return xerror.WrapConflictErrorWithMsg(
+                    "provider %s key %s is referenced by cluster %s",
+                    newProvider.Name, *k.Name, cluster.Name)
+            }
+        }
+    }
+
+    return nil
+}
+```
+
+### 5.3 `ProviderModelRefChecker` 实现
+
+文件：`ai-gateway-api/model/icluster_conf/cluster.go`
+
+```go
+// ProviderModelRefChecker returns a hook that verifies all clusters referencing
+// the provider still have valid llm_config.models after a provider update.
+func (cm *ClusterManager) ProviderModelRefChecker(ctx context.Context,
+    oldProvider, newProvider *iprovider.Provider) error {
+
+    if newProvider == nil {
+        return nil
+    }
+
+    newModelSet := map[string]bool{}
+    for _, m := range newProvider.Models {
+        newModelSet[m] = true
+    }
+
+    clusters, err := cm.storager.FetchClusterList(ctx, nil)
+    if err != nil {
+        return err
+    }
+
+    for _, cluster := range clusters {
+        if cluster.LLMConfig == nil || cluster.LLMConfig.Provider == nil {
+            continue
+        }
+        if *cluster.LLMConfig.Provider != newProvider.Name {
+            continue
+        }
+        for _, m := range cluster.LLMConfig.Models {
+            if !newModelSet[m] {
+                return xerror.WrapConflictErrorWithMsg(
+                    "provider %s model %s is referenced by cluster %s",
+                    newProvider.Name, m, cluster.Name)
+            }
+        }
+    }
+
+    return nil
+}
+```
+
+### 5.4 `ProviderManager.UpdateProvider` 调用点
+
+文件：`ai-gateway-api/endpoints/openapi_v1/provider/update.go`
+
+```go
+if err := container.ProviderManager.UpdateProvider(req.Context(), name, param,
+    container.ClusterManager.ProviderInstancePoolSyncer,
+    container.ClusterManager.ProviderKeyRefChecker,
+    container.ClusterManager.ProviderModelRefChecker,
+); err != nil {
+    return nil, err
+}
+```
+
+### 5.5 触发条件
+
+在 `ProviderManager.UpdateProvider` 中，由于存储层 `toDAOParam` 会调用 `FillDefaults` 把未传的 `models`/`keys` 从 `nil` 改成空切片，因此需要在调用 `storager.UpdateProvider` 前保存原始值：
+
+```go
+origInstancePool := param.InstancePool
+origKeys := param.Keys
+origModels := param.Models
+```
+
+校验 hook 的触发条件为：
+
+- `ProviderInstancePoolSyncer`：当 `origInstancePool != nil` 且与 `existing.InstancePool` 不同时触发。
+- `ProviderKeyRefChecker`：当 `origKeys != nil` 且与 `existing.Keys` 不同时触发。
+- `ProviderModelRefChecker`：当 `origModels != nil` 且与 `existing.Models` 不同时触发。
+
+构建 hook 快照前，再把未变更字段恢复为 `nil`，避免 `applyProviderUpdate` 误把空切片当作“清空”处理。这样可避免无意义的遍历，同时确保用户显式修改这些字段时一定做完整性检查。
+
+## 6. 边界与风险
+
+| 场景 | 行为 | 说明 |
+|------|------|------|
+| 仅新增 provider keys/models | 通过 | 不破坏现有 cluster |
+| 仅修改 provider key 值（name 不变） | 通过 | key 值导出时实时投影 |
+| 删除/重命名 provider key | 若被 cluster 引用则 409 | 用户需先更新 cluster |
+| 删除 provider model | 若被 cluster/route rule 引用则 409 | 同时保护路由规则 |
+| provider 未被任何 cluster 引用 | 任意更新均通过 | 无约束 |
+| cluster `llm_config.keys` 为空 | 不检查 key 引用 | 空数组是合法状态 |
+
+## 7. 测试计划
+
+### 7.1 单元测试
+
+#### `ai-gateway-api/model/icluster_conf/cluster_test.go`
+
+新增 `TestProviderKeyRefChecker`：
+
+1. 构造 provider old keys `[k1, k2]`，new keys `[k2, k3]`。
+2. 构造两个 cluster：一个引用 `k1`，一个不引用该 provider。
+3. 调用 `ProviderKeyRefChecker`。
+4. 断言：引用 `k1` 的 cluster 触发 `409 Conflict`；不引用的 cluster 无影响。
+
+新增 `TestProviderModelRefChecker`：
+
+1. 构造 provider old models `[m1, m2]`，new models `[m2, m3]`。
+2. 构造两个 cluster：一个引用 `m1`，一个不引用该 provider。
+3. 调用 `ProviderModelRefChecker`。
+4. 断言：引用 `m1` 的 cluster 触发 `409 Conflict`。
+
+#### `ai-gateway-api/model/iprovider/provider_test.go`
+
+新增 `TestUpdateProvider_KeyRefCheckFails` 与 `TestUpdateProvider_ModelRefCheckFails`：
+
+1. mock provider storager 返回旧 provider。
+2. mock cluster storager 返回引用旧 key/model 的 cluster。
+3. 调用 `UpdateProvider` 并传入对应 checker。
+4. 断言返回错误，且 provider 行未更新（事务回滚）。
+
+### 7.2 集成测试
+
+#### `ai-gateway-api/test/integration/tests/provider/instance_pool_sync/instance_pool_sync_test.go` 或新目录
+
+新增两个子用例：
+
+- `PV-SYNC-1-002 删除 provider key 被 cluster 引用时返回 409`
+- `PV-SYNC-1-003 删除 provider model 被 cluster 引用时返回 409`
+
+验证 Open API 行为符合预期。
+
+## 8. 实施状态
+
+- [x] `model/icluster_conf/cluster.go`：新增 `ProviderKeyRefChecker`
+- [x] `model/icluster_conf/cluster.go`：新增 `ProviderModelRefChecker`
+- [x] `model/iprovider/provider.go`：修正 hook 触发条件，避免 `FillDefaults` 导致的误判
+- [x] `endpoints/openapi_v1/provider/update.go`：注入两个 hook
+- [x] `model/iprovider/provider_test.go`：新增事务回滚单元测试
+- [x] `model/icluster_conf/cluster_test.go`：新增 checker 单元测试
+- [x] 集成测试补充
+
+## 9. 参考文档
+
+- [Issue #106](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/106)
+- `ai-gateway-api/design-docs/modifications/2026-08-28-issue-106-provider-instance-pool-sync/design-changes.md`
+- `ai-gateway-api/design-docs/api-define/OpenAPI接口定义/providers.md`
+- `ai-gateway-api/design-docs/api-define/OpenAPI接口定义/clusters.md`
+- `ai-gateway-api/model/icluster_conf/cluster.go`
+- `ai-gateway-api/model/iprovider/provider.go`
+- `ai-gateway-api/endpoints/openapi_v1/provider/update.go`

--- a/design-docs/sys-design/details/provider与cluster概念分离.md
+++ b/design-docs/sys-design/details/provider与cluster概念分离.md
@@ -117,11 +117,17 @@
 | POST | `/providers` | 创建 provider |
 | GET | `/providers` | 分页/过滤查询 provider 列表 |
 | GET | `/providers/{provider_name}` | 查询单个 provider |
-| PATCH | `/providers/{provider_name}` | 部分更新 provider |
+| PATCH | `/providers/{provider_name}` | 部分更新 provider；若修改 `keys`/`models` 导致已有 cluster 引用失效，返回 409 |
 | DELETE | `/providers/{provider_name}` | 删除 provider |
 | POST | `/providers/tools/discover-models` | 触发模型发现 |
 
 `PATCH /providers/{provider_name}` 请求体**不能包含 `name`**，名称由 URI 路径参数唯一指定，若请求体携带 `name` 返回 422。
+
+部分更新 provider 时，如果请求体显式修改了 `instance_pool`、`keys` 或 `models`：
+
+- `instance_pool` 变更会同步刷新所有引用该 provider 的 cluster 子集群实例池（EPP 子集群除外）。
+- `keys` 删除/重命名会校验无 cluster 仍引用旧 key name；否则返回 409。
+- `models` 删除会校验无 cluster 仍引用已被移除的 model；否则返回 409。
 
 删除 provider 前，须校验无 `/clusters` 引用；`/model-prices` 中的同名 provider 不再作为阻塞条件。
 
@@ -150,6 +156,7 @@ URL 与 HTTP Method 不变，请求/响应体变化：
 - `model/icluster_conf/ClusterManager` 注入 `iprovider.ProviderStorager`：
   - 创建/更新 cluster 时校验 provider 存在、models 子集、keys name 存在性。
   - 根据 provider `instance_pool` 自动生成/更新 pool/sub_cluster。
+  - 以 hook 形式向 `ProviderManager.UpdateProvider` 注册 `ProviderInstancePoolSyncer`、`ProviderKeyRefChecker`、`ProviderModelRefChecker`：provider 更新时同步实例池，并反向校验 cluster 对 key / model 的引用完整性。
 - `model/icluster_conf/exporter.go` 在生成 `AIConf` 时：
   - 从 provider 读取 `instance_pool` 生成 BFE 实例池/子集群/集群。
   - 按 `name` join provider `keys` 与 cluster `llm_config.keys` 生成带明文的 `AIConf.Keys`。
@@ -262,7 +269,7 @@ BFE 接收到的配置结构和字段与重构前完全一致：
 |------|------|----------|
 | 破坏性 API 变更 | 现有调用方需修改 | 提前发版说明；提供迁移指南；必要时保留只读兼容层。 |
 | Key 明文迁移 | 迁移脚本处理敏感数据 | 日志脱敏；确保 key 加密存储不变。 |
-| 多 cluster 共享 provider | 修改 provider 影响所有引用 cluster | 更新时给出引用列表确认；删除时强制无引用。 |
+| 多 cluster 共享 provider | 修改 provider 影响所有引用 cluster | `instance_pool` 变更自动同步到 cluster；`keys`/`models` 变更反向校验引用完整性，冲突时返回 409；删除时强制无引用。 |
 | 更新接口误传 `name` | 调用方可能习惯在 Body 中重复名称 | 接口层显式拒绝请求体中的 `name`，返回 422；文档明确名称由 URI 决定。 |
 | 删除 cluster 时存在路由规则引用 | 级联删除可能导致路由指向不存在集群 | 删除前检查 AI 路由规则引用，返回引用冲突错误，要求先解除引用。 |
 | 模型发现失败 | discover-models 可能失败 | 辅助能力，支持手动维护 `models`。 |

--- a/design-docs/sys-design/模型层设计文档.md
+++ b/design-docs/sys-design/模型层设计文档.md
@@ -501,6 +501,8 @@ type ClusterManager struct {
 
 `ClusterManager.CreateCluster` / `UpdateCluster` 会校验 `llm_config.provider` 引用已存在的 Provider，且 `llm_config.models` 为 Provider `models` 的子集、`llm_config.keys` 中的 `name` 均存在于 Provider `keys` 中；创建/更新时根据 Provider 的 `instance_pool` 自动生成或更新实例池与子集群。
 
+`ProviderManager.UpdateProvider` 在事务内调用 `ClusterManager.ProviderInstancePoolSyncer`、`ProviderKeyRefChecker`、`ProviderModelRefChecker`：当 provider 的 `instance_pool`、`keys`、`models` 显式变更时，同步更新引用 cluster 的实例池，并校验 cluster 引用的 key name / model 仍存在于新 provider 中；任一校验失败返回 409，整个事务回滚。
+
 `ClusterManager.DeleteCluster` 会执行引用检查：若该集群被 **AI 路由规则**（AI Route Rules，含 Global / Entity / API-Key 三级）引用，则删除失败；检查由 `model/route_rules/route_rules.go` 的 `RouteRulesManager.ClusterDeleteChecker` 实现。通过引用检查后，遍历并级联删除子集群及其关联实例池，最后删除集群与负载均衡矩阵。
 
 > 说明：代码实现中 `ClusterManager.deleteCheckers` 仍保留产品级路由规则检查作为防御性校验，但 AI 网关场景不使用产品级路由规则，对外文档与接口行为均只描述 AI 路由规则引用检查。

--- a/endpoints/openapi_v1/provider/update.go
+++ b/endpoints/openapi_v1/provider/update.go
@@ -58,6 +58,8 @@ func UpdateAction(req *http.Request) (interface{}, error) {
 
 	if err := container.ProviderManager.UpdateProvider(req.Context(), name, param,
 		container.ClusterManager.ProviderInstancePoolSyncer,
+		container.ClusterManager.ProviderKeyRefChecker,
+		container.ClusterManager.ProviderModelRefChecker,
 	); err != nil {
 		return nil, err
 	}

--- a/model/icluster_conf/cluster.go
+++ b/model/icluster_conf/cluster.go
@@ -759,6 +759,50 @@ func (cm *ClusterManager) ProviderDeleteChecker(ctx context.Context, providerNam
 	return nil
 }
 
+// providerInstancePoolEqual reports whether two provider instance pools are
+// identical. Order matters because the pool is a snapshot.
+func providerInstancePoolEqual(a, b []iprovider.ProviderInstance) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name ||
+			a[i].Addr != b[i].Addr ||
+			a[i].Port != b[i].Port ||
+			a[i].Weight != b[i].Weight ||
+			a[i].Disable != b[i].Disable {
+			return false
+		}
+	}
+	return true
+}
+
+// providerKeysEqual reports whether two provider key lists are identical.
+func providerKeysEqual(a, b []iprovider.ProviderKey) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name || a[i].Key != b[i].Key {
+			return false
+		}
+	}
+	return true
+}
+
+// providerModelsEqual reports whether two provider model lists are identical.
+func providerModelsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // ProviderInstancePoolSyncer returns a hook suitable for passing to
 // iprovider.ProviderManager.UpdateProvider. When the provider's instance_pool
 // changes, it updates the instance pool of every non-EPP sub-cluster that
@@ -767,6 +811,9 @@ func (cm *ClusterManager) ProviderInstancePoolSyncer(ctx context.Context,
 	oldProvider, newProvider *iprovider.Provider) error {
 
 	if newProvider == nil || len(newProvider.InstancePool) == 0 {
+		return nil
+	}
+	if oldProvider != nil && providerInstancePoolEqual(oldProvider.InstancePool, newProvider.InstancePool) {
 		return nil
 	}
 
@@ -792,6 +839,91 @@ func (cm *ClusterManager) ProviderInstancePoolSyncer(ctx context.Context,
 				Instances: newInstances,
 			}); err != nil {
 				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// ProviderKeyRefChecker returns a hook that verifies all clusters referencing
+// the provider still have valid llm_config.keys names after a provider update.
+func (cm *ClusterManager) ProviderKeyRefChecker(ctx context.Context,
+	oldProvider, newProvider *iprovider.Provider) error {
+
+	if newProvider == nil {
+		return nil
+	}
+	if oldProvider != nil && providerKeysEqual(oldProvider.Keys, newProvider.Keys) {
+		return nil
+	}
+
+	newKeyNames := map[string]bool{}
+	for _, k := range newProvider.Keys {
+		newKeyNames[k.Name] = true
+	}
+
+	clusters, err := cm.storager.FetchClusterList(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, cluster := range clusters {
+		if cluster.LLMConfig == nil || cluster.LLMConfig.Provider == nil {
+			continue
+		}
+		if *cluster.LLMConfig.Provider != newProvider.Name {
+			continue
+		}
+		for _, k := range cluster.LLMConfig.Keys {
+			if k.Name == nil || *k.Name == "" {
+				continue
+			}
+			if !newKeyNames[*k.Name] {
+				return xerror.WrapConflictErrorWithMsg(
+					"provider %s key %s is referenced by cluster %s",
+					newProvider.Name, *k.Name, cluster.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ProviderModelRefChecker returns a hook that verifies all clusters referencing
+// the provider still have valid llm_config.models after a provider update.
+func (cm *ClusterManager) ProviderModelRefChecker(ctx context.Context,
+	oldProvider, newProvider *iprovider.Provider) error {
+
+	if newProvider == nil {
+		return nil
+	}
+	if oldProvider != nil && providerModelsEqual(oldProvider.Models, newProvider.Models) {
+		return nil
+	}
+
+	newModelSet := map[string]bool{}
+	for _, m := range newProvider.Models {
+		newModelSet[m] = true
+	}
+
+	clusters, err := cm.storager.FetchClusterList(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, cluster := range clusters {
+		if cluster.LLMConfig == nil || cluster.LLMConfig.Provider == nil {
+			continue
+		}
+		if *cluster.LLMConfig.Provider != newProvider.Name {
+			continue
+		}
+		for _, m := range cluster.LLMConfig.Models {
+			if !newModelSet[m] {
+				return xerror.WrapConflictErrorWithMsg(
+					"provider %s model %s is referenced by cluster %s",
+					newProvider.Name, m, cluster.Name)
 			}
 		}
 	}

--- a/model/icluster_conf/cluster_test.go
+++ b/model/icluster_conf/cluster_test.go
@@ -171,6 +171,184 @@ func TestClusterManager_ProviderInstancePoolSyncer(t *testing.T) {
 	})
 }
 
+func TestClusterManager_ProviderKeyRefChecker(t *testing.T) {
+	ctx := context.Background()
+	providerName := "deepseek"
+
+	makeCluster := func(name string, provider *string, keyNames []string) *Cluster {
+		keys := make([]ClusterKeyRef, 0, len(keyNames))
+		for _, k := range keyNames {
+			keys = append(keys, ClusterKeyRef{Name: lib.PString(k), Weight: lib.PInt(100)})
+		}
+		return &Cluster{
+			ID:   1,
+			Name: name,
+			LLMConfig: &LLMConfig{
+				Provider: provider,
+				Keys:     keys,
+			},
+		}
+	}
+
+	t.Run("blocks removal of referenced key", func(t *testing.T) {
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				return []*Cluster{
+					makeCluster("c1", &providerName, []string{"k1"}),
+					makeCluster("c2", lib.PString("other"), []string{"k1"}),
+				}, nil
+			},
+		}
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, &fakePoolStorager{}, nil, nil, nil, nil)
+		newProvider := &iprovider.Provider{
+			Name: providerName,
+			Keys: []iprovider.ProviderKey{{Name: "k2", Key: "sk-new"}},
+		}
+		err := cm.ProviderKeyRefChecker(ctx, nil, newProvider)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "key k1 is referenced by cluster c1")
+	})
+
+	t.Run("allows rename when old keys are still covered", func(t *testing.T) {
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				return []*Cluster{
+					makeCluster("c1", &providerName, []string{"k1", "k2"}),
+				}, nil
+			},
+		}
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, &fakePoolStorager{}, nil, nil, nil, nil)
+		newProvider := &iprovider.Provider{
+			Name: providerName,
+			Keys: []iprovider.ProviderKey{
+				{Name: "k1", Key: "sk-1"},
+				{Name: "k2", Key: "sk-2"},
+				{Name: "k3", Key: "sk-3"},
+			},
+		}
+		err := cm.ProviderKeyRefChecker(ctx, nil, newProvider)
+		require.NoError(t, err)
+	})
+
+	t.Run("skips when keys unchanged", func(t *testing.T) {
+		called := false
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				called = true
+				return []*Cluster{
+					makeCluster("c1", &providerName, []string{"k1"}),
+				}, nil
+			},
+		}
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, &fakePoolStorager{}, nil, nil, nil, nil)
+		oldProvider := &iprovider.Provider{
+			Name: providerName,
+			Keys: []iprovider.ProviderKey{{Name: "k1", Key: "sk-same"}},
+		}
+		newProvider := &iprovider.Provider{
+			Name: providerName,
+			Keys: []iprovider.ProviderKey{{Name: "k1", Key: "sk-same"}},
+		}
+		err := cm.ProviderKeyRefChecker(ctx, oldProvider, newProvider)
+		require.NoError(t, err)
+		assert.False(t, called, "fetch should be skipped when keys are unchanged")
+	})
+
+	t.Run("propagates fetch error", func(t *testing.T) {
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				return nil, errors.New("db down")
+			},
+		}
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, &fakePoolStorager{}, nil, nil, nil, nil)
+		err := cm.ProviderKeyRefChecker(ctx, nil, &iprovider.Provider{Name: providerName})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db down")
+	})
+}
+
+func TestClusterManager_ProviderModelRefChecker(t *testing.T) {
+	ctx := context.Background()
+	providerName := "deepseek"
+
+	makeCluster := func(name string, provider *string, models []string) *Cluster {
+		return &Cluster{
+			ID:   1,
+			Name: name,
+			LLMConfig: &LLMConfig{
+				Provider: provider,
+				Models:   models,
+			},
+		}
+	}
+
+	t.Run("blocks removal of referenced model", func(t *testing.T) {
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				return []*Cluster{
+					makeCluster("c1", &providerName, []string{"m1"}),
+					makeCluster("c2", lib.PString("other"), []string{"m1"}),
+				}, nil
+			},
+		}
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, &fakePoolStorager{}, nil, nil, nil, nil)
+		newProvider := &iprovider.Provider{
+			Name:   providerName,
+			Models: []string{"m2"},
+		}
+		err := cm.ProviderModelRefChecker(ctx, nil, newProvider)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "model m1 is referenced by cluster c1")
+	})
+
+	t.Run("allows addition of new models", func(t *testing.T) {
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				return []*Cluster{
+					makeCluster("c1", &providerName, []string{"m1"}),
+				}, nil
+			},
+		}
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, &fakePoolStorager{}, nil, nil, nil, nil)
+		newProvider := &iprovider.Provider{
+			Name:   providerName,
+			Models: []string{"m1", "m2"},
+		}
+		err := cm.ProviderModelRefChecker(ctx, nil, newProvider)
+		require.NoError(t, err)
+	})
+
+	t.Run("skips when models unchanged", func(t *testing.T) {
+		called := false
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				called = true
+				return []*Cluster{
+					makeCluster("c1", &providerName, []string{"m1"}),
+				}, nil
+			},
+		}
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, &fakePoolStorager{}, nil, nil, nil, nil)
+		oldProvider := &iprovider.Provider{Name: providerName, Models: []string{"m1"}}
+		newProvider := &iprovider.Provider{Name: providerName, Models: []string{"m1"}}
+		err := cm.ProviderModelRefChecker(ctx, oldProvider, newProvider)
+		require.NoError(t, err)
+		assert.False(t, called, "fetch should be skipped when models are unchanged")
+	})
+
+	t.Run("propagates fetch error", func(t *testing.T) {
+		clusterStorager := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				return nil, errors.New("db down")
+			},
+		}
+		cm := NewClusterManager(&fakeTxn{}, clusterStorager, nil, nil, &fakePoolStorager{}, nil, nil, nil, nil)
+		err := cm.ProviderModelRefChecker(ctx, nil, &iprovider.Provider{Name: providerName})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db down")
+	})
+}
+
 func newTestClusterBase() *Cluster {
 	return &Cluster{
 		ID:   1,

--- a/model/iprovider/provider.go
+++ b/model/iprovider/provider.go
@@ -193,16 +193,43 @@ func (m *ProviderManager) UpdateProvider(ctx context.Context, name string,
 			return xerror.WrapRecordNotExist("provider")
 		}
 
+		// Capture which cluster-relevant fields are explicitly provided before
+		// the storager applies defaults (FillDefaults mutates nil slices into
+		// empty slices, which would be mistaken for an intentional clear).
+		origInstancePool := param.InstancePool
+		origKeys := param.Keys
+		origModels := param.Models
+
 		if err := m.storager.UpdateProvider(ctx, name, param); err != nil {
 			return err
 		}
 
-		// Propagate instance_pool changes to referencing clusters. Only invoke
-		// hooks when the caller explicitly supplied instance_pool and it differs
-		// from the current one.
-		if param.InstancePool != nil &&
-			len(syncHooks) > 0 &&
-			!providerInstancePoolEqual(existing.InstancePool, param.InstancePool) {
+		// Invoke hooks only when an explicitly provided cluster-relevant field
+		// actually changed. Each hook is responsible for checking whether its own
+		// concern needs action.
+		clusterConfigChanged := false
+		if origInstancePool != nil && !providerInstancePoolEqual(existing.InstancePool, origInstancePool) {
+			clusterConfigChanged = true
+		}
+		if origKeys != nil && !providerKeysEqual(existing.Keys, origKeys) {
+			clusterConfigChanged = true
+		}
+		if origModels != nil && !providerModelsEqual(existing.Models, origModels) {
+			clusterConfigChanged = true
+		}
+
+		if len(syncHooks) > 0 && clusterConfigChanged {
+			// Restore nil for unchanged fields so applyProviderUpdate preserves
+			// the existing provider values when building the hook snapshot.
+			if origInstancePool == nil {
+				param.InstancePool = nil
+			}
+			if origKeys == nil {
+				param.Keys = nil
+			}
+			if origModels == nil {
+				param.Models = nil
+			}
 			newProvider := applyProviderUpdate(existing, param)
 			for _, hook := range syncHooks {
 				if err := hook(ctx, existing, newProvider); err != nil {
@@ -741,6 +768,34 @@ func providerInstancePoolEqual(a, b []ProviderInstance) bool {
 			a[i].Port != b[i].Port ||
 			a[i].Weight != b[i].Weight ||
 			a[i].Disable != b[i].Disable {
+			return false
+		}
+	}
+	return true
+}
+
+// providerKeysEqual reports whether two provider key lists are identical.
+// Order matters because keys are replaced as an ordered array.
+func providerKeysEqual(a, b []ProviderKey) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name || a[i].Key != b[i].Key {
+			return false
+		}
+	}
+	return true
+}
+
+// providerModelsEqual reports whether two provider model lists are identical.
+// Order matters because models are replaced as an ordered array.
+func providerModelsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
 			return false
 		}
 	}

--- a/model/iprovider/provider_test.go
+++ b/model/iprovider/provider_test.go
@@ -144,13 +144,19 @@ func TestProviderManager_UpdateProvider(t *testing.T) {
 	})
 
 	t.Run("sync hook not invoked when instance_pool unchanged", func(t *testing.T) {
+		param := validProviderParam()
+		param.InstancePool = []ProviderInstance{
+			{Name: "same", Addr: "1.2.3.4", Port: 443, Weight: 100},
+		}
+
 		store := &fakeProviderStorager{
 			fetchFn: func(ctx context.Context, filter *ProviderFilter) (*Provider, error) {
 				return &Provider{
-					Name: "deepseek",
-					InstancePool: []ProviderInstance{
-						{Name: "same", Addr: "1.2.3.4", Port: 443, Weight: 100},
-					},
+					Name:           "deepseek",
+					Models:         param.Models,
+					Keys:           param.Keys,
+					InstancePool:   param.InstancePool,
+					ModelProtocols: param.ModelProtocols,
 				}, nil
 			},
 		}
@@ -162,10 +168,6 @@ func TestProviderManager_UpdateProvider(t *testing.T) {
 			return nil
 		}
 
-		param := validProviderParam()
-		param.InstancePool = []ProviderInstance{
-			{Name: "same", Addr: "1.2.3.4", Port: 443, Weight: 100},
-		}
 		err := m.UpdateProvider(ctx, "deepseek", param, hook)
 		require.NoError(t, err)
 		assert.Equal(t, 0, hookCalled)
@@ -195,6 +197,82 @@ func TestProviderManager_UpdateProvider(t *testing.T) {
 		err := m.UpdateProvider(ctx, "deepseek", param, hook)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "sync failed")
+	})
+
+	t.Run("key ref checker error rolls back", func(t *testing.T) {
+		store := &fakeProviderStorager{
+			fetchFn: func(ctx context.Context, filter *ProviderFilter) (*Provider, error) {
+				return &Provider{
+					Name: "deepseek",
+					Keys: []ProviderKey{{Name: "k1", Key: "sk-old"}},
+				}, nil
+			},
+		}
+		m := NewProviderManager(&fakeTxn{}, store)
+
+		hook := func(ctx context.Context, oldProvider, newProvider *Provider) error {
+			return errors.New("key referenced")
+		}
+
+		param := validProviderParam()
+		param.Keys = []ProviderKey{{Name: "k2", Key: "sk-new"}}
+		err := m.UpdateProvider(ctx, "deepseek", param, hook)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "key referenced")
+	})
+
+	t.Run("model ref checker error rolls back", func(t *testing.T) {
+		store := &fakeProviderStorager{
+			fetchFn: func(ctx context.Context, filter *ProviderFilter) (*Provider, error) {
+				return &Provider{
+					Name:   "deepseek",
+					Models: []string{"m1"},
+				}, nil
+			},
+		}
+		m := NewProviderManager(&fakeTxn{}, store)
+
+		hook := func(ctx context.Context, oldProvider, newProvider *Provider) error {
+			return errors.New("model referenced")
+		}
+
+		param := validProviderParam()
+		param.Models = []string{"m2"}
+		err := m.UpdateProvider(ctx, "deepseek", param, hook)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "model referenced")
+	})
+
+	t.Run("hooks not invoked when keys and models unchanged", func(t *testing.T) {
+		param := validProviderParam()
+		param.InstancePool = []ProviderInstance{
+			{Name: "same", Addr: "1.2.3.4", Port: 443, Weight: 100},
+		}
+
+		store := &fakeProviderStorager{
+			fetchFn: func(ctx context.Context, filter *ProviderFilter) (*Provider, error) {
+				return &Provider{
+					Name:           "deepseek",
+					Models:         param.Models,
+					Keys:           param.Keys,
+					InstancePool:   param.InstancePool,
+					ModelProtocols: param.ModelProtocols,
+				}, nil
+			},
+		}
+		m := NewProviderManager(&fakeTxn{}, store)
+
+		hookCalled := 0
+		hook := func(ctx context.Context, oldProvider, newProvider *Provider) error {
+			hookCalled++
+			return errors.New("should not be called")
+		}
+
+		// Only change the description; none of instance_pool/keys/models changed.
+		param.Description = lib.PString("new description")
+		err := m.UpdateProvider(ctx, "deepseek", param, hook)
+		require.NoError(t, err)
+		assert.Equal(t, 0, hookCalled)
 	})
 }
 

--- a/test/integration/tests/provider/instance_pool_sync/instance_pool_sync_test.go
+++ b/test/integration/tests/provider/instance_pool_sync/instance_pool_sync_test.go
@@ -135,6 +135,88 @@ func assertBackendExists(t *testing.T, resp *testutil.APIResponse, clusterName, 
 	t.Fatalf("backend %s (%s:%d) not found in cluster %s", name, addr, port, clusterName)
 }
 
+// PV-SYNC-1-002: deleting a provider key that is referenced by a cluster
+// should be rejected with 409 Conflict.
+func TestProvider_DeleteReferencedKeyReturnsConflict(t *testing.T) {
+	providerName := testutil.UniqueProviderName()
+	if _, err := testutil.CreateProvider(providerName, map[string]interface{}{
+		"keys": []interface{}{
+			map[string]interface{}{"name": "k1", "key": "sk-111111111111"},
+			map[string]interface{}{"name": "k2", "key": "sk-222222222222"},
+		},
+	}); err != nil {
+		t.Fatalf("setup provider failed: %v", err)
+	}
+	defer testutil.DeleteProvider(providerName)
+
+	clusterName := testutil.UniqueClusterName()
+	_, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+		"name": clusterName,
+		"llm_config": map[string]interface{}{
+			"models":   []string{"deepseek-chat"},
+			"provider": providerName,
+			"keys": []interface{}{
+				map[string]interface{}{"name": "k1", "weight": 100},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("setup cluster failed: %v", err)
+	}
+	defer testutil.DeleteCluster(clusterName)
+
+	resp, err := testutil.GetClient().Patch("/open-api/v1/providers/"+providerName, map[string]interface{}{
+		"instance_pool": []interface{}{
+			map[string]interface{}{"name": "backend-1", "addr": "10.0.0.1", "weight": 100, "port": 8080},
+		},
+		"keys": []interface{}{
+			map[string]interface{}{"name": "k2", "key": "sk-222222222222"},
+		},
+		"model_protocols": []string{"openai"},
+	})
+	if err != nil {
+		t.Fatalf("update provider failed: %v", err)
+	}
+	testutil.AssertErrCode(t, resp, 409)
+}
+
+// PV-SYNC-1-003: deleting a provider model that is referenced by a cluster
+// should be rejected with 409 Conflict.
+func TestProvider_DeleteReferencedModelReturnsConflict(t *testing.T) {
+	providerName := testutil.UniqueProviderName()
+	if _, err := testutil.CreateProvider(providerName, map[string]interface{}{
+		"models": []string{"m1", "m2"},
+	}); err != nil {
+		t.Fatalf("setup provider failed: %v", err)
+	}
+	defer testutil.DeleteProvider(providerName)
+
+	clusterName := testutil.UniqueClusterName()
+	_, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+		"name": clusterName,
+		"llm_config": map[string]interface{}{
+			"models":   []string{"m2"},
+			"provider": providerName,
+		},
+	})
+	if err != nil {
+		t.Fatalf("setup cluster failed: %v", err)
+	}
+	defer testutil.DeleteCluster(clusterName)
+
+	resp, err := testutil.GetClient().Patch("/open-api/v1/providers/"+providerName, map[string]interface{}{
+		"instance_pool": []interface{}{
+			map[string]interface{}{"name": "backend-1", "addr": "10.0.0.1", "weight": 100, "port": 8080},
+		},
+		"models":          []string{"m1"},
+		"model_protocols": []string{"openai"},
+	})
+	if err != nil {
+		t.Fatalf("update provider failed: %v", err)
+	}
+	testutil.AssertErrCode(t, resp, 409)
+}
+
 func assertBackendNotExists(t *testing.T, resp *testutil.APIResponse, clusterName, name string) {
 	t.Helper()
 	config := clusterTableConfig(t, resp)


### PR DESCRIPTION
…ty on update (#106)

- Add ProviderKeyRefChecker and ProviderModelRefChecker hooks in model/icluster_conf/cluster.go to verify clusters still reference valid provider keys/models after a provider update.
- Update ProviderManager.UpdateProvider to invoke the new hooks only when keys/models/instance_pool are explicitly changed, preserving existing behavior for partial PATCH requests (avoid FillDefaults false positives).
- Inject the new hooks into the PATCH /providers endpoint.
- Add unit tests for the checkers and hook error handling.
- Add integration tests PV-SYNC-1-002 and PV-SYNC-1-003.
- Update sys-design and OpenAPI docs to describe the new 409 behavior.

Closes #106