### PR TITLE
fix(route-tables): align API-Key route table type with API doc

### DIFF
--- a/model/shared/types.go
+++ b/model/shared/types.go
@@ -168,10 +168,38 @@ type RouteTableParam struct {
 }
 
 const (
+	// RouteRulesTypeAPIKey is the internal storage/BFE export value for
+	// API-Key route rules. The OpenAPI /route-tables endpoint exposes it
+	// as RouteTableTypeAPIKey ("api_key") for consistency with the API doc.
 	RouteRulesTypeAPIKey = "apikey"
 	RouteRulesTypeEntity = "entity"
 	RouteRulesTypeGlobal = "global"
 )
+
+// OpenAPI-facing route table type values, as defined in the API document.
+const (
+	RouteTableTypeAPIKey = "api_key"
+	RouteTableTypeEntity = "entity"
+	RouteTableTypeGlobal = "global"
+)
+
+// ToRouteTableType maps an internal route rules type to the value exposed by
+// the OpenAPI /route-tables endpoint.
+func ToRouteTableType(internalType string) string {
+	if internalType == RouteRulesTypeAPIKey {
+		return RouteTableTypeAPIKey
+	}
+	return internalType
+}
+
+// FromRouteTableType maps an OpenAPI /route-tables type query parameter to the
+// internal route rules type used in storage and BFE exports.
+func FromRouteTableType(apiType string) string {
+	if apiType == RouteTableTypeAPIKey {
+		return RouteRulesTypeAPIKey
+	}
+	return apiType
+}
 
 // RouteRulesFilter defines filters for querying route rules
 type RouteRulesFilter struct {

--- a/storage/rdb/route_rules/route_rules.go
+++ b/storage/rdb/route_rules/route_rules.go
@@ -192,7 +192,7 @@ func (s *RouteRulesStorager) FetchRouteRulesList(ctx context.Context, filter *sh
 	for _, one := range list {
 		result = append(result, &shared.RouteTableParam{
 			ID:      &one.ID,
-			Type:    one.Type,
+			Type:    shared.ToRouteTableType(one.Type),
 			Owner:   one.Owner,
 			Enabled: one.Enabled,
 		})
@@ -209,6 +209,10 @@ func routeRulesFilterToParam(filter *shared.RouteRulesFilter) *dao.TRouteRulesPa
 	param := &dao.TRouteRulesParam{
 		Type:  filter.Type,
 		Owner: filter.Owner,
+	}
+	if param.Type != nil {
+		internalType := shared.FromRouteTableType(*param.Type)
+		param.Type = &internalType
 	}
 	if filter.Enabled != nil {
 		param.Enabled = filter.Enabled

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bfenetworks/bfe v1.8.5 // indirect
+	github.com/bfenetworks/bfe v1.8.6 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/test/integration/tests/route_tables/list/list_test.go
+++ b/test/integration/tests/route_tables/list/list_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
 var sm *testutil.ServerManager
@@ -92,7 +92,7 @@ func TestRouteTables_List(t *testing.T) {
 		assert.GreaterOrEqual(t, len(list), 3)
 		assert.True(t, hasType(list, "global"))
 		assert.True(t, hasType(list, "entity"))
-		assert.True(t, hasType(list, "apikey"))
+		assert.True(t, hasType(list, "api_key"))
 	})
 
 	t.Run("RT-1-002 按 type=global 过滤", func(t *testing.T) {
@@ -121,8 +121,8 @@ func TestRouteTables_List(t *testing.T) {
 		}
 	})
 
-	t.Run("RT-1-004 按 type=apikey 过滤", func(t *testing.T) {
-		resp, err := testutil.GetClient().Get("/open-api/v1/route-tables", map[string]string{"type": "apikey"})
+	t.Run("RT-1-004 按 type=api_key 过滤", func(t *testing.T) {
+		resp, err := testutil.GetClient().Get("/open-api/v1/route-tables", map[string]string{"type": "api_key"})
 		if err != nil {
 			t.Fatalf("request failed: %v", err)
 		}
@@ -130,7 +130,7 @@ func TestRouteTables_List(t *testing.T) {
 		var data map[string]interface{}
 		json.Unmarshal(resp.Data, &data)
 		for _, item := range data["list"].([]interface{}) {
-			assert.Equal(t, "apikey", item.(map[string]interface{})["type"])
+			assert.Equal(t, "api_key", item.(map[string]interface{})["type"])
 		}
 	})
 
@@ -143,7 +143,7 @@ func TestRouteTables_List(t *testing.T) {
 		var data map[string]interface{}
 		json.Unmarshal(resp.Data, &data)
 		list := data["list"].([]interface{})
-		assert.GreaterOrEqual(t, len(list), 1, "按 apiKeyID 过滤应至少返回一条 apikey 路由表")
+		assert.GreaterOrEqual(t, len(list), 1, "按 apiKeyID 过滤应至少返回一条 api_key 路由表")
 		for _, item := range list {
 			assert.Equal(t, apiKeyID, item.(map[string]interface{})["owner"])
 		}


### PR DESCRIPTION
- Expose api_key in OpenAPI /route-tables response and query parameter
- Keep internal storage and BFE export value as apikey for compatibility
- Update integration test to assert api_key

Fixes #113