### PR TITLE
feat(cluster): default key_affinity.enabled to true

### DIFF
--- a/design-docs/api-define/InnerAPI接口定义/server-data-conf.md
+++ b/design-docs/api-define/InnerAPI接口定义/server-data-conf.md
@@ -223,7 +223,7 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/tls_conf/server_data_co
 | KeyPolicy.MaxRetries | int | 请求内总额外重试次数 |
 | KeyPolicy.RetryBackoffInitial | int | 初始退避时间，单位毫秒 |
 | KeyPolicy.RetryBackoffMax | int | 最大退避时间，单位毫秒 |
-| KeyPolicy.SessionAffinity | bool | 是否开启会话级 Key 亲和性；对应 OpenAPI `llm_config.key_affinity.enabled`，默认 `false` |
+| KeyPolicy.SessionAffinity | bool | 是否开启会话级 Key 亲和性；对应 OpenAPI `llm_config.key_affinity.enabled`，默认 `true` |
 | KeyPolicy.SessionAffinityTTL | int | 绑定空闲超时时间，单位秒；对应 OpenAPI `llm_config.key_affinity.ttl`，默认 `600`；命中后 BFE 会刷新 TTL |
 | KeyPolicy.SessionAffinityRedisPrefix | string | Redis 绑定键前缀；对应 OpenAPI `llm_config.key_affinity.redis_prefix`，默认 `"bfe:ai:key_affinity"` |
 | KeyPolicy.SessionAffinityPenaltyEnable | bool | 是否开启 Key 惩罚；对应 OpenAPI `llm_config.key_affinity.penalty_enable`，默认 `true` |

--- a/design-docs/api-define/OpenAPI接口定义/clusters.md
+++ b/design-docs/api-define/OpenAPI接口定义/clusters.md
@@ -163,7 +163,7 @@
 
 | 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
 | - | - | - | - | - | - |
-| enabled | bool | 是否开启会话级 Key 亲和性 | N | 默认 `false`；为 `true` 时开启基于 Redis + `ClientKeyId` 的 Key 绑定 | 非必填；必须为 bool |
+| enabled | bool | 是否开启会话级 Key 亲和性 | N | 默认 `true`；为 `true` 时开启基于 Redis + `ClientKeyId` 的 Key 绑定 | 非必填；必须为 bool |
 | ttl | int | 绑定空闲超时时间 | N | 单位秒，默认 `600`；命中绑定后 BFE 会刷新 TTL，持续请求则绑定保持 | 非必填；若传入，须为 `>0` 的整数 |
 | redis_prefix | string | Redis key 前缀 | N | 默认 `"bfe:ai:key_affinity"` | 非必填；若传入，必须非空 |
 | penalty_enable | bool | 是否开启 Key 惩罚 | N | 默认 `true`；为 `true` 时，近期返回 429/401/403 的 Key 会被跳过 | 非必填；必须为 bool |

--- a/design-docs/sys-design/模型层设计文档.md
+++ b/design-docs/sys-design/模型层设计文档.md
@@ -669,7 +669,7 @@ type AIKeyPolicy struct {
     MaxRetries                   int
     RetryBackoffInitial          int
     RetryBackoffMax              int
-    SessionAffinity              bool   // 默认 false
+    SessionAffinity              bool   // 默认 true
     SessionAffinityTTL           int    // 绑定空闲超时时间，默认 600，单位秒
     SessionAffinityRedisPrefix   string // Redis key 前缀，默认 "bfe:ai:key_affinity"
     SessionAffinityPenaltyEnable bool   // 是否开启 Key 惩罚，默认 true
@@ -718,7 +718,7 @@ type AIConf struct {
 }
 ```
 
-导出时 `KeyPolicy` 字段若未配置则填充默认值：`Strategy="weighted_random"`、`MaxRetries=0`、`RetryBackoffInitial=500`、`RetryBackoffMax=5000`、`SessionAffinity=false`、`SessionAffinityTTL=600`、`SessionAffinityRedisPrefix="bfe:ai:key_affinity"`、`SessionAffinityPenaltyEnable=true`。
+导出时 `KeyPolicy` 字段若未配置则填充默认值：`Strategy="weighted_random"`、`MaxRetries=0`、`RetryBackoffInitial=500`、`RetryBackoffMax=5000`、`SessionAffinity=true`、`SessionAffinityTTL=600`、`SessionAffinityRedisPrefix="bfe:ai:key_affinity"`、`SessionAffinityPenaltyEnable=true`。
 
 导出逻辑：
 

--- a/endpoints/openapi_v1/product_cluster/create.go
+++ b/endpoints/openapi_v1/product_cluster/create.go
@@ -331,13 +331,37 @@ func normalizeLLMConfig(llm *icluster_conf.LLMConfig) *icluster_conf.LLMConfig {
 		ModelMappings: llm.ModelMappings,
 		Keys:          llm.Keys,
 		KeyPolicy:     llm.KeyPolicy,
-		KeyAffinity:   llm.KeyAffinity,
+		KeyAffinity:   normalizeKeyAffinity(llm.KeyAffinity),
 		Provider:      llm.Provider,
 		MatchPrefix:   llm.MatchPrefix,
 		StripPrefix:   llm.StripPrefix,
 	}
 	if rst.Keys == nil {
 		rst.Keys = []icluster_conf.ClusterKeyRef{}
+	}
+
+	return rst
+}
+
+func normalizeKeyAffinity(affinity *icluster_conf.KeyAffinity) *icluster_conf.KeyAffinity {
+	rst := &icluster_conf.KeyAffinity{}
+	if affinity != nil {
+		rst.Enabled = affinity.Enabled
+		rst.TTL = affinity.TTL
+		rst.RedisPrefix = affinity.RedisPrefix
+		rst.PenaltyEnable = affinity.PenaltyEnable
+	}
+	if rst.Enabled == nil {
+		rst.Enabled = lib.PBool(true)
+	}
+	if rst.TTL == nil {
+		rst.TTL = lib.PInt(600)
+	}
+	if rst.RedisPrefix == nil {
+		rst.RedisPrefix = lib.PString("bfe:ai:key_affinity")
+	}
+	if rst.PenaltyEnable == nil {
+		rst.PenaltyEnable = lib.PBool(true)
 	}
 
 	return rst

--- a/endpoints/openapi_v1/product_cluster/create_test.go
+++ b/endpoints/openapi_v1/product_cluster/create_test.go
@@ -204,4 +204,31 @@ func TestNormalizeLLMConfig(t *testing.T) {
 		assert.Equal(t, "bfe:ai:key_affinity", *got.KeyAffinity.RedisPrefix)
 		assert.Equal(t, true, *got.KeyAffinity.PenaltyEnable)
 	})
+
+	t.Run("key_affinity fills defaults when empty object", func(t *testing.T) {
+		in := &icluster_conf.LLMConfig{
+			Models:      []string{"gpt-4"},
+			KeyAffinity: &icluster_conf.KeyAffinity{},
+		}
+		got := normalizeLLMConfig(in)
+		require.NotNil(t, got)
+		require.NotNil(t, got.KeyAffinity)
+		assert.Equal(t, true, *got.KeyAffinity.Enabled)
+		assert.Equal(t, 600, *got.KeyAffinity.TTL)
+		assert.Equal(t, "bfe:ai:key_affinity", *got.KeyAffinity.RedisPrefix)
+		assert.Equal(t, true, *got.KeyAffinity.PenaltyEnable)
+	})
+
+	t.Run("key_affinity fills defaults when nil", func(t *testing.T) {
+		in := &icluster_conf.LLMConfig{
+			Models: []string{"gpt-4"},
+		}
+		got := normalizeLLMConfig(in)
+		require.NotNil(t, got)
+		require.NotNil(t, got.KeyAffinity)
+		assert.Equal(t, true, *got.KeyAffinity.Enabled)
+		assert.Equal(t, 600, *got.KeyAffinity.TTL)
+		assert.Equal(t, "bfe:ai:key_affinity", *got.KeyAffinity.RedisPrefix)
+		assert.Equal(t, true, *got.KeyAffinity.PenaltyEnable)
+	})
 }

--- a/model/icluster_conf/cluster.go
+++ b/model/icluster_conf/cluster.go
@@ -205,7 +205,7 @@ type KeyPolicy struct {
 }
 
 type KeyAffinity struct {
-	Enabled       *bool   `json:"enabled"`        // default false
+	Enabled       *bool   `json:"enabled"`        // default true
 	TTL           *int    `json:"ttl"`            // idle timeout in seconds, default 600
 	RedisPrefix   *string `json:"redis_prefix"`   // default "bfe:ai:key_affinity"
 	PenaltyEnable *bool   `json:"penalty_enable"` // default true
@@ -1261,7 +1261,7 @@ func newAIConf(llmConfig *LLMConfig, modelTable *cluster_conf.ModelTable,
 		MaxRetries:                   0,
 		RetryBackoffInitial:          500,
 		RetryBackoffMax:              5000,
-		SessionAffinity:              false,
+		SessionAffinity:              true,
 		SessionAffinityTTL:           600,
 		SessionAffinityRedisPrefix:   "bfe:ai:key_affinity",
 		SessionAffinityPenaltyEnable: true,
@@ -1273,7 +1273,7 @@ func newAIConf(llmConfig *LLMConfig, modelTable *cluster_conf.ModelTable,
 		aiConf.KeyPolicy.RetryBackoffMax = derefInt(llmConfig.KeyPolicy.RetryBackoffMax, 5000)
 	}
 	if llmConfig.KeyAffinity != nil {
-		aiConf.KeyPolicy.SessionAffinity = derefBool(llmConfig.KeyAffinity.Enabled, false)
+		aiConf.KeyPolicy.SessionAffinity = derefBool(llmConfig.KeyAffinity.Enabled, true)
 		aiConf.KeyPolicy.SessionAffinityTTL = derefInt(llmConfig.KeyAffinity.TTL, 600)
 		aiConf.KeyPolicy.SessionAffinityRedisPrefix = derefString(llmConfig.KeyAffinity.RedisPrefix, "bfe:ai:key_affinity")
 		aiConf.KeyPolicy.SessionAffinityPenaltyEnable = derefBool(llmConfig.KeyAffinity.PenaltyEnable, true)

--- a/test/integration/tests/clusters/design.md
+++ b/test/integration/tests/clusters/design.md
@@ -15,7 +15,7 @@ v0.0.7 起，`llm_config` 支持多 API-Key：
   - 两个字段透传到 InnerAPI 导出的 `AIConf.MatchPrefix` / `StripPrefix`，由 BFE 在转发前执行前缀裁剪。
 - v0.6 起，`llm_config` 新增 `key_affinity`（会话级 Key 亲和性）：
   - 非必填，用于基于 Redis + `ClientKeyId` 保持同一客户端会话在一段时间内命中同一个后端 API-Key；
-  - 包含 `enabled`（默认 `false`）、`ttl`（空闲超时秒数，默认 `600`）、`redis_prefix`（默认 `"bfe:ai:key_affinity"`）、`penalty_enable`（默认 `true`）；
+  - 包含 `enabled`（默认 `true`）、`ttl`（空闲超时秒数，默认 `600`）、`redis_prefix`（默认 `"bfe:ai:key_affinity"`）、`penalty_enable`（默认 `true`）；
   - 若传入 `ttl` 必须 `>0`；若传入 `redis_prefix` 必须非空；
   - 导出到 InnerAPI 的 `AIConf.KeyPolicy.SessionAffinity*` 字段。
 

--- a/test/integration/tests/innerapi/tls_conf/design.md
+++ b/test/integration/tests/innerapi/tls_conf/design.md
@@ -112,7 +112,7 @@ innerapi/tls_conf/
 - **前置**：创建集群时不传 `key_affinity`。
 - **请求**：`GET /inner-api/v1/configs/tls_conf/server_data_conf`
 - **预期**：
-  - `ClusterConf.Config.<cluster>.AIConf.KeyPolicy.SessionAffinity == false`；
+  - `ClusterConf.Config.<cluster>.AIConf.KeyPolicy.SessionAffinity == true`；
   - `ClusterConf.Config.<cluster>.AIConf.KeyPolicy.SessionAffinityTTL == 600`；
   - `ClusterConf.Config.<cluster>.AIConf.KeyPolicy.SessionAffinityRedisPrefix == "bfe:ai:key_affinity"`；
   - `ClusterConf.Config.<cluster>.AIConf.KeyPolicy.SessionAffinityPenaltyEnable == true`。

--- a/test/integration/tests/innerapi/tls_conf/tls_conf_test.go
+++ b/test/integration/tests/innerapi/tls_conf/tls_conf_test.go
@@ -128,7 +128,7 @@ func TestInnerAPI_TlsConf(t *testing.T) {
 		assert.Equal(t, float64(3), policy["MaxRetries"])
 		assert.Equal(t, float64(100), policy["RetryBackoffInitial"])
 		assert.Equal(t, float64(5000), policy["RetryBackoffMax"])
-		assert.Equal(t, false, policy["SessionAffinity"])
+		assert.Equal(t, true, policy["SessionAffinity"])
 		assert.Equal(t, float64(600), policy["SessionAffinityTTL"])
 		assert.Equal(t, "bfe:ai:key_affinity", policy["SessionAffinityRedisPrefix"])
 		assert.Equal(t, true, policy["SessionAffinityPenaltyEnable"])
@@ -435,7 +435,7 @@ models:
 		if !assert.True(t, ok, "AIConf.KeyPolicy should be an object") {
 			return
 		}
-		assert.Equal(t, false, keyPolicy["SessionAffinity"])
+		assert.Equal(t, true, keyPolicy["SessionAffinity"])
 		assert.Equal(t, float64(600), keyPolicy["SessionAffinityTTL"])
 		assert.Equal(t, "bfe:ai:key_affinity", keyPolicy["SessionAffinityRedisPrefix"])
 		assert.Equal(t, true, keyPolicy["SessionAffinityPenaltyEnable"])


### PR DESCRIPTION
- Set KeyAffinity.Enabled default to true in model and export

- Normalize key_affinity fields in create/update handlers

- Update related tests and design docs