### PR TITLE
feat(operation-log): record failed write operations and update sys-de…

### DIFF
--- a/design-docs/modifications/2026-08-31-operation-log-failure-records/change-summary.md
+++ b/design-docs/modifications/2026-08-31-operation-log-failure-records/change-summary.md
@@ -1,0 +1,45 @@
+# 操作日志失败记录变更摘要
+
+> 关联 issue：[ai-gateway-api#117](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/117)  
+> 前置设计文档：`ai-gateway-api/design-docs/modifications/2026-08-31-operation-log/`
+
+## 1. 背景
+
+`ai-gateway-api` 在 2026-08-31-operation-log 变更中已为所有配置域接入操作日志，并在设计文档中明确：
+
+> “失败操作一并记录 | 写操作失败时同样记录日志（`status = 2`），保留失败审计证据。”
+
+但实际代码实现仅在写操作**成功**后调用 `OperationLogManager.Record()`。以 `ClusterManager.DeleteCluster` 为例，当集群仍被路由规则引用时，事务执行失败直接返回错误，操作日志表中不会留下任何记录，导致管理员无法通过 `GET /operation-logs` 追溯到这次失败的删除尝试。
+
+## 2. 目标
+
+- 让所有配置域的写操作在失败时也能生成一条 `status = 2` 的操作日志。
+- 失败日志需携带简明的错误信息（`error_msg`），便于审计与排障。
+- 保持现有成功日志行为不变，不引入新的 API 契约变更。
+
+## 3. 范围
+
+| 范围 | 说明 |
+|------|------|
+| 涉及仓库 | `ai-gateway-api` |
+| 涉及模块 | 所有已接入操作日志的配置域 Manager：`model/entity`、`model/api_key`、`model/iprovider`、`model/icluster_conf`、`model/iroute_conf`、`model/iprotocol`、`model/quota`、`model/rate_limit_policy`、`model/imodel_price`、`model/iauth` |
+| 涉及接口 | 无接口契约变更；`GET /open-api/v1/operation-logs` 已支持按 `status` 过滤 |
+| 数据迁移 | 无，复用现有 `operation_logs` 表的 `status` 与 `error_msg` 字段 |
+| 数据面影响 | 无 |
+
+## 4. 关键决策
+
+| 决策 | 说明 |
+|------|------|
+| 统一 `recordXxxOperation` 签名 | 各域的私有记录函数增加 `err error` 入参，由函数内部根据 `err != nil` 决定 `Status` 与 `ErrorMsg`。 |
+| 失败分支显式调用 | 在 Manager 的 Create / Update / Delete / Reset / Import / 授权变更等写操作返回错误前，调用记录函数并传入错误。 |
+| 错误信息截断 | `error_msg` 字段为 `varchar(1024)`，超过长度时截断并追加省略标记，避免写入数据库时超长。 |
+| 异步落盘不变 | 失败日志仍通过 `OperationLogManager.Record()` 进入异步缓冲队列，不阻塞业务返回。 |
+| 最小可识别信息 | 失败日志至少包含操作动作、资源类型、资源 ID / 名称、失败原因；变更摘要（`change_summary`）在失败时尽可能保留入参或旧值。 |
+
+## 5. 关联文档
+
+- `ai-gateway-api/design-docs/modifications/2026-08-31-operation-log/change-summary.md`
+- `ai-gateway-api/design-docs/modifications/2026-08-31-operation-log/api-changes.md`
+- `ai-gateway-api/design-docs/modifications/2026-08-31-operation-log/design-changes.md`
+- `ai-gateway-api/design-docs/modifications/2026-08-31-operation-log-failure-records/design-changes.md`

--- a/design-docs/modifications/2026-08-31-operation-log-failure-records/design-changes.md
+++ b/design-docs/modifications/2026-08-31-operation-log-failure-records/design-changes.md
@@ -1,0 +1,206 @@
+# 操作日志失败记录设计变更说明
+
+## 1. 现状问题
+
+当前各配置域的操作日志记录函数固定将 `Status` 设置为 `ioperlog.StatusSuccess`，且不接收 `error` 入参，例如：
+
+```go
+// model/icluster_conf/cluster_operation_log.go
+func (cm *ClusterManager) recordClusterOperation(
+    ctx context.Context,
+    action string,
+    clusterID int64,
+    clusterName string,
+    before, after map[string]interface{},
+) {
+    entry := &ioperlog.OperationLogEntry{
+        ...
+        Status: ioperlog.StatusSuccess,
+        ...
+    }
+    cm.operationLogManager.Record(ctx, entry)
+}
+```
+
+Manager 的写操作仅在成功分支调用该函数：
+
+```go
+// model/icluster_conf/cluster.go
+func (cm *ClusterManager) DeleteCluster(...) (err error) {
+    err = cm.txn.AtomExecute(ctx, func(ctx context.Context) error {
+        ...
+    })
+    if err != nil {
+        return err   // 失败时无日志
+    }
+    cm.recordClusterOperation(...)
+    return nil
+}
+```
+
+这导致 [issue #117](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/117) 中描述的 `DELETE /clusters/{cluster_name}` 失败场景没有任何操作日志。
+
+## 2. 设计变更
+
+### 2.1 新增错误信息截断工具函数
+
+在 `model/ioperlog` 中新增辅助函数，确保 `error_msg` 不超过数据库字段长度：
+
+```go
+// model/ioperlog/helper.go
+func TruncateErrorMessage(err error, maxLen int) string
+```
+
+- `maxLen` 默认取 `1024`，与 `operation_logs.error_msg` 字段长度一致。
+- 截断时保留末尾省略标记（如 `...`），使阅读者明确信息已被截断。
+- 若 `err == nil` 返回空字符串。
+
+### 2.2 修改各域记录函数签名
+
+所有 `recordXxxOperation` 函数统一增加 `err error` 入参：
+
+```go
+func (cm *ClusterManager) recordClusterOperation(
+    ctx context.Context,
+    action string,
+    clusterID int64,
+    clusterName string,
+    before, after map[string]interface{},
+    err error,   // 新增
+)
+```
+
+函数内部：
+
+```go
+status := ioperlog.StatusSuccess
+errorMsg := ""
+if err != nil {
+    status = ioperlog.StatusFailed
+    errorMsg = ioperlog.TruncateErrorMessage(err, 1024)
+}
+
+entry := &ioperlog.OperationLogEntry{
+    ...
+    Status:   status,
+    ErrorMsg: errorMsg,
+    ...
+}
+
+cm.operationLogManager.Record(ctx, entry)
+```
+
+涉及文件：
+
+| 域 | 记录函数文件 |
+|----|--------------|
+| entity | `model/entity/operation_log.go` |
+| api_key | `model/api_key/api_key_operation_log.go` |
+| provider | `model/iprovider/provider_operation_log.go` |
+| cluster | `model/icluster_conf/cluster_operation_log.go` |
+| route / domain | `model/iroute_conf/operation_log.go` |
+| certificate | `model/iprotocol/operation_log.go` |
+| quota_plan | `model/quota/operation_log.go` |
+| rate_limit_policy | `model/rate_limit_policy/operation_log.go` |
+| model_price | `model/imodel_price/operation_log.go` |
+| user / token | `model/iauth/operation_log.go` |
+
+### 2.3 在 Manager 失败分支补充调用
+
+对每个 Manager 的写操作，在返回错误前调用记录函数并传入 `err`。典型模式：
+
+```go
+err = cm.txn.AtomExecute(ctx, func(ctx context.Context) error { ... })
+if err != nil {
+    cm.recordClusterOperation(
+        ctx,
+        string(ioperlog.ActionDelete),
+        cluster.ID,
+        cluster.Name,
+        clusterToMap(cluster),
+        nil,
+        err,
+    )
+    return err
+}
+cm.recordClusterOperation(
+    ctx,
+    string(ioperlog.ActionDelete),
+    cluster.ID,
+    cluster.Name,
+    clusterToMap(cluster),
+    nil,
+    nil,
+)
+return nil
+```
+
+优先处理 [issue #117](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/117) 相关的 `ClusterManager.DeleteCluster`，随后批量处理其余 Manager：
+
+| Manager | 文件路径 | 需补充失败日志的动作 |
+|---------|----------|----------------------|
+| EntityManager | `model/entity/entity_manager.go` | Create / Update / Delete |
+| EntityTypeManager | `model/entity/entity_type_manager.go` | Create / Update / Delete |
+| APIKeyManager | `model/api_key/api_key.go` | Create / Update / Delete |
+| ProviderManager | `model/iprovider/provider.go` | Create / Update / Delete |
+| ClusterManager | `model/icluster_conf/cluster.go` | Create / Update / Delete |
+| RouteRuleManager | `model/iroute_conf/route_rule.go` | Create / Update / Delete |
+| DomainManager | `model/iroute_conf/domain.go` | Create / Update / Delete |
+| CertificateManager | `model/iprotocol/certificate.go` | Create / Update / Delete |
+| QuotaPlanManager | `model/quota/quota_plan_manager.go` | Create / Update / Delete / Reset |
+| RateLimitPolicyManager | `model/rate_limit_policy/rate_limit_policy_manager.go` | Create / Update / Delete |
+| ModelPriceManager | `model/imodel_price/model_price.go` | Create / Update / Delete / Import |
+| AuthManager | `model/iauth/authentication.go` / `authorization.go` | User / Token 的 Create / Update / Delete / 授权变更 |
+
+### 2.4 失败时变更摘要的处理
+
+- **Create 失败**：`change_summary` 可仅包含请求入参（`after`），帮助定位因参数校验失败导致的错误。
+- **Update 失败**：若已查询到旧值，则保留 `before`；否则仅记录请求入参。
+- **Delete 失败**：保留被删除对象的旧值（`before`），与成功删除时一致。
+- 所有写入 `change_summary` 的数据继续经过 `ioperlog.MaskSensitiveFields()` 脱敏。
+
+## 3. 接口与数据模型影响
+
+### 3.1 API 接口
+
+无变化。`GET /open-api/v1/operation-logs` 已支持 `status` 参数（`1` 成功，`2` 失败）和 `error_msg` 字段。
+
+### 3.2 数据表
+
+无变化。复用 `operation_logs` 表的现有字段：
+
+```sql
+`status` tinyint(4) NOT NULL DEFAULT '1' COMMENT '操作结果：1=success, 2=failed',
+`error_msg` varchar(1024) NOT NULL DEFAULT '' COMMENT '失败时的简要错误信息',
+```
+
+## 4. 系统设计文档更新
+
+为保持 `design-docs/sys-design/` 与代码实现同步，进行以下更新：
+
+- `sys-design/模型层设计文档.md` 第 4.25 节：补充失败日志的写入时机、`recordXxxOperation` 的 `err` 参数语义、以及 `ClusterManager.DeleteCluster` 等典型失败路径示例。
+- `sys-design/数据库设计文档.md` 第 6.9 节：补充 `status` 与 `error_msg` 字段在失败审计中的用途说明。
+- 新增 `sys-design/details/操作日志模块.md`：沉淀操作日志模块的总体架构、数据模型、写入流程、异步批量机制、脱敏规则、接入域、失败日志处理、测试策略与边界情况。
+- 更新 `sys-design/summary.md`：将"操作日志模块"索引从指向 modifications 改为指向新的 `details/操作日志模块.md`。
+
+## 5. 测试要求
+
+- 为 `ClusterManager.DeleteCluster` 新增失败场景单元测试：构造 delete checker 返回错误，断言生成的日志 `Status == ioperlog.StatusFailed` 且 `ErrorMsg` 非空。
+- 为 `EntityManager` / `EntityTypeManager` 补充失败场景单元测试。
+- 其余域至少保证编译通过；时间允许时补充失败断言。
+- 运行：
+
+```bash
+cd ai-gateway-api
+make test-model
+make test-model-cover-gate
+```
+
+确保 `model/` 语句覆盖率不低于 70%。
+
+## 6. 风险与注意事项
+
+- **避免循环**：记录失败日志时不应触发新的业务校验或写操作，仅做数据组装。
+- **幂等性**：同一操作多次失败会产生多条失败日志，符合审计需求。
+- **错误信息敏感内容**：当前直接记录 `err.Error()`；若后续有合规要求，可在 `TruncateErrorMessage` 中增加敏感词过滤。
+- **队列压力**：失败日志数量通常远低于成功日志，异步缓冲队列压力可忽略。

--- a/design-docs/sys-design/details/操作日志模块.md
+++ b/design-docs/sys-design/details/操作日志模块.md
@@ -1,0 +1,228 @@
+# 操作日志模块
+
+## 1. 背景与目标
+
+`ai-gateway-api` 作为 AI 网关的控制面，会频繁发生配置变更（创建/更新/删除 Entity、Cluster、Route、API-Key 等）。这些变更是故障追溯、安全审计、合规检查的关键依据。操作日志模块的目标是：
+
+- 记录所有会产生写操作的配置变更；
+- 区分成功与失败操作，保留失败审计证据；
+- 对敏感字段脱敏，避免日志泄露；
+- 采用异步批量写入，尽量降低对主业务请求的延迟影响；
+- 提供结构化查询接口 `GET /open-api/v1/operation-logs`。
+
+## 2. 总体架构
+
+操作日志模块位于 `model/ioperlog`，向下通过 `storage/rdb/ioperlog` 落库，向上为各业务 Manager 提供 `OperationLogRecorder` 接口。
+
+```
+endpoints/openapi_v1/operation_log
+        │
+        ▼
+   model/ioperlog
+   ├─ types.go      # 数据类型与接口
+   ├─ manager.go    # 异步缓冲 + 批量写入 + 查询
+   ├─ mask.go       # 敏感字段脱敏
+   └─ helper.go     # 错误信息截断等工具
+        │
+        ▼
+   storage/rdb/ioperlog
+   └─ operation_log.go  # DAO 封装
+```
+
+各业务 Manager 在 `stateful/container/container.go` 中通过 `SetOperationLogManager` 注入 `OperationLogManager`。
+
+## 3. 核心数据模型
+
+### 3.1 `OperationLogEntry`
+
+```go
+type OperationLogEntry struct {
+    ID               int64
+    LogID            string
+    OperatorType     OperatorType // 0=user, 1=token
+    OperatorID       int64
+    OperatorName     string
+    Action           string       // create/update/delete/reset/import/bind/unbind
+    ResourceType     string       // entity/api_key/provider/cluster/...
+    ResourceID       string
+    ResourceName     string
+    ResourceParentID string
+    Status           int8         // 1=success, 2=failed
+    ErrorMsg         string
+    ChangeSummary    map[string]interface{} // 脱敏后的变更摘要
+    RequestPath      string
+    RequestMethod    string
+    ClientIP         string
+    UserAgent        string
+    CreatedAt        time.Time
+}
+```
+
+### 3.2 状态与动作常量
+
+```go
+const (
+    StatusSuccess int8 = 1
+    StatusFailed  int8 = 2
+)
+
+const (
+    ActionCreate   ActionType = "create"
+    ActionUpdate   ActionType = "update"
+    ActionDelete   ActionType = "delete"
+    ActionReset    ActionType = "reset"
+    ActionImport   ActionType = "import"
+    ActionBind     ActionType = "bind"
+    ActionUnbind   ActionType = "unbind"
+)
+```
+
+## 4. 写入流程
+
+### 4.1 成功路径
+
+业务 Manager 在事务成功提交后，组装 `OperationLogEntry` 并调用 `Record`：
+
+```go
+m.recordClusterOperation(ctx, string(ioperlog.ActionCreate), clusterID, clusterName, nil, clusterParamToMap(param), nil)
+```
+
+此时 `Status = StatusSuccess`，`ErrorMsg` 为空。
+
+### 4.2 失败路径
+
+当写操作因参数校验、业务约束、数据库错误等原因失败时，在返回错误前调用同一函数并传入 `err`：
+
+```go
+err = cm.txn.AtomExecute(ctx, func(ctx context.Context) error {
+    for _, checker := range cm.deleteCheckers {
+        if err = checker(ctx, product, cluster); err != nil {
+            return err
+        }
+    }
+    // ...
+})
+if err != nil {
+    cm.recordClusterOperation(ctx, string(ioperlog.ActionDelete), cluster.ID, cluster.Name, clusterToMap(cluster), nil, err)
+    return err
+}
+```
+
+`recordClusterOperation` 内部根据 `err != nil` 设置 `Status = StatusFailed`，并调用 `ioperlog.TruncateErrorMessageDefault(err)` 填充 `ErrorMsg`。
+
+### 4.3 错误信息截断
+
+`operation_logs.error_msg` 字段为 `varchar(1024)`。`TruncateErrorMessage` 将超过长度的错误信息截断并追加 `...` 省略标记，避免数据库写入失败。
+
+```go
+func TruncateErrorMessage(err error, maxLen int) string
+func TruncateErrorMessageDefault(err error) string // maxLen = 1024
+```
+
+## 5. 异步批量机制
+
+`OperationLogManager` 采用内存缓冲通道 + 后台批量 worker：
+
+- 缓冲通道默认容量 `4096` 条；
+- 批量大小默认 `200` 条；flush 超时默认 `5s`；
+- `Record(ctx, entry)` 先由 `ContextExtractor` 从 `ctx` 注入 `log_id`、请求路径、客户端 IP 等请求级字段，再投递到缓冲通道；
+- 缓冲满或关闭时降级为同步写入；写入失败重试 3 次，仍失败则记录 error log；
+- 进程退出时 `Close()` flush 缓冲区剩余日志。
+
+失败日志与成功日志走同一条异步通道，不阻塞业务返回。
+
+## 6. 敏感字段脱敏
+
+`model/ioperlog/mask.go` 提供统一脱敏函数：
+
+```go
+func MaskAPIKeyToken(token string) string
+func MaskString(string) string
+func MaskSensitiveFields(data map[string]interface{}) map[string]interface{}
+```
+
+脱敏规则：
+
+| 字段 | 规则 |
+|------|------|
+| `password`、`secret`、`session_key`、`private_key` 等 | 替换为 `******` |
+| `api_key`、`apikey`、`key`（字符串类型） | 保留前 4 位和后 4 位，中间用 `****` 替代 |
+| `certificate`、`cert_body`、`private_key_body` 等 | 替换为 `[已更新]`，不记录具体内容 |
+| 嵌套 map | 递归脱敏 |
+
+各业务 Manager 在构造 `change_summary` 后调用 `MaskSensitiveFields`，确保持久化前完成脱敏。
+
+## 7. 接入域与调用模式
+
+以下 Manager 已接入操作日志：
+
+| 域 | Manager 文件 | 记录动作 |
+|----|--------------|----------|
+| entity | `model/entity/entity_manager.go` | Create / Update / Delete |
+| entity_type | `model/entity/entity_type_manager.go` | Create / Update / Delete |
+| api_key | `model/api_key/api_key.go` | Create / Update / Delete |
+| provider | `model/iprovider/provider.go` | Create / Update / Delete / UpdatePricingTiers |
+| cluster | `model/icluster_conf/cluster.go` | Create / Update / Delete |
+| route | `model/iroute_conf/route_rule.go` | Upsert / Delete |
+| domain | `model/iroute_conf/domain.go` | Create / Update / Delete |
+| certificate | `model/iprotocol/certificate.go` | Create / Delete / SetDefault |
+| quota_plan | `model/quota/quota_plan_manager.go` | Create / Update / Delete / Reset |
+| rate_limit_policy | `model/rate_limit_policy/rate_limit_policy_manager.go` | Create / Update / Delete |
+| model_price | `model/imodel_price/model_price.go` | Create / Update / Delete / Import |
+| user / token | `model/iauth/authentication.go` / `authorization.go` | Create / Update / Delete / Reset / 授权变更 |
+
+每个域的 `operation_log.go` 提供类似如下私有函数：
+
+```go
+func (m *XxxManager) recordXxxOperation(
+    ctx context.Context,
+    action string,
+    resourceID, resourceName, parentID string,
+    before, after map[string]interface{},
+    err error,
+)
+```
+
+函数内部统一根据 `err` 设置 `Status` 与 `ErrorMsg`。
+
+## 8. 查询接口
+
+`GET /open-api/v1/operation-logs` 提供按以下维度过滤：
+
+- `operator_name`：操作人名称模糊匹配
+- `action`：操作动作
+- `resource_type`：资源类型
+- `resource_id`：资源业务 ID
+- `status`：`1` 成功，`2` 失败
+- `start_time` / `end_time`：时间范围
+- `page` / `page_size`：分页
+
+返回字段包含 `status`、`error_msg`、`change_summary`、`request_path` 等。
+
+## 9. 失败日志的特殊处理
+
+### 9.1 变更摘要
+
+- **Create 失败**：保留请求入参（`after`），帮助定位参数校验失败。
+- **Update 失败**：若已查询到旧值，保留 `before`；否则仅记录请求入参。
+- **Delete 失败**：保留被删除对象的旧值（`before`）。
+
+### 9.2 幂等性与重试
+
+同一操作的多次失败会产生多条失败日志，每条日志独立记录一次失败尝试，符合审计需求。
+
+### 9.3 敏感信息
+
+`ErrorMsg` 直接记录 `err.Error()`。若后续有合规要求，可在 `TruncateErrorMessage` 中扩展敏感词过滤。
+
+## 10. 测试策略
+
+- **单元测试**：各域 `operation_log_test.go` 验证成功与失败场景下 `Status`、`ErrorMsg` 的正确性。
+- **集成测试**：`test/integration/tests/operation_log/list/list_test.go` 构造真实失败场景（如删除被路由规则引用的集群），验证 `GET /operation-logs` 能查询到 `status=2` 的记录。
+
+## 11. 边界情况与注意事项
+
+- **避免循环**：记录失败日志时不应触发新的业务校验或写操作。
+- **队列压力**：失败日志数量通常远低于成功日志，异步缓冲队列压力可忽略。
+- **字段长度**：`error_msg` 写入前必须截断，防止超长导致数据库错误。
+- **接口兼容**：`OperationLogRecorder.Record` 接口不变，新增失败日志不需要修改容器注入。

--- a/design-docs/sys-design/summary.md
+++ b/design-docs/sys-design/summary.md
@@ -20,7 +20,7 @@
 
 | 文档名称 | 相对路径 | 摘要说明 |
 |---------|---------|---------|
-| 操作日志模块 | [design-docs/modifications/2026-08-31-operation-log/change-summary.md](../modifications/2026-08-31-operation-log/change-summary.md) | 描述 `model/ioperlog` 操作日志设计：覆盖 entity / api-key / provider / cluster 等域的变更记录、异步批量写入、敏感字段脱敏与 `GET /operation-logs` 查询接口。 |
+| 操作日志模块 | [details/操作日志模块.md](./details/操作日志模块.md) | 描述 `model/ioperlog` 操作日志设计：覆盖 entity / api-key / provider / cluster 等域的变更记录、成功与失败双路径日志、异步批量写入、敏感字段脱敏与 `GET /operation-logs` 查询接口。 |
 | 认证授权机制 | [details/认证授权机制.md](./details/认证授权机制.md) | 描述 `model/iauth` 的认证授权设计，包括用户与 Token 共用 `users` 表、`Visitor` 统一抽象、Scope 作用域、Feature-Action 权限模型、四种认证方式以及中间件集成与数据库表设计。 |
 | InnerAPI 配置导出与版本控制 | [details/InnerAPI配置导出与版本控制.md](./details/InnerAPI配置导出与版本控制.md) | 描述面向 BFE/Conf Agent 的 InnerAPI 配置导出机制，包括 `VersionControlManager` 的 MD5 签名比对、版本号生成、`config_versions` 表持久化、9 类配置导出主题、增量同步流程，以及 `mod-api-key` 的批量预加载 + 内存回溯性能优化。 |
 | API-Key 与 Entity 关联及模型继承 | [details/API-Key与Entity关联及模型继承.md](./details/API-Key与Entity关联及模型继承.md) | 描述 API-Key 与 Entity 的挂载关系、Entity 层级树约束、模型白名单交集与黑名单继承、配额计划层级合并、限流策略与路由规则的层级收集，以及导出到 BFE 时的最终生效规则。 |

--- a/design-docs/sys-design/数据库设计文档.md
+++ b/design-docs/sys-design/数据库设计文档.md
@@ -1093,7 +1093,10 @@ CREATE TABLE `operation_logs` (
 | `user_agent` | varchar(512) | NOT NULL DEFAULT '' | User-Agent |
 | `created_at` | datetime | NOT NULL | 操作发生时间 |
 
-> 说明：`operation_logs` 由 `model/ioperlog` 异步批量写入；`change_summary` 在写入前已调用 `MaskSensitiveFields` 完成脱敏。
+> 说明：
+> - `operation_logs` 由 `model/ioperlog` 异步批量写入。
+> - `change_summary` 在写入前已调用 `MaskSensitiveFields` 完成脱敏。
+> - `status` 字段区分成功（`1`）与失败（`2`）操作；失败时 `error_msg` 记录被截断至 1024 字符的错误信息，用于审计与排障。
 
 ---
 

--- a/design-docs/sys-design/模型层设计文档.md
+++ b/design-docs/sys-design/模型层设计文档.md
@@ -517,7 +517,19 @@ func MaskSensitiveFields(data map[string]interface{}) map[string]interface{}
 
 #### 4.25.4 接入域
 
-第一期在以下 Manager 的写操作（含失败路径）中接入操作日志记录：Entity / EntityType / API-Key / Provider / Cluster / RouteRule / Domain / Certificate / QuotaPlan / RateLimitPolicy / ModelPrice / User / Token。各 Manager 通过 `SetOperationLogManager` 注入 `OperationLogManager` 并在事务提交后调用 `Record`。
+第一期在以下 Manager 的写操作中接入操作日志记录：Entity / EntityType / API-Key / Provider / Cluster / RouteRule / Domain / Certificate / QuotaPlan / RateLimitPolicy / ModelPrice / User / Token。各 Manager 通过 `SetOperationLogManager` 注入 `OperationLogManager`。
+
+每个接入域提供一个私有函数 `recordXxxOperation(ctx, action, resourceID, resourceName, parentID, before, after, err)`，其中最后一个参数 `err` 决定日志状态：
+
+- 当 `err == nil` 时，`Status = StatusSuccess`（`1`），`ErrorMsg` 为空。
+- 当 `err != nil` 时，`Status = StatusFailed`（`2`），`ErrorMsg` 为 `ioperlog.TruncateErrorMessageDefault(err)` 截断后的错误信息（不超过 `operation_logs.error_msg` 字段长度 1024）。
+
+调用时机：
+
+- **成功路径**：业务事务提交成功后调用，传入 `nil`。
+- **失败路径**：在写操作返回错误前调用，传入具体的 `err`。例如 `ClusterManager.DeleteCluster` 在 `deleteCheckers` 返回 "route in use" 时，会立即记录一条 `status=2` 的失败日志，再向上返回错误。
+
+该设计保证既保留成功变更的审计轨迹，也保留失败尝试的审计证据，满足 issue #117 等场景的排障需求。
 
 ---
 

--- a/model/api_key/api_key.go
+++ b/model/api_key/api_key.go
@@ -408,9 +408,9 @@ func (rppm *APIKeyManager) populateQuotaBalances(ctx context.Context, list []*AP
 // DeleteAPIKey deletes an API key based on filter criteria
 func (rppm *APIKeyManager) DeleteAPIKey(ctx context.Context, filter *APIKeyFilter) error {
 	var (
-		quotaKey        string
-		rateLimitKeys   []string
-		oldAPIKey       *APIKeyParam
+		quotaKey      string
+		rateLimitKeys []string
+		oldAPIKey     *APIKeyParam
 	)
 
 	err := rppm.txn.AtomExecute(ctx, func(ctx context.Context) error {
@@ -460,13 +460,14 @@ func (rppm *APIKeyManager) DeleteAPIKey(ctx context.Context, filter *APIKeyFilte
 		return rppm.storager.DeleteAPIKey(ctx, filter)
 	})
 	if err != nil {
+		rppm.recordAPIKeyOperation(ctx, string(ioperlog.ActionDelete), oldAPIKey, nil, apiKeyParamToMap(oldAPIKey), err)
 		return err
 	}
 
 	// 事务提交成功后清理 Redis Key
 	rppm.cleanupRedisKeys(ctx, quotaKey, rateLimitKeys)
 
-	rppm.recordAPIKeyOperation(ctx, string(ioperlog.ActionDelete), oldAPIKey, nil, apiKeyParamToMap(oldAPIKey))
+	rppm.recordAPIKeyOperation(ctx, string(ioperlog.ActionDelete), oldAPIKey, nil, apiKeyParamToMap(oldAPIKey), nil)
 	return nil
 }
 
@@ -527,7 +528,7 @@ func (rppm *APIKeyManager) UpdateAPIKey(ctx context.Context, filter *APIKeyFilte
 				}
 				param.QuotaPlanID = &quotaPlanID
 
-				}
+			}
 		}
 
 		if param.RateLimitPolicy != nil && rppm.rateLimitPolicyStorager != nil {
@@ -573,6 +574,7 @@ func (rppm *APIKeyManager) UpdateAPIKey(ctx context.Context, filter *APIKeyFilte
 		return err
 	})
 	if err != nil {
+		rppm.recordAPIKeyOperation(ctx, string(ioperlog.ActionUpdate), oldAPIKey, apiKeyParamToMap(oldAPIKey), apiKeyParamToMap(param), err)
 		return err
 	}
 
@@ -580,7 +582,7 @@ func (rppm *APIKeyManager) UpdateAPIKey(ctx context.Context, filter *APIKeyFilte
 		rppm.cleanupRedisKeys(ctx, "", rateLimitKeysToDelete)
 	}
 
-	rppm.recordAPIKeyOperation(ctx, string(ioperlog.ActionUpdate), oldAPIKey, apiKeyParamToMap(oldAPIKey), apiKeyParamToMap(param))
+	rppm.recordAPIKeyOperation(ctx, string(ioperlog.ActionUpdate), oldAPIKey, apiKeyParamToMap(oldAPIKey), apiKeyParamToMap(param), nil)
 	return nil
 }
 
@@ -678,6 +680,7 @@ func (rppm *APIKeyManager) CreateAPIKey(ctx context.Context,
 		return err
 	})
 	if err != nil {
+		rppm.recordAPIKeyOperation(ctx, string(ioperlog.ActionCreate), param, nil, apiKeyParamToMap(param), err)
 		return err
 	}
 
@@ -690,7 +693,7 @@ func (rppm *APIKeyManager) CreateAPIKey(ctx context.Context,
 		}
 	}
 
-	rppm.recordAPIKeyOperation(ctx, string(ioperlog.ActionCreate), param, nil, apiKeyParamToMap(param))
+	rppm.recordAPIKeyOperation(ctx, string(ioperlog.ActionCreate), param, nil, apiKeyParamToMap(param), nil)
 	return nil
 }
 

--- a/model/api_key/api_key_operation_log.go
+++ b/model/api_key/api_key_operation_log.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 )
 
-func (rppm *APIKeyManager) recordAPIKeyOperation(ctx context.Context, action string, apiKey *APIKeyParam, before, after map[string]interface{}) {
+func (rppm *APIKeyManager) recordAPIKeyOperation(ctx context.Context, action string, apiKey *APIKeyParam, before, after map[string]interface{}, err error) {
 	if rppm.operationLogManager == nil || apiKey == nil {
 		return
 	}
@@ -42,13 +42,21 @@ func (rppm *APIKeyManager) recordAPIKeyOperation(ctx context.Context, action str
 		resourceParentID = *apiKey.EntityID
 	}
 
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
+	}
+
 	entry := &ioperlog.OperationLogEntry{
 		Action:           action,
 		ResourceType:     string(ioperlog.ResourceTypeAPIKey),
 		ResourceID:       resourceID,
 		ResourceName:     resourceName,
 		ResourceParentID: resourceParentID,
-		Status:           ioperlog.StatusSuccess,
+		Status:           status,
+		ErrorMsg:         errorMsg,
 		CreatedAt:        time.Now(),
 	}
 

--- a/model/entity/entity_manager.go
+++ b/model/entity/entity_manager.go
@@ -66,25 +66,37 @@ func (m *EntityManager) CreateEntity(ctx context.Context, param *EntityParam) (i
 	if param.Type != nil && m.entityTypeStorager != nil {
 		entityTypeInfo, err := m.entityTypeStorager.FetchEntityType(ctx, &EntityTypeFilter{TypeName: param.Type})
 		if err != nil {
+			entityID, entityName, parentID := entityParamIdentifiers(param)
+			m.recordEntityOperation(ctx, string(ioperlog.ActionCreate), entityID, entityName, parentID, nil, entityParamToMap(param), err)
 			return 0, err
 		}
 		if entityTypeInfo == nil {
-			return 0, xerror.WrapParamError(fmt.Errorf("entity type not found: %s", *param.Type))
+			err := xerror.WrapParamError(fmt.Errorf("entity type not found: %s", *param.Type))
+			entityID, entityName, parentID := entityParamIdentifiers(param)
+			m.recordEntityOperation(ctx, string(ioperlog.ActionCreate), entityID, entityName, parentID, nil, entityParamToMap(param), err)
+			return 0, err
 		}
 	}
 
 	if param.Name != nil && *param.Name != "" {
 		existing, err := m.storager.FetchEntity(ctx, &EntityFilter{Name: param.Name})
 		if err != nil {
+			entityID, entityName, parentID := entityParamIdentifiers(param)
+			m.recordEntityOperation(ctx, string(ioperlog.ActionCreate), entityID, entityName, parentID, nil, entityParamToMap(param), err)
 			return 0, err
 		}
 		if existing != nil {
-			return 0, xerror.WrapRecordExisted("Entity")
+			err := xerror.WrapRecordExisted("Entity")
+			entityID, entityName, parentID := entityParamIdentifiers(param)
+			m.recordEntityOperation(ctx, string(ioperlog.ActionCreate), entityID, entityName, parentID, nil, entityParamToMap(param), err)
+			return 0, err
 		}
 	}
 
 	if param.ParentID != nil && *param.ParentID != "" && param.Type != nil && m.entityTypeStorager != nil {
 		if err := m.checkEntityLevel(ctx, *param.Type, *param.ParentID); err != nil {
+			entityID, entityName, parentID := entityParamIdentifiers(param)
+			m.recordEntityOperation(ctx, string(ioperlog.ActionCreate), entityID, entityName, parentID, nil, entityParamToMap(param), err)
 			return 0, err
 		}
 	}
@@ -125,6 +137,8 @@ func (m *EntityManager) CreateEntity(ctx context.Context, param *EntityParam) (i
 		return nil
 	})
 	if err != nil {
+		entityID, entityName, parentID := entityParamIdentifiers(param)
+		m.recordEntityOperation(ctx, string(ioperlog.ActionCreate), entityID, entityName, parentID, nil, entityParamToMap(param), err)
 		return 0, err
 	}
 
@@ -154,7 +168,7 @@ func (m *EntityManager) CreateEntity(ctx context.Context, param *EntityParam) (i
 	if param.ParentID != nil {
 		parentID = *param.ParentID
 	}
-	m.recordEntityOperation(ctx, string(ioperlog.ActionCreate), entityID, entityName, parentID, nil, entityParamToMap(param))
+	m.recordEntityOperation(ctx, string(ioperlog.ActionCreate), entityID, entityName, parentID, nil, entityParamToMap(param), nil)
 
 	return id, nil
 }
@@ -219,18 +233,27 @@ func (m *EntityManager) FetchEntityList(ctx context.Context, filter *EntityFilte
 func (m *EntityManager) UpdateEntity(ctx context.Context, filter *EntityFilter, param *EntityParam) (int64, error) {
 	if param.ParentID != nil && *param.ParentID != "" && param.Type != nil && m.entityTypeStorager != nil {
 		if err := m.checkEntityLevel(ctx, *param.Type, *param.ParentID); err != nil {
+			entityID, entityName, parentID := entityParamIdentifiers(param)
+			m.recordEntityOperation(ctx, string(ioperlog.ActionUpdate), entityID, entityName, parentID, entityParamToMap(param), nil, err)
 			return 0, err
 		}
 	} else if param.ParentID != nil && *param.ParentID != "" && m.entityTypeStorager != nil {
 		list, err := m.storager.FetchEntityList(ctx, filter)
 		if err != nil {
+			entityID, entityName, parentID := entityParamIdentifiers(param)
+			m.recordEntityOperation(ctx, string(ioperlog.ActionUpdate), entityID, entityName, parentID, entityParamToMap(param), nil, err)
 			return 0, err
 		}
 		if len(list) == 0 {
-			return 0, xerror.WrapRecordNotExist("Entity")
+			err := xerror.WrapRecordNotExist("Entity")
+			entityID, entityName, parentID := entityParamIdentifiers(param)
+			m.recordEntityOperation(ctx, string(ioperlog.ActionUpdate), entityID, entityName, parentID, entityParamToMap(param), nil, err)
+			return 0, err
 		}
 		if list[0].Type != nil {
 			if err := m.checkEntityLevel(ctx, *list[0].Type, *param.ParentID); err != nil {
+				entityID, entityName, parentID := entityParamIdentifiers(param)
+				m.recordEntityOperation(ctx, string(ioperlog.ActionUpdate), entityID, entityName, parentID, entityParamToMap(param), nil, err)
 				return 0, err
 			}
 		}
@@ -311,6 +334,11 @@ func (m *EntityManager) UpdateEntity(ctx context.Context, filter *EntityFilter, 
 		return err
 	})
 	if err != nil {
+		entityID, entityName, parentID := entityParamIdentifiers(param)
+		if oldEntity != nil {
+			entityID, entityName, parentID = entityParamIdentifiers(oldEntity)
+		}
+		m.recordEntityOperation(ctx, string(ioperlog.ActionUpdate), entityID, entityName, parentID, entityParamToMap(oldEntity), entityParamToMap(param), err)
 		return affected, err
 	}
 
@@ -332,7 +360,7 @@ func (m *EntityManager) UpdateEntity(ctx context.Context, filter *EntityFilter, 
 			parentID = *oldEntity.ParentID
 		}
 	}
-	m.recordEntityOperation(ctx, string(ioperlog.ActionUpdate), entityID, entityName, parentID, entityParamToMap(oldEntity), entityParamToMap(param))
+	m.recordEntityOperation(ctx, string(ioperlog.ActionUpdate), entityID, entityName, parentID, entityParamToMap(oldEntity), entityParamToMap(param), nil)
 
 	return affected, nil
 }
@@ -400,6 +428,8 @@ func (m *EntityManager) DeleteEntity(ctx context.Context, filter *EntityFilter) 
 		return m.storager.DeleteEntity(ctx, filter)
 	})
 	if err != nil {
+		entityID, entityName, parentID := entityParamIdentifiers(oldEntity)
+		m.recordEntityOperation(ctx, string(ioperlog.ActionDelete), entityID, entityName, parentID, entityParamToMap(oldEntity), nil, err)
 		return err
 	}
 
@@ -420,7 +450,7 @@ func (m *EntityManager) DeleteEntity(ctx context.Context, filter *EntityFilter) 
 			parentID = *oldEntity.ParentID
 		}
 	}
-	m.recordEntityOperation(ctx, string(ioperlog.ActionDelete), entityID, entityName, parentID, entityParamToMap(oldEntity), nil)
+	m.recordEntityOperation(ctx, string(ioperlog.ActionDelete), entityID, entityName, parentID, entityParamToMap(oldEntity), nil, nil)
 
 	return nil
 }
@@ -694,4 +724,20 @@ func (a *entityStoragerAdapter) FetchEntity(ctx context.Context, filter *shared.
 		Name: entity.Name,
 		Type: entity.Type,
 	}, nil
+}
+
+func entityParamIdentifiers(param *EntityParam) (entityID, entityName, parentID string) {
+	if param == nil {
+		return "", "", ""
+	}
+	if param.EntityID != nil {
+		entityID = *param.EntityID
+	}
+	if param.Name != nil {
+		entityName = *param.Name
+	}
+	if param.ParentID != nil {
+		parentID = *param.ParentID
+	}
+	return
 }

--- a/model/entity/entity_type_manager.go
+++ b/model/entity/entity_type_manager.go
@@ -45,23 +45,29 @@ func (m *EntityTypeManager) SetOperationLogManager(manager ioperlog.OperationLog
 // CreateEntityType 创建 Entity 类型
 func (m *EntityTypeManager) CreateEntityType(ctx context.Context, param *EntityTypeParam) (int64, error) {
 	if param.TypeName == nil || *param.TypeName == "" {
-		return 0, xerror.WrapParamErrorWithMsg("type_name is required")
+		err := xerror.WrapParamErrorWithMsg("type_name is required")
+		m.recordEntityTypeOperation(ctx, string(ioperlog.ActionCreate), param, nil, entityTypeParamToMap(param), err)
+		return 0, err
 	}
 
 	existing, err := m.storager.FetchEntityType(ctx, &EntityTypeFilter{TypeName: param.TypeName})
 	if err != nil {
+		m.recordEntityTypeOperation(ctx, string(ioperlog.ActionCreate), param, nil, entityTypeParamToMap(param), err)
 		return 0, err
 	}
 	if existing != nil {
-		return 0, xerror.WrapRecordExisted("Entity-Type")
+		err := xerror.WrapRecordExisted("Entity-Type")
+		m.recordEntityTypeOperation(ctx, string(ioperlog.ActionCreate), param, nil, entityTypeParamToMap(param), err)
+		return 0, err
 	}
 
 	id, err := m.storager.CreateEntityType(ctx, param)
 	if err != nil {
+		m.recordEntityTypeOperation(ctx, string(ioperlog.ActionCreate), param, nil, entityTypeParamToMap(param), err)
 		return 0, err
 	}
 
-	m.recordEntityTypeOperation(ctx, string(ioperlog.ActionCreate), param, nil, entityTypeParamToMap(param))
+	m.recordEntityTypeOperation(ctx, string(ioperlog.ActionCreate), param, nil, entityTypeParamToMap(param), nil)
 	return id, nil
 }
 
@@ -79,35 +85,48 @@ func (m *EntityTypeManager) FetchEntityTypeList(ctx context.Context, filter *Ent
 func (m *EntityTypeManager) UpdateEntityType(ctx context.Context, filter *EntityTypeFilter, param *EntityTypeParam) (int64, error) {
 	oldEntityType, err := m.storager.FetchEntityType(ctx, filter)
 	if err != nil {
+		m.recordEntityTypeOperation(ctx, string(ioperlog.ActionUpdate), param, entityTypeParamToMap(param), nil, err)
 		return 0, err
 	}
 	if oldEntityType == nil {
-		return 0, xerror.WrapRecordNotExist("Entity-Type")
+		err := xerror.WrapRecordNotExist("Entity-Type")
+		m.recordEntityTypeOperation(ctx, string(ioperlog.ActionUpdate), param, entityTypeParamToMap(param), nil, err)
+		return 0, err
 	}
 
 	affected, err := m.storager.UpdateEntityType(ctx, filter, param)
 	if err != nil {
+		m.recordEntityTypeOperation(ctx, string(ioperlog.ActionUpdate), oldEntityType, entityTypeParamToMap(oldEntityType), entityTypeParamToMap(param), err)
 		return affected, err
 	}
 
-	m.recordEntityTypeOperation(ctx, string(ioperlog.ActionUpdate), oldEntityType, entityTypeParamToMap(oldEntityType), entityTypeParamToMap(param))
+	m.recordEntityTypeOperation(ctx, string(ioperlog.ActionUpdate), oldEntityType, entityTypeParamToMap(oldEntityType), entityTypeParamToMap(param), nil)
 	return affected, nil
 }
 
 // DeleteEntityType 删除 Entity 类型
 func (m *EntityTypeManager) DeleteEntityType(ctx context.Context, filter *EntityTypeFilter) error {
+	fallbackParam := &EntityTypeParam{}
+	if filter != nil {
+		fallbackParam.TypeName = filter.TypeName
+	}
+
 	oldEntityType, err := m.storager.FetchEntityType(ctx, filter)
 	if err != nil {
+		m.recordEntityTypeOperation(ctx, string(ioperlog.ActionDelete), fallbackParam, entityTypeParamToMap(fallbackParam), nil, err)
 		return err
 	}
 	if oldEntityType == nil {
-		return xerror.WrapRecordNotExist("Entity-Type")
-	}
-
-	if err := m.storager.DeleteEntityType(ctx, filter); err != nil {
+		err := xerror.WrapRecordNotExist("Entity-Type")
+		m.recordEntityTypeOperation(ctx, string(ioperlog.ActionDelete), fallbackParam, entityTypeParamToMap(fallbackParam), nil, err)
 		return err
 	}
 
-	m.recordEntityTypeOperation(ctx, string(ioperlog.ActionDelete), oldEntityType, entityTypeParamToMap(oldEntityType), nil)
+	if err := m.storager.DeleteEntityType(ctx, filter); err != nil {
+		m.recordEntityTypeOperation(ctx, string(ioperlog.ActionDelete), oldEntityType, entityTypeParamToMap(oldEntityType), nil, err)
+		return err
+	}
+
+	m.recordEntityTypeOperation(ctx, string(ioperlog.ActionDelete), oldEntityType, entityTypeParamToMap(oldEntityType), nil, nil)
 	return nil
 }

--- a/model/entity/operation_log.go
+++ b/model/entity/operation_log.go
@@ -21,9 +21,16 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 )
 
-func (m *EntityManager) recordEntityOperation(ctx context.Context, action string, entityID, entityName, parentID string, before, after map[string]interface{}) {
+func (m *EntityManager) recordEntityOperation(ctx context.Context, action string, entityID, entityName, parentID string, before, after map[string]interface{}, err error) {
 	if m.operationLogManager == nil {
 		return
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -32,7 +39,8 @@ func (m *EntityManager) recordEntityOperation(ctx context.Context, action string
 		ResourceID:       entityID,
 		ResourceName:     entityName,
 		ResourceParentID: parentID,
-		Status:           ioperlog.StatusSuccess,
+		Status:           status,
+		ErrorMsg:         errorMsg,
 		CreatedAt:        time.Now(),
 	}
 
@@ -50,7 +58,7 @@ func (m *EntityManager) recordEntityOperation(ctx context.Context, action string
 	m.operationLogManager.Record(ctx, entry)
 }
 
-func (m *EntityTypeManager) recordEntityTypeOperation(ctx context.Context, action string, param *EntityTypeParam, before, after map[string]interface{}) {
+func (m *EntityTypeManager) recordEntityTypeOperation(ctx context.Context, action string, param *EntityTypeParam, before, after map[string]interface{}, err error) {
 	if m.operationLogManager == nil || param == nil {
 		return
 	}
@@ -64,12 +72,20 @@ func (m *EntityTypeManager) recordEntityTypeOperation(ctx context.Context, actio
 		resourceName = *param.Description
 	}
 
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
+	}
+
 	entry := &ioperlog.OperationLogEntry{
 		Action:       action,
 		ResourceType: string(ioperlog.ResourceTypeEntityType),
 		ResourceID:   resourceID,
 		ResourceName: resourceName,
-		Status:       ioperlog.StatusSuccess,
+		Status:       status,
+		ErrorMsg:     errorMsg,
 		CreatedAt:    time.Now(),
 	}
 

--- a/model/entity/operation_log_test.go
+++ b/model/entity/operation_log_test.go
@@ -16,6 +16,7 @@ package entity
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
@@ -219,4 +220,80 @@ func TestEntityManager_DeleteEntity_RecordsOperationLog(t *testing.T) {
 	assert.Equal(t, string(ioperlog.ActionDelete), entry.Action)
 	assert.Equal(t, entityID, entry.ResourceID)
 	assert.Equal(t, entityName, entry.ResourceName)
+}
+
+func TestEntityManager_CreateEntity_RecordsFailedOperationLog(t *testing.T) {
+	ctx := context.Background()
+	recorder := &fakeOperationLogRecorder{}
+
+	entityID := "ent-1"
+	entityName := "entity-one"
+	entityType := "tenant"
+
+	manager := NewEntityManager(&fakeTxn{}, &fakeEntityStorager{
+		fetchFn: func(ctx context.Context, filter *EntityFilter) (*EntityParam, error) {
+			return nil, nil
+		},
+		createFn: func(ctx context.Context, param *EntityParam) (int64, error) {
+			return 0, errors.New("db connection failed")
+		},
+	}, &fakeEntityTypeStorager{
+		fetchFn: func(ctx context.Context, filter *EntityTypeFilter) (*EntityTypeParam, error) {
+			return &EntityTypeParam{TypeName: lib.PString(entityType), Level: lib.PInt(1)}, nil
+		},
+	}, &fakeSharedQuotaPlanStorager{}, &fakeSharedRateLimitPolicyStorager{}, &fakeRouteRulesStorager{}, nil)
+	manager.SetOperationLogManager(recorder)
+
+	_, err := manager.CreateEntity(ctx, &EntityParam{
+		EntityID: &entityID,
+		Name:     &entityName,
+		Type:     &entityType,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db connection failed")
+
+	require.Len(t, recorder.entries, 1)
+	entry := recorder.entries[0]
+	assert.Equal(t, string(ioperlog.ActionCreate), entry.Action)
+	assert.Equal(t, string(ioperlog.ResourceTypeEntity), entry.ResourceType)
+	assert.Equal(t, entityID, entry.ResourceID)
+	assert.Equal(t, entityName, entry.ResourceName)
+	assert.Equal(t, ioperlog.StatusFailed, entry.Status)
+	assert.Contains(t, entry.ErrorMsg, "db connection failed")
+}
+
+func TestEntityManager_DeleteEntity_RecordsFailedOperationLog(t *testing.T) {
+	ctx := context.Background()
+	recorder := &fakeOperationLogRecorder{}
+
+	entityID := "ent-1"
+	entityName := "entity-one"
+
+	manager := NewEntityManager(&fakeTxn{}, &fakeEntityStorager{
+		fetchFn: func(ctx context.Context, filter *EntityFilter) (*EntityParam, error) {
+			return &EntityParam{EntityID: &entityID, Name: &entityName}, nil
+		},
+		listFn: func(ctx context.Context, filter *EntityFilter) ([]*EntityParam, error) {
+			if filter.EntityID != nil && *filter.EntityID == entityID {
+				return []*EntityParam{{EntityID: &entityID, Name: &entityName}}, nil
+			}
+			return nil, nil
+		},
+		deleteFn: func(ctx context.Context, filter *EntityFilter) error {
+			return errors.New("delete constraint violation")
+		},
+	}, &fakeEntityTypeStorager{}, &fakeSharedQuotaPlanStorager{}, &fakeSharedRateLimitPolicyStorager{}, &fakeRouteRulesStorager{}, nil)
+	manager.SetOperationLogManager(recorder)
+
+	err := manager.DeleteEntity(ctx, &EntityFilter{EntityID: &entityID})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete constraint violation")
+
+	require.Len(t, recorder.entries, 1)
+	entry := recorder.entries[0]
+	assert.Equal(t, string(ioperlog.ActionDelete), entry.Action)
+	assert.Equal(t, entityID, entry.ResourceID)
+	assert.Equal(t, entityName, entry.ResourceName)
+	assert.Equal(t, ioperlog.StatusFailed, entry.Status)
+	assert.Contains(t, entry.ErrorMsg, "delete constraint violation")
 }

--- a/model/iauth/authentication.go
+++ b/model/iauth/authentication.go
@@ -353,7 +353,13 @@ func (m *AuthenticateManager) Authenticate(ctx context.Context, param *Authentic
 }
 
 func (m *AuthenticateManager) DestroySessionKey(ctx context.Context, sessionKey string) (err error) {
-	return m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+	var oldUser *User
+	updateParam := &UserParam{
+		SessionKey:         lib.PString(""),
+		SessionKeyCreateAt: lib.PTime(time.Time{}.AddDate(0, 1, 1)),
+	}
+
+	err = m.txn.AtomExecute(ctx, func(ctx context.Context) error {
 		user, err := m.storager.FetchUser(ctx, &UserFilter{
 			SessionKey: &sessionKey,
 		})
@@ -364,12 +370,23 @@ func (m *AuthenticateManager) DestroySessionKey(ctx context.Context, sessionKey 
 		if user == nil {
 			return xerror.WrapAuthenticateFailErrorWithMsg("Session Key Not Exist")
 		}
+		oldUser = user
 
-		return m.storager.UpdateUser(ctx, user, &UserParam{
-			SessionKey:         lib.PString(""),
-			SessionKeyCreateAt: lib.PTime(time.Time{}.AddDate(0, 1, 1)),
-		})
+		return m.storager.UpdateUser(ctx, user, updateParam)
 	})
+	if err != nil {
+		userID := int64(0)
+		name := ""
+		if oldUser != nil {
+			userID = oldUser.ID
+			name = oldUser.Name
+		}
+		m.recordUserOperation(ctx, string(ioperlog.ActionReset), userID, name, "", userToMap(oldUser), userParamToMap(updateParam), err)
+		return err
+	}
+
+	m.recordUserOperation(ctx, string(ioperlog.ActionReset), oldUser.ID, oldUser.Name, "", userToMap(oldUser), userParamToMap(updateParam), nil)
+	return nil
 }
 
 type TokenFilter struct {
@@ -415,10 +432,11 @@ func (m *AuthenticateManager) DeleteToken(ctx context.Context, token *Token) (er
 		return m.authorizeStorager.UnbindTokenAllProduct(ctx, token)
 	})
 	if err != nil {
+		m.recordTokenOperation(ctx, string(ioperlog.ActionDelete), token.ID, token.Name, "", tokenToMap(token), nil, err)
 		return err
 	}
 
-	m.recordTokenOperation(ctx, string(ioperlog.ActionDelete), token.ID, token.Name, "", tokenToMap(token), nil)
+	m.recordTokenOperation(ctx, string(ioperlog.ActionDelete), token.ID, token.Name, "", tokenToMap(token), nil, nil)
 	return nil
 }
 
@@ -482,6 +500,17 @@ func (m *AuthenticateManager) CreateToken(ctx context.Context, param *TokenParam
 		return err
 	})
 	if err != nil {
+		tokenName := ""
+		if token != nil {
+			tokenName = token.Name
+		} else if param != nil && param.Name != nil {
+			tokenName = *param.Name
+		}
+		parentID := ""
+		if product != nil {
+			parentID = product.Name
+		}
+		m.recordTokenOperation(ctx, string(ioperlog.ActionCreate), 0, tokenName, parentID, nil, tokenParamToMap(param), err)
 		return nil, err
 	}
 
@@ -489,7 +518,7 @@ func (m *AuthenticateManager) CreateToken(ctx context.Context, param *TokenParam
 	if product != nil {
 		parentID = product.Name
 	}
-	m.recordTokenOperation(ctx, string(ioperlog.ActionCreate), token.ID, token.Name, parentID, nil, tokenToMap(token))
+	m.recordTokenOperation(ctx, string(ioperlog.ActionCreate), token.ID, token.Name, parentID, nil, tokenToMap(token), nil)
 	return token, nil
 }
 
@@ -514,10 +543,11 @@ func (m *AuthenticateManager) CreateUser(ctx context.Context, param *UserParam) 
 
 		return m.storager.CreateUser(ctx, param)
 	}); err != nil {
+		m.recordUserOperation(ctx, string(ioperlog.ActionCreate), 0, userParamName(param), "", nil, userParamToMap(param), err)
 		return err
 	}
 
-	m.recordUserOperation(ctx, string(ioperlog.ActionCreate), 0, userParamName(param), "", nil, userParamToMap(param))
+	m.recordUserOperation(ctx, string(ioperlog.ActionCreate), 0, userParamName(param), "", nil, userParamToMap(param), nil)
 	return nil
 }
 
@@ -543,10 +573,17 @@ func (m *AuthenticateManager) DeleteUser(ctx context.Context, userName string) (
 		return m.authorizeStorager.UnbindUserAllProduct(ctx, user)
 	})
 	if err != nil {
+		userID := int64(0)
+		name := userName
+		if oldUser != nil {
+			userID = oldUser.ID
+			name = oldUser.Name
+		}
+		m.recordUserOperation(ctx, string(ioperlog.ActionDelete), userID, name, "", userToMap(oldUser), nil, err)
 		return err
 	}
 
-	m.recordUserOperation(ctx, string(ioperlog.ActionDelete), oldUser.ID, oldUser.Name, "", userToMap(oldUser), nil)
+	m.recordUserOperation(ctx, string(ioperlog.ActionDelete), oldUser.ID, oldUser.Name, "", userToMap(oldUser), nil, nil)
 	return nil
 }
 
@@ -584,6 +621,17 @@ func (m *AuthenticateManager) UpdateUserPassword(ctx context.Context, pcd *Passw
 		SessionKeyCreateAt: lib.PTime(time.Time{}.AddDate(0, 1, 1)),
 	})
 	if err != nil {
+		userID := int64(0)
+		name := pcd.UserName
+		if oldUser != nil {
+			userID = oldUser.ID
+			name = oldUser.Name
+		}
+		m.recordUserOperation(ctx, string(ioperlog.ActionUpdate), userID, name, "", userToMap(oldUser), userParamToMap(&UserParam{
+			Password:           &pcd.Password,
+			SessionKey:         lib.PString(""),
+			SessionKeyCreateAt: lib.PTime(time.Time{}.AddDate(0, 1, 1)),
+		}), err)
 		return err
 	}
 
@@ -591,7 +639,7 @@ func (m *AuthenticateManager) UpdateUserPassword(ctx context.Context, pcd *Passw
 		Password:           &pcd.Password,
 		SessionKey:         lib.PString(""),
 		SessionKeyCreateAt: lib.PTime(time.Time{}.AddDate(0, 1, 1)),
-	}))
+	}), nil)
 	return nil
 }
 

--- a/model/iauth/authorization.go
+++ b/model/iauth/authorization.go
@@ -66,25 +66,24 @@ func (m *AuthorizeManager) SetOperationLogManager(manager ioperlog.OperationLogR
 }
 
 func (m *AuthorizeManager) UpdateUserIsAdmin(ctx context.Context, user *User, isAdmin bool) (err error) {
-	err = m.txn.AtomExecute(ctx, func(ctx context.Context) error {
-		mapping := map[bool][]string{
-			false: {ScopeProduct},
-			true:  {ScopeSystem},
-		}
-
-		return m.storager.UpdateUserScopes(ctx, user, mapping[isAdmin])
-	})
-	if err != nil {
-		return err
-	}
-
 	scopes := []string{ScopeProduct}
 	if isAdmin {
 		scopes = []string{ScopeSystem}
 	}
+
+	err = m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+		return m.storager.UpdateUserScopes(ctx, user, scopes)
+	})
+	if err != nil {
+		m.recordUserOperation(ctx, string(ioperlog.ActionUpdate), user.ID, user.Name, "", userToMap(user), map[string]interface{}{
+			"scopes": scopes,
+		}, err)
+		return err
+	}
+
 	m.recordUserOperation(ctx, string(ioperlog.ActionUpdate), user.ID, user.Name, "", userToMap(user), map[string]interface{}{
 		"scopes": scopes,
-	})
+	}, nil)
 	return nil
 }
 
@@ -188,10 +187,11 @@ func (m *AuthorizeManager) BindUserProduct(ctx context.Context, user *User, prod
 		return err
 	})
 	if err != nil {
+		m.recordUserProductBinding(ctx, string(ioperlog.ActionBind), user, product, err)
 		return err
 	}
 
-	m.recordUserProductBinding(ctx, string(ioperlog.ActionBind), user, product)
+	m.recordUserProductBinding(ctx, string(ioperlog.ActionBind), user, product, nil)
 	return nil
 }
 
@@ -208,10 +208,11 @@ func (m *AuthorizeManager) UnBindUserProduct(ctx context.Context, user *User, pr
 		return m.storager.UnbindUserProduct(ctx, user, product)
 	})
 	if err != nil {
+		m.recordUserProductBinding(ctx, string(ioperlog.ActionUnbind), user, product, err)
 		return err
 	}
 
-	m.recordUserProductBinding(ctx, string(ioperlog.ActionUnbind), user, product)
+	m.recordUserProductBinding(ctx, string(ioperlog.ActionUnbind), user, product, nil)
 	return nil
 }
 

--- a/model/iauth/operation_log.go
+++ b/model/iauth/operation_log.go
@@ -23,31 +23,31 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 )
 
-func (m *AuthenticateManager) recordUserOperation(ctx context.Context, action string, userID int64, userName, parentID string, before, after map[string]interface{}) {
+func (m *AuthenticateManager) recordUserOperation(ctx context.Context, action string, userID int64, userName, parentID string, before, after map[string]interface{}, err error) {
 	if m.operationLogManager == nil {
 		return
 	}
 
-	recordAuthOperation(m.operationLogManager, ctx, action, ioperlog.ResourceTypeUser, userID, userName, parentID, before, after)
+	recordAuthOperation(m.operationLogManager, ctx, action, ioperlog.ResourceTypeUser, userID, userName, parentID, before, after, err)
 }
 
-func (m *AuthenticateManager) recordTokenOperation(ctx context.Context, action string, tokenID int64, tokenName, parentID string, before, after map[string]interface{}) {
+func (m *AuthenticateManager) recordTokenOperation(ctx context.Context, action string, tokenID int64, tokenName, parentID string, before, after map[string]interface{}, err error) {
 	if m.operationLogManager == nil {
 		return
 	}
 
-	recordAuthOperation(m.operationLogManager, ctx, action, ioperlog.ResourceTypeToken, tokenID, tokenName, parentID, before, after)
+	recordAuthOperation(m.operationLogManager, ctx, action, ioperlog.ResourceTypeToken, tokenID, tokenName, parentID, before, after, err)
 }
 
-func (m *AuthorizeManager) recordUserOperation(ctx context.Context, action string, userID int64, userName, parentID string, before, after map[string]interface{}) {
+func (m *AuthorizeManager) recordUserOperation(ctx context.Context, action string, userID int64, userName, parentID string, before, after map[string]interface{}, err error) {
 	if m.operationLogManager == nil {
 		return
 	}
 
-	recordAuthOperation(m.operationLogManager, ctx, action, ioperlog.ResourceTypeUser, userID, userName, parentID, before, after)
+	recordAuthOperation(m.operationLogManager, ctx, action, ioperlog.ResourceTypeUser, userID, userName, parentID, before, after, err)
 }
 
-func (m *AuthorizeManager) recordUserProductBinding(ctx context.Context, action string, user *User, product *ibasic.Product) {
+func (m *AuthorizeManager) recordUserProductBinding(ctx context.Context, action string, user *User, product *ibasic.Product, err error) {
 	if m.operationLogManager == nil || user == nil {
 		return
 	}
@@ -60,13 +60,21 @@ func (m *AuthorizeManager) recordUserProductBinding(ctx context.Context, action 
 	recordAuthOperation(m.operationLogManager, ctx, action, ioperlog.ResourceTypeUser, user.ID, user.Name, parentID,
 		map[string]interface{}{"user": userToMap(user)},
 		map[string]interface{}{"product": productToMap(product)},
+		err,
 	)
 }
 
-func recordAuthOperation(recorder ioperlog.OperationLogRecorder, ctx context.Context, action string, resourceType ioperlog.ResourceType, resourceID int64, resourceName, parentID string, before, after map[string]interface{}) {
+func recordAuthOperation(recorder ioperlog.OperationLogRecorder, ctx context.Context, action string, resourceType ioperlog.ResourceType, resourceID int64, resourceName, parentID string, before, after map[string]interface{}, err error) {
 	idStr := ""
 	if resourceID != 0 {
 		idStr = strconv.FormatInt(resourceID, 10)
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -75,7 +83,8 @@ func recordAuthOperation(recorder ioperlog.OperationLogRecorder, ctx context.Con
 		ResourceID:       idStr,
 		ResourceName:     resourceName,
 		ResourceParentID: parentID,
-		Status:           ioperlog.StatusSuccess,
+		Status:           status,
+		ErrorMsg:         errorMsg,
 		CreatedAt:        time.Now(),
 	}
 

--- a/model/icluster_conf/cluster.go
+++ b/model/icluster_conf/cluster.go
@@ -525,15 +525,18 @@ func (cm *ClusterManager) CreateCluster(ctx context.Context, product *ibasic.Pro
 			ID: clusterID,
 		}, bindingSubClusters, nil)
 	})
-	if err != nil {
-		return err
-	}
 
 	clusterName := ""
 	if param.Name != nil {
 		clusterName = *param.Name
 	}
-	cm.recordClusterOperation(ctx, string(ioperlog.ActionCreate), clusterID, clusterName, nil, clusterParamToMap(param))
+
+	if err != nil {
+		cm.recordClusterOperation(ctx, string(ioperlog.ActionCreate), clusterID, clusterName, nil, clusterParamToMap(param), err)
+		return err
+	}
+
+	cm.recordClusterOperation(ctx, string(ioperlog.ActionCreate), clusterID, clusterName, nil, clusterParamToMap(param), nil)
 	return nil
 }
 
@@ -754,10 +757,11 @@ func (cm *ClusterManager) UpdateCluster(ctx context.Context, product *ibasic.Pro
 		return cm.storager.ClusterUpdate(ctx, product, oldData, param)
 	})
 	if err != nil {
+		cm.recordClusterOperation(ctx, string(ioperlog.ActionUpdate), oldData.ID, oldData.Name, clusterToMap(oldData), clusterParamToMap(param), err)
 		return err
 	}
 
-	cm.recordClusterOperation(ctx, string(ioperlog.ActionUpdate), oldData.ID, oldData.Name, clusterToMap(oldData), clusterParamToMap(param))
+	cm.recordClusterOperation(ctx, string(ioperlog.ActionUpdate), oldData.ID, oldData.Name, clusterToMap(oldData), clusterParamToMap(param), nil)
 	return nil
 }
 
@@ -1056,10 +1060,11 @@ func (cm *ClusterManager) DeleteCluster(ctx context.Context, product *ibasic.Pro
 		return nil
 	})
 	if err != nil {
+		cm.recordClusterOperation(ctx, string(ioperlog.ActionDelete), cluster.ID, cluster.Name, clusterToMap(cluster), nil, err)
 		return err
 	}
 
-	cm.recordClusterOperation(ctx, string(ioperlog.ActionDelete), cluster.ID, cluster.Name, clusterToMap(cluster), nil)
+	cm.recordClusterOperation(ctx, string(ioperlog.ActionDelete), cluster.ID, cluster.Name, clusterToMap(cluster), nil, nil)
 	return nil
 }
 

--- a/model/icluster_conf/cluster_operation_log.go
+++ b/model/icluster_conf/cluster_operation_log.go
@@ -23,9 +23,16 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 )
 
-func (cm *ClusterManager) recordClusterOperation(ctx context.Context, action string, clusterID int64, clusterName string, before, after map[string]interface{}) {
+func (cm *ClusterManager) recordClusterOperation(ctx context.Context, action string, clusterID int64, clusterName string, before, after map[string]interface{}, err error) {
 	if cm.operationLogManager == nil {
 		return
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -33,7 +40,8 @@ func (cm *ClusterManager) recordClusterOperation(ctx context.Context, action str
 		ResourceType: string(ioperlog.ResourceTypeCluster),
 		ResourceID:   strconv.FormatInt(clusterID, 10),
 		ResourceName: clusterName,
-		Status:       ioperlog.StatusSuccess,
+		Status:       status,
+		ErrorMsg:     errorMsg,
 		CreatedAt:    time.Now(),
 	}
 

--- a/model/icluster_conf/cluster_test.go
+++ b/model/icluster_conf/cluster_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ibasic"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/imodel_price"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iprovider"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iversion_control"
 	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
@@ -1378,4 +1379,36 @@ func newClusterManagerForExport(t *testing.T, version string) *ClusterManager {
 		},
 	}
 	return NewClusterManager(&fakeTxn{}, clusterStore, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, vcm, nil, nil)
+}
+
+type fakeOperationLogRecorder struct {
+	entries []*ioperlog.OperationLogEntry
+}
+
+func (r *fakeOperationLogRecorder) Record(ctx context.Context, entry *ioperlog.OperationLogEntry) {
+	r.entries = append(r.entries, entry)
+}
+
+func TestClusterManager_DeleteCluster_RecordsFailedOperationLog(t *testing.T) {
+	ctx := context.Background()
+	product := &ibasic.Product{ID: 2, Name: "test"}
+	recorder := &fakeOperationLogRecorder{}
+
+	m := NewClusterManager(&fakeTxn{}, &fakeClusterStorager{}, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, map[string]func(context.Context, *ibasic.Product, *Cluster) error{
+		"route": func(ctx context.Context, p *ibasic.Product, c *Cluster) error {
+			return errors.New("route in use")
+		},
+	}, nil)
+	m.SetOperationLogManager(recorder)
+
+	err := m.DeleteCluster(ctx, product, newTestClusterBase())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "route in use")
+
+	require.Len(t, recorder.entries, 1)
+	entry := recorder.entries[0]
+	assert.Equal(t, string(ioperlog.ActionDelete), entry.Action)
+	assert.Equal(t, string(ioperlog.ResourceTypeCluster), entry.ResourceType)
+	assert.Equal(t, ioperlog.StatusFailed, entry.Status)
+	assert.Contains(t, entry.ErrorMsg, "route in use")
 }

--- a/model/imodel_price/model_price.go
+++ b/model/imodel_price/model_price.go
@@ -105,20 +105,20 @@ func (t TierPriceMap) MarshalJSON() ([]byte, error) {
 
 // ModelPrice represents a single model pricing/capability record.
 type ModelPrice struct {
-	ID                  int64                       `json:"id" yaml:"id,omitempty"`
-	Provider            string                      `json:"provider" yaml:"provider"`
-	Model               string                      `json:"model" yaml:"model"`
-	BaseModel           string                      `json:"base_model" yaml:"base_model"`
-	Mode                string                      `json:"mode" yaml:"mode"`
-	Capabilities        []string                    `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
-	SupportedParameters []string                    `json:"supported_parameters,omitempty" yaml:"supported_parameters,omitempty"`
-	Limits              map[string]interface{}      `json:"limits,omitempty" yaml:"limits,omitempty"`
-	Prices              PriceMap                    `json:"prices,omitempty" yaml:"prices,omitempty"`
-	TierPrices          TierPriceMap                `json:"tier_prices,omitempty" yaml:"tier_prices,omitempty"`
-	PriceCurrency       string                      `json:"price_currency,omitempty" yaml:"price_currency,omitempty"`
-	Metadata            map[string]interface{}      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	CreateTime          *int64                      `json:"create_time,omitempty" yaml:"create_time,omitempty"`
-	UpdateTime          *int64                      `json:"update_time,omitempty" yaml:"update_time,omitempty"`
+	ID                  int64                  `json:"id" yaml:"id,omitempty"`
+	Provider            string                 `json:"provider" yaml:"provider"`
+	Model               string                 `json:"model" yaml:"model"`
+	BaseModel           string                 `json:"base_model" yaml:"base_model"`
+	Mode                string                 `json:"mode" yaml:"mode"`
+	Capabilities        []string               `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	SupportedParameters []string               `json:"supported_parameters,omitempty" yaml:"supported_parameters,omitempty"`
+	Limits              map[string]interface{} `json:"limits,omitempty" yaml:"limits,omitempty"`
+	Prices              PriceMap               `json:"prices,omitempty" yaml:"prices,omitempty"`
+	TierPrices          TierPriceMap           `json:"tier_prices,omitempty" yaml:"tier_prices,omitempty"`
+	PriceCurrency       string                 `json:"price_currency,omitempty" yaml:"price_currency,omitempty"`
+	Metadata            map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	CreateTime          *int64                 `json:"create_time,omitempty" yaml:"create_time,omitempty"`
+	UpdateTime          *int64                 `json:"update_time,omitempty" yaml:"update_time,omitempty"`
 }
 
 // ModelPriceFilter is used to query model price records.
@@ -170,38 +170,44 @@ func (m *Manager) SetOperationLogManager(manager ioperlog.OperationLogRecorder) 
 // CreateModelPrice creates a single model price record.
 func (m *Manager) CreateModelPrice(ctx context.Context, param *ModelPrice) (int64, error) {
 	if err := ValidateModelPrice(param); err != nil {
+		m.recordModelPriceOperation(ctx, string(ioperlog.ActionCreate), "", modelPriceName(param), nil, modelPriceToMap(param), err)
 		return 0, err
 	}
 	id, err := m.storager.CreateModelPrice(ctx, param)
 	if err != nil {
+		m.recordModelPriceOperation(ctx, string(ioperlog.ActionCreate), "", modelPriceName(param), nil, modelPriceToMap(param), err)
 		return 0, err
 	}
 
-	m.recordModelPriceOperation(ctx, string(ioperlog.ActionCreate), modelPriceIDString(id), modelPriceName(param), nil, modelPriceToMap(param))
+	m.recordModelPriceOperation(ctx, string(ioperlog.ActionCreate), modelPriceIDString(id), modelPriceName(param), nil, modelPriceToMap(param), nil)
 	return id, nil
 }
 
 // UpdateModelPrice updates a model price record matched by filter.
 func (m *Manager) UpdateModelPrice(ctx context.Context, filter *ModelPriceFilter, param *ModelPrice) (int64, error) {
+	resourceID := ""
+	if filter != nil && filter.ID != nil {
+		resourceID = modelPriceIDString(*filter.ID)
+	}
+
 	if err := ValidateModelPrice(param); err != nil {
+		m.recordModelPriceOperation(ctx, string(ioperlog.ActionUpdate), resourceID, modelPriceName(param), nil, modelPriceToMap(param), err)
 		return 0, err
 	}
 
 	oldPrice, err := m.storager.FetchModelPrice(ctx, filter)
 	if err != nil {
+		m.recordModelPriceOperation(ctx, string(ioperlog.ActionUpdate), resourceID, modelPriceName(param), nil, modelPriceToMap(param), err)
 		return 0, err
 	}
 
 	affected, err := m.storager.UpdateModelPrice(ctx, filter, param)
 	if err != nil {
+		m.recordModelPriceOperation(ctx, string(ioperlog.ActionUpdate), resourceID, modelPriceName(param), modelPriceToMap(oldPrice), modelPriceToMap(param), err)
 		return affected, err
 	}
 
-	resourceID := ""
-	if filter != nil && filter.ID != nil {
-		resourceID = modelPriceIDString(*filter.ID)
-	}
-	m.recordModelPriceOperation(ctx, string(ioperlog.ActionUpdate), resourceID, modelPriceName(param), modelPriceToMap(oldPrice), modelPriceToMap(param))
+	m.recordModelPriceOperation(ctx, string(ioperlog.ActionUpdate), resourceID, modelPriceName(param), modelPriceToMap(oldPrice), modelPriceToMap(param), nil)
 	return affected, nil
 }
 
@@ -212,20 +218,23 @@ func (m *Manager) ListProviders(ctx context.Context) ([]string, error) {
 
 // DeleteModelPrice deletes model price records matched by filter.
 func (m *Manager) DeleteModelPrice(ctx context.Context, filter *ModelPriceFilter) error {
-	oldPrice, err := m.storager.FetchModelPrice(ctx, filter)
-	if err != nil {
-		return err
-	}
-
-	if err := m.storager.DeleteModelPrice(ctx, filter); err != nil {
-		return err
-	}
-
 	resourceID := ""
 	if filter != nil && filter.ID != nil {
 		resourceID = modelPriceIDString(*filter.ID)
 	}
-	m.recordModelPriceOperation(ctx, string(ioperlog.ActionDelete), resourceID, modelPriceName(oldPrice), modelPriceToMap(oldPrice), nil)
+
+	oldPrice, err := m.storager.FetchModelPrice(ctx, filter)
+	if err != nil {
+		m.recordModelPriceOperation(ctx, string(ioperlog.ActionDelete), resourceID, "", nil, nil, err)
+		return err
+	}
+
+	if err := m.storager.DeleteModelPrice(ctx, filter); err != nil {
+		m.recordModelPriceOperation(ctx, string(ioperlog.ActionDelete), resourceID, modelPriceName(oldPrice), modelPriceToMap(oldPrice), nil, err)
+		return err
+	}
+
+	m.recordModelPriceOperation(ctx, string(ioperlog.ActionDelete), resourceID, modelPriceName(oldPrice), modelPriceToMap(oldPrice), nil, nil)
 	return nil
 }
 
@@ -252,11 +261,14 @@ const (
 // mode = "merge":  update existing (provider, model, mode) records and insert new ones.
 func (m *Manager) ImportModelPrices(ctx context.Context, entries []*ModelPrice, mode string) (imported int, skipped int, err error) {
 	if mode != string(ImportModeReplace) && mode != string(ImportModeMerge) {
-		return 0, 0, xerror.WrapParamErrorWithMsg("import mode must be replace or merge")
+		err = xerror.WrapParamErrorWithMsg("import mode must be replace or merge")
+		m.recordModelPriceImport(ctx, mode, 0, entries, err)
+		return 0, 0, err
 	}
 
 	for _, entry := range entries {
 		if err := ValidateModelPrice(entry); err != nil {
+			m.recordModelPriceImport(ctx, mode, 0, entries, err)
 			return 0, 0, err
 		}
 	}
@@ -305,9 +317,10 @@ func (m *Manager) ImportModelPrices(ctx context.Context, entries []*ModelPrice, 
 		return nil
 	})
 	if err != nil {
+		m.recordModelPriceImport(ctx, mode, imported, entries, err)
 		return imported, skipped, err
 	}
 
-	m.recordModelPriceImport(ctx, mode, imported, entries)
+	m.recordModelPriceImport(ctx, mode, imported, entries, nil)
 	return imported, skipped, nil
 }

--- a/model/imodel_price/operation_log.go
+++ b/model/imodel_price/operation_log.go
@@ -22,9 +22,16 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 )
 
-func (m *Manager) recordModelPriceOperation(ctx context.Context, action, resourceID, resourceName string, before, after map[string]interface{}) {
+func (m *Manager) recordModelPriceOperation(ctx context.Context, action, resourceID, resourceName string, before, after map[string]interface{}, err error) {
 	if m.operationLogManager == nil {
 		return
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -33,7 +40,8 @@ func (m *Manager) recordModelPriceOperation(ctx context.Context, action, resourc
 		ResourceID:       resourceID,
 		ResourceName:     resourceName,
 		ResourceParentID: "",
-		Status:           ioperlog.StatusSuccess,
+		Status:           status,
+		ErrorMsg:         errorMsg,
 		CreatedAt:        time.Now(),
 	}
 
@@ -51,9 +59,16 @@ func (m *Manager) recordModelPriceOperation(ctx context.Context, action, resourc
 	m.operationLogManager.Record(ctx, entry)
 }
 
-func (m *Manager) recordModelPriceImport(ctx context.Context, mode string, imported int, entries []*ModelPrice) {
+func (m *Manager) recordModelPriceImport(ctx context.Context, mode string, imported int, entries []*ModelPrice, err error) {
 	if m.operationLogManager == nil {
 		return
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -62,7 +77,8 @@ func (m *Manager) recordModelPriceImport(ctx context.Context, mode string, impor
 		ResourceID:       "batch",
 		ResourceName:     "model_price_import",
 		ResourceParentID: "",
-		Status:           ioperlog.StatusSuccess,
+		Status:           status,
+		ErrorMsg:         errorMsg,
 		CreatedAt:        time.Now(),
 	}
 

--- a/model/ioperlog/helper.go
+++ b/model/ioperlog/helper.go
@@ -1,0 +1,51 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package ioperlog
+
+// DefaultErrorMessageMaxLen is the maximum length of operation_logs.error_msg
+// column (varchar(1024)).
+const DefaultErrorMessageMaxLen = 1024
+
+// TruncateErrorMessage converts an error to a string and truncates it to the
+// given maximum length so that it can be safely stored in the database. If the
+// error is nil, an empty string is returned. If truncation occurs, a trailing
+// ellipsis is appended to indicate that the message was shortened.
+func TruncateErrorMessage(err error, maxLen int) string {
+	if err == nil {
+		return ""
+	}
+
+	msg := err.Error()
+	if maxLen <= 0 {
+		return msg
+	}
+
+	if len(msg) <= maxLen {
+		return msg
+	}
+
+	ellipsis := "..."
+	if maxLen <= len(ellipsis) {
+		return msg[:maxLen]
+	}
+
+	return msg[:maxLen-len(ellipsis)] + ellipsis
+}
+
+// TruncateErrorMessageDefault truncates an error message to the default column
+// length (1024 characters).
+func TruncateErrorMessageDefault(err error) string {
+	return TruncateErrorMessage(err, DefaultErrorMessageMaxLen)
+}

--- a/model/ioperlog/helper_test.go
+++ b/model/ioperlog/helper_test.go
@@ -1,0 +1,63 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package ioperlog
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncateErrorMessage(t *testing.T) {
+	t.Run("nil error returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", TruncateErrorMessage(nil, 1024))
+	})
+
+	t.Run("short message is kept intact", func(t *testing.T) {
+		msg := "route in use"
+		assert.Equal(t, msg, TruncateErrorMessage(errors.New(msg), 1024))
+	})
+
+	t.Run("long message is truncated with ellipsis", func(t *testing.T) {
+		msg := strings.Repeat("a", 2000)
+		got := TruncateErrorMessage(errors.New(msg), 1024)
+		assert.Len(t, got, 1024)
+		assert.True(t, strings.HasSuffix(got, "..."))
+	})
+
+	t.Run("maxLen zero returns full message", func(t *testing.T) {
+		msg := "any error"
+		assert.Equal(t, msg, TruncateErrorMessage(errors.New(msg), 0))
+	})
+
+	t.Run("maxLen smaller than ellipsis returns raw prefix", func(t *testing.T) {
+		msg := "hello world"
+		assert.Equal(t, "he", TruncateErrorMessage(errors.New(msg), 2))
+	})
+}
+
+func TestTruncateErrorMessageDefault(t *testing.T) {
+	t.Run("uses default max length", func(t *testing.T) {
+		msg := strings.Repeat("b", DefaultErrorMessageMaxLen+100)
+		got := TruncateErrorMessageDefault(errors.New(msg))
+		assert.Len(t, got, DefaultErrorMessageMaxLen)
+	})
+
+	t.Run("nil error returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", TruncateErrorMessageDefault(nil))
+	})
+}

--- a/model/iprotocol/certificate.go
+++ b/model/iprotocol/certificate.go
@@ -21,13 +21,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bfenetworks/bfe/bfe_tls"
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ibasic"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/itxn"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iversion_control"
-	"github.com/bfenetworks/bfe/bfe_tls"
 )
 
 const certificateExpiredDateLayout = "2006-01-02 15:04:05"
@@ -105,11 +105,15 @@ func (pm *CertificateManager) FetchCertificates(ctx context.Context, param *Cert
 
 func (pm *CertificateManager) DeleteCertificate(ctx context.Context, certificate *Certificate) (err error) {
 	if certificate.IsDefault {
-		return xerror.WrapModelErrorWithMsg("Cant Delete Default Certificate")
+		err = xerror.WrapModelErrorWithMsg("Cant Delete Default Certificate")
+		pm.recordCertificateOperation(ctx, string(ioperlog.ActionDelete), certificate.CertName, certificate.CertName, "", certificateToMap(certificate), nil, err)
+		return
 	}
 
 	if len(certificate.Products) > 0 {
-		return xerror.WrapModelErrorWithMsg("Cant Delete Certificate Be Refer By Product")
+		err = xerror.WrapModelErrorWithMsg("Cant Delete Certificate Be Refer By Product")
+		pm.recordCertificateOperation(ctx, string(ioperlog.ActionDelete), certificate.CertName, certificate.CertName, "", certificateToMap(certificate), nil, err)
+		return
 	}
 
 	err = pm.txn.AtomExecute(ctx, func(ctx context.Context) error {
@@ -122,10 +126,11 @@ func (pm *CertificateManager) DeleteCertificate(ctx context.Context, certificate
 		return pm.storager.DeleteCertificate(ctx, certificate)
 	})
 	if err != nil {
+		pm.recordCertificateOperation(ctx, string(ioperlog.ActionDelete), certificate.CertName, certificate.CertName, "", certificateToMap(certificate), nil, err)
 		return
 	}
 
-	pm.recordCertificateOperation(ctx, string(ioperlog.ActionDelete), certificate.CertName, certificate.CertName, "", certificateToMap(certificate), nil)
+	pm.recordCertificateOperation(ctx, string(ioperlog.ActionDelete), certificate.CertName, certificate.CertName, "", certificateToMap(certificate), nil, nil)
 	return
 }
 
@@ -194,12 +199,19 @@ func parseExpiredDate(certFileContent string) (string, error) {
 }
 
 func (pm *CertificateManager) CreateCertificate(ctx context.Context, param *CertificateParam) (err error) {
+	certName := ""
+	if param.CertName != nil {
+		certName = *param.CertName
+	}
+
 	if err = validateCertPair(*param.CertFileContent, *param.KeyFileContent); err != nil {
+		pm.recordCertificateOperation(ctx, string(ioperlog.ActionCreate), certName, certName, "", nil, certificateParamToMap(param), err)
 		return err
 	}
 
 	expiredDate, err := parseExpiredDate(*param.CertFileContent)
 	if err != nil {
+		pm.recordCertificateOperation(ctx, string(ioperlog.ActionCreate), certName, certName, "", nil, certificateParamToMap(param), err)
 		return err
 	}
 	param.ExpiredDate = &expiredDate
@@ -252,14 +264,11 @@ func (pm *CertificateManager) CreateCertificate(ctx context.Context, param *Cert
 		return pm.storager.CreateCertificate(ctx, param)
 	})
 	if err != nil {
+		pm.recordCertificateOperation(ctx, string(ioperlog.ActionCreate), certName, certName, "", nil, certificateParamToMap(param), err)
 		return
 	}
 
-	certName := ""
-	if param.CertName != nil {
-		certName = *param.CertName
-	}
-	pm.recordCertificateOperation(ctx, string(ioperlog.ActionCreate), certName, certName, "", nil, certificateParamToMap(param))
+	pm.recordCertificateOperation(ctx, string(ioperlog.ActionCreate), certName, certName, "", nil, certificateParamToMap(param), nil)
 
 	return
 }
@@ -290,12 +299,16 @@ func (pm *CertificateManager) UpdateAsDefaultCertificate(ctx context.Context, ce
 		})
 	})
 	if err != nil {
+		pm.recordCertificateOperation(ctx, string(ioperlog.ActionUpdate), cert.CertName, cert.CertName, "", certificateToMap(cert), map[string]interface{}{
+			"cert_name":  cert.CertName,
+			"is_default": true,
+		}, err)
 		return
 	}
 
 	pm.recordCertificateOperation(ctx, string(ioperlog.ActionUpdate), cert.CertName, cert.CertName, "", certificateToMap(cert), map[string]interface{}{
 		"cert_name":  cert.CertName,
 		"is_default": true,
-	})
+	}, nil)
 	return
 }

--- a/model/iprotocol/operation_log.go
+++ b/model/iprotocol/operation_log.go
@@ -21,9 +21,16 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 )
 
-func (pm *CertificateManager) recordCertificateOperation(ctx context.Context, action, resourceID, resourceName, parentID string, before, after map[string]interface{}) {
+func (pm *CertificateManager) recordCertificateOperation(ctx context.Context, action, resourceID, resourceName, parentID string, before, after map[string]interface{}, err error) {
 	if pm.operationLogManager == nil {
 		return
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -32,7 +39,8 @@ func (pm *CertificateManager) recordCertificateOperation(ctx context.Context, ac
 		ResourceID:       resourceID,
 		ResourceName:     resourceName,
 		ResourceParentID: parentID,
-		Status:           ioperlog.StatusSuccess,
+		Status:           status,
+		ErrorMsg:         errorMsg,
 		CreatedAt:        time.Now(),
 	}
 

--- a/model/iprovider/provider.go
+++ b/model/iprovider/provider.go
@@ -157,6 +157,11 @@ func (m *ProviderManager) SetOperationLogManager(manager ioperlog.OperationLogRe
 // CreateProvider creates a new provider after validation.
 func (m *ProviderManager) CreateProvider(ctx context.Context, param *ProviderParam) (int64, error) {
 	if err := ValidateProviderParam(param); err != nil {
+		name := ""
+		if param != nil && param.Name != nil {
+			name = *param.Name
+		}
+		m.recordProviderOperation(ctx, string(ioperlog.ActionCreate), name, nil, providerParamToMap(param), err)
 		return 0, err
 	}
 
@@ -174,10 +179,11 @@ func (m *ProviderManager) CreateProvider(ctx context.Context, param *ProviderPar
 		return err
 	})
 	if err != nil {
+		m.recordProviderOperation(ctx, string(ioperlog.ActionCreate), *param.Name, nil, providerParamToMap(param), err)
 		return 0, err
 	}
 
-	m.recordProviderOperation(ctx, string(ioperlog.ActionCreate), *param.Name, nil, providerParamToMap(param))
+	m.recordProviderOperation(ctx, string(ioperlog.ActionCreate), *param.Name, nil, providerParamToMap(param), nil)
 	return id, nil
 }
 
@@ -191,6 +197,7 @@ func (m *ProviderManager) UpdateProvider(ctx context.Context, name string,
 	syncHooks ...func(ctx context.Context, oldProvider, newProvider *Provider) error) error {
 
 	if err := ValidateProviderParam(param); err != nil {
+		m.recordProviderOperation(ctx, string(ioperlog.ActionUpdate), name, nil, providerParamToMap(param), err)
 		return err
 	}
 
@@ -253,10 +260,11 @@ func (m *ProviderManager) UpdateProvider(ctx context.Context, name string,
 		return nil
 	})
 	if err != nil {
+		m.recordProviderOperation(ctx, string(ioperlog.ActionUpdate), name, providerToMap(oldProvider), providerParamToMap(param), err)
 		return err
 	}
 
-	m.recordProviderOperation(ctx, string(ioperlog.ActionUpdate), name, providerToMap(oldProvider), providerParamToMap(param))
+	m.recordProviderOperation(ctx, string(ioperlog.ActionUpdate), name, providerToMap(oldProvider), providerParamToMap(param), nil)
 	return nil
 }
 
@@ -264,10 +272,12 @@ func (m *ProviderManager) UpdateProvider(ctx context.Context, name string,
 // It supports both JSON (parsed into PricingTiersParam) and YAML bodies at the endpoint layer.
 func (m *ProviderManager) UpdatePricingTiers(ctx context.Context, name string, param *PricingTiersParam) error {
 	if err := ValidatePricingTiersParam(param); err != nil {
+		m.recordProviderOperation(ctx, string(ioperlog.ActionUpdate), name, nil, nil, err)
 		return err
 	}
 
-	return m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+	var oldProvider *Provider
+	err := m.txn.AtomExecute(ctx, func(ctx context.Context) error {
 		existing, err := m.storager.FetchProvider(ctx, &ProviderFilter{Name: &name})
 		if err != nil {
 			return err
@@ -275,6 +285,7 @@ func (m *ProviderManager) UpdatePricingTiers(ctx context.Context, name string, p
 		if existing == nil {
 			return xerror.WrapRecordNotExist("provider")
 		}
+		oldProvider = existing
 
 		// Preserve all existing provider fields; only update time_zone and tiers.
 		updateParam := &ProviderParam{
@@ -290,6 +301,17 @@ func (m *ProviderManager) UpdatePricingTiers(ctx context.Context, name string, p
 		}
 		return m.storager.UpdateProvider(ctx, name, updateParam)
 	})
+	if err != nil {
+		m.recordProviderOperation(ctx, string(ioperlog.ActionUpdate), name, providerToMap(oldProvider), nil, err)
+		return err
+	}
+
+	after := map[string]interface{}{
+		"time_zone": param.TimeZone,
+		"tiers":     param.Tiers,
+	}
+	m.recordProviderOperation(ctx, string(ioperlog.ActionUpdate), name, providerToMap(oldProvider), after, nil)
+	return nil
 }
 
 // DeleteProvider deletes a provider if it is not referenced.
@@ -316,10 +338,11 @@ func (m *ProviderManager) DeleteProvider(ctx context.Context, name string,
 		return m.storager.DeleteProvider(ctx, name)
 	})
 	if err != nil {
+		m.recordProviderOperation(ctx, string(ioperlog.ActionDelete), name, providerToMap(oldProvider), nil, err)
 		return err
 	}
 
-	m.recordProviderOperation(ctx, string(ioperlog.ActionDelete), name, providerToMap(oldProvider), nil)
+	m.recordProviderOperation(ctx, string(ioperlog.ActionDelete), name, providerToMap(oldProvider), nil, nil)
 	return nil
 }
 

--- a/model/iprovider/provider_operation_log.go
+++ b/model/iprovider/provider_operation_log.go
@@ -22,9 +22,16 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 )
 
-func (m *ProviderManager) recordProviderOperation(ctx context.Context, action, name string, before, after map[string]interface{}) {
+func (m *ProviderManager) recordProviderOperation(ctx context.Context, action, name string, before, after map[string]interface{}, err error) {
 	if m.operationLogManager == nil || name == "" {
 		return
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -32,7 +39,8 @@ func (m *ProviderManager) recordProviderOperation(ctx context.Context, action, n
 		ResourceType: string(ioperlog.ResourceTypeProvider),
 		ResourceID:   name,
 		ResourceName: name,
-		Status:       ioperlog.StatusSuccess,
+		Status:       status,
+		ErrorMsg:     errorMsg,
 		CreatedAt:    time.Now(),
 	}
 

--- a/model/iroute_conf/domain.go
+++ b/model/iroute_conf/domain.go
@@ -111,9 +111,9 @@ type DomainStorager interface {
 type DomainManager struct {
 	txn itxn.TxnStorager
 
-	storager              DomainStorager
-	routeRuleManager      *RouteRuleManager
-	operationLogManager   ioperlog.OperationLogRecorder
+	storager            DomainStorager
+	routeRuleManager    *RouteRuleManager
+	operationLogManager ioperlog.OperationLogRecorder
 }
 
 func NewDomainManager(txn itxn.TxnStorager, storager DomainStorager,
@@ -194,15 +194,18 @@ func (m *DomainManager) CreateDomain(ctx context.Context, product *ibasic.Produc
 
 		return m.storager.CreateDomain(ctx, product, param)
 	})
-	if err != nil {
-		return
-	}
 
 	domainName := ""
 	if param.Name != nil {
 		domainName = *param.Name
 	}
-	m.recordDomainOperation(ctx, string(ioperlog.ActionCreate), domainName, domainName, strconv.FormatInt(product.ID, 10), nil, domainParamToMap(param))
+
+	if err != nil {
+		m.recordDomainOperation(ctx, string(ioperlog.ActionCreate), domainName, domainName, strconv.FormatInt(product.ID, 10), nil, domainParamToMap(param), err)
+		return
+	}
+
+	m.recordDomainOperation(ctx, string(ioperlog.ActionCreate), domainName, domainName, strconv.FormatInt(product.ID, 10), nil, domainParamToMap(param), nil)
 
 	return
 }
@@ -210,20 +213,24 @@ func (m *DomainManager) CreateDomain(ctx context.Context, product *ibasic.Produc
 func (m *DomainManager) DeleteDomain(ctx context.Context, product *ibasic.Product, domain *Domain) (err error) {
 	dbui, err := m.BeUsed(ctx, product, domain)
 	if err != nil {
+		m.recordDomainOperation(ctx, string(ioperlog.ActionDelete), domain.Name, domain.Name, strconv.FormatInt(product.ID, 10), domainToMap(domain), nil, err)
 		return err
 	}
 	if dbui != nil {
-		return xerror.WrapDependentUnReadyErrorWithMsg(dbui.String())
+		err = xerror.WrapDependentUnReadyErrorWithMsg(dbui.String())
+		m.recordDomainOperation(ctx, string(ioperlog.ActionDelete), domain.Name, domain.Name, strconv.FormatInt(product.ID, 10), domainToMap(domain), nil, err)
+		return err
 	}
 
 	err = m.txn.AtomExecute(ctx, func(ctx context.Context) error {
 		return m.storager.DeleteDomain(ctx, product, domain)
 	})
 	if err != nil {
+		m.recordDomainOperation(ctx, string(ioperlog.ActionDelete), domain.Name, domain.Name, strconv.FormatInt(product.ID, 10), domainToMap(domain), nil, err)
 		return
 	}
 
-	m.recordDomainOperation(ctx, string(ioperlog.ActionDelete), domain.Name, domain.Name, strconv.FormatInt(product.ID, 10), domainToMap(domain), nil)
+	m.recordDomainOperation(ctx, string(ioperlog.ActionDelete), domain.Name, domain.Name, strconv.FormatInt(product.ID, 10), domainToMap(domain), nil, nil)
 	return
 }
 

--- a/model/iroute_conf/operation_log.go
+++ b/model/iroute_conf/operation_log.go
@@ -23,9 +23,16 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 )
 
-func (rm *RouteRuleManager) recordRouteRuleOperation(ctx context.Context, action string, product *ibasic.Product, before, after map[string]interface{}) {
+func (rm *RouteRuleManager) recordRouteRuleOperation(ctx context.Context, action string, product *ibasic.Product, before, after map[string]interface{}, err error) {
 	if rm.operationLogManager == nil || product == nil {
 		return
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -34,7 +41,8 @@ func (rm *RouteRuleManager) recordRouteRuleOperation(ctx context.Context, action
 		ResourceID:       product.Name,
 		ResourceName:     product.Name,
 		ResourceParentID: strconv.FormatInt(product.ID, 10),
-		Status:           ioperlog.StatusSuccess,
+		Status:           status,
+		ErrorMsg:         errorMsg,
 		CreatedAt:        time.Now(),
 	}
 
@@ -84,9 +92,16 @@ func productRouteRuleToMap(rule *ProductRouteRule) map[string]interface{} {
 	return m
 }
 
-func (m *DomainManager) recordDomainOperation(ctx context.Context, action, resourceID, resourceName, parentID string, before, after map[string]interface{}) {
+func (m *DomainManager) recordDomainOperation(ctx context.Context, action, resourceID, resourceName, parentID string, before, after map[string]interface{}, err error) {
 	if m.operationLogManager == nil {
 		return
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -95,7 +110,8 @@ func (m *DomainManager) recordDomainOperation(ctx context.Context, action, resou
 		ResourceID:       resourceID,
 		ResourceName:     resourceName,
 		ResourceParentID: parentID,
-		Status:           ioperlog.StatusSuccess,
+		Status:           status,
+		ErrorMsg:         errorMsg,
 		CreatedAt:        time.Now(),
 	}
 
@@ -141,10 +157,10 @@ func domainToMap(domain *Domain) map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"id":                       domain.ID,
-		"product_id":               domain.ProductID,
-		"name":                     domain.Name,
-		"using_advanced_redirect":  domain.UsingAdvancedRedirect,
-		"using_advanced_hsts":      domain.UsingAdvancedHsts,
+		"id":                      domain.ID,
+		"product_id":              domain.ProductID,
+		"name":                    domain.Name,
+		"using_advanced_redirect": domain.UsingAdvancedRedirect,
+		"using_advanced_hsts":     domain.UsingAdvancedHsts,
 	}
 }

--- a/model/iroute_conf/route_rule.go
+++ b/model/iroute_conf/route_rule.go
@@ -222,6 +222,7 @@ func (rm *RouteRuleManager) ExpressionVerify(ctx context.Context, expression str
 func (rm *RouteRuleManager) UpsertProductRule(ctx context.Context, product *ibasic.Product, rule *ProductRouteRule) error {
 	cr, err := rule.Convert()
 	if err != nil {
+		rm.recordRouteRuleOperation(ctx, string(ioperlog.ActionUpdate), product, nil, nil, err)
 		return err
 	}
 
@@ -275,10 +276,11 @@ func (rm *RouteRuleManager) UpsertProductRule(ctx context.Context, product *ibas
 		return nil
 	})
 	if err != nil {
+		rm.recordRouteRuleOperation(ctx, string(ioperlog.ActionUpdate), product, beforeRule, nil, err)
 		return err
 	}
 
-	rm.recordRouteRuleOperation(ctx, string(ioperlog.ActionUpdate), product, beforeRule, productRouteRuleToMap(rule))
+	rm.recordRouteRuleOperation(ctx, string(ioperlog.ActionUpdate), product, beforeRule, productRouteRuleToMap(rule), nil)
 
 	return nil
 }

--- a/model/quota/operation_log.go
+++ b/model/quota/operation_log.go
@@ -22,9 +22,16 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 )
 
-func (m *QuotaPlanManager) recordQuotaPlanOperation(ctx context.Context, action string, planID, parentID string, before, after map[string]interface{}) {
+func (m *QuotaPlanManager) recordQuotaPlanOperation(ctx context.Context, action string, planID, parentID string, before, after map[string]interface{}, err error) {
 	if m.operationLogManager == nil {
 		return
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -33,7 +40,8 @@ func (m *QuotaPlanManager) recordQuotaPlanOperation(ctx context.Context, action 
 		ResourceID:       planID,
 		ResourceName:     "",
 		ResourceParentID: parentID,
-		Status:           ioperlog.StatusSuccess,
+		Status:           status,
+		ErrorMsg:         errorMsg,
 		CreatedAt:        time.Now(),
 	}
 

--- a/model/quota/quota_plan_manager.go
+++ b/model/quota/quota_plan_manager.go
@@ -59,10 +59,11 @@ func (m *QuotaPlanManager) SetOperationLogManager(manager ioperlog.OperationLogR
 func (m *QuotaPlanManager) CreateQuotaPlan(ctx context.Context, param *QuotaPlanParam) (int64, error) {
 	id, err := m.storager.CreateQuotaPlan(ctx, param)
 	if err != nil {
+		m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionCreate), "", "", nil, quotaPlanParamToMap(param), err)
 		return 0, err
 	}
 
-	m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionCreate), quotaPlanIDString(id), "", nil, quotaPlanParamToMap(param))
+	m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionCreate), quotaPlanIDString(id), "", nil, quotaPlanParamToMap(param), nil)
 	return id, nil
 }
 
@@ -80,11 +81,21 @@ func (m *QuotaPlanManager) FetchQuotaPlanList(ctx context.Context, filter *Quota
 func (m *QuotaPlanManager) UpdateQuotaPlan(ctx context.Context, filter *QuotaPlanFilter, param *QuotaPlanParam) (int64, error) {
 	oldPlan, err := m.storager.FetchQuotaPlan(ctx, filter)
 	if err != nil {
+		resourceID := ""
+		if filter != nil && filter.ID != nil {
+			resourceID = quotaPlanIDString(*filter.ID)
+		}
+		m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionUpdate), resourceID, "", nil, quotaPlanParamToMap(param), err)
 		return 0, err
 	}
 
 	affected, err := m.storager.UpdateQuotaPlan(ctx, filter, param)
 	if err != nil {
+		resourceID := ""
+		if filter != nil && filter.ID != nil {
+			resourceID = quotaPlanIDString(*filter.ID)
+		}
+		m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionUpdate), resourceID, "", quotaPlanParamToMap(oldPlan), quotaPlanParamToMap(param), err)
 		return affected, err
 	}
 
@@ -92,7 +103,7 @@ func (m *QuotaPlanManager) UpdateQuotaPlan(ctx context.Context, filter *QuotaPla
 	if filter != nil && filter.ID != nil {
 		resourceID = quotaPlanIDString(*filter.ID)
 	}
-	m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionUpdate), resourceID, "", quotaPlanParamToMap(oldPlan), quotaPlanParamToMap(param))
+	m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionUpdate), resourceID, "", quotaPlanParamToMap(oldPlan), quotaPlanParamToMap(param), nil)
 	return affected, nil
 }
 
@@ -100,10 +111,20 @@ func (m *QuotaPlanManager) UpdateQuotaPlan(ctx context.Context, filter *QuotaPla
 func (m *QuotaPlanManager) DeleteQuotaPlan(ctx context.Context, filter *QuotaPlanFilter) error {
 	oldPlan, err := m.storager.FetchQuotaPlan(ctx, filter)
 	if err != nil {
+		resourceID := ""
+		if filter != nil && filter.ID != nil {
+			resourceID = quotaPlanIDString(*filter.ID)
+		}
+		m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionDelete), resourceID, "", nil, nil, err)
 		return err
 	}
 
 	if err := m.storager.DeleteQuotaPlan(ctx, filter); err != nil {
+		resourceID := ""
+		if filter != nil && filter.ID != nil {
+			resourceID = quotaPlanIDString(*filter.ID)
+		}
+		m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionDelete), resourceID, "", quotaPlanParamToMap(oldPlan), nil, err)
 		return err
 	}
 
@@ -111,7 +132,7 @@ func (m *QuotaPlanManager) DeleteQuotaPlan(ctx context.Context, filter *QuotaPla
 	if filter != nil && filter.ID != nil {
 		resourceID = quotaPlanIDString(*filter.ID)
 	}
-	m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionDelete), resourceID, "", quotaPlanParamToMap(oldPlan), nil)
+	m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionDelete), resourceID, "", quotaPlanParamToMap(oldPlan), nil, nil)
 	return nil
 }
 
@@ -168,6 +189,18 @@ func (m *QuotaPlanManager) ResetBalance(ctx context.Context, planID int64, newQu
 		return nil
 	})
 	if err != nil {
+		afterMap := quotaPlanParamToMap(oldPlan)
+		if afterMap == nil {
+			afterMap = map[string]interface{}{}
+		}
+		if resetQuota != nil {
+			afterMap["quota"] = *resetQuota
+		}
+		if updateLastResetAt {
+			now := time.Now()
+			afterMap["last_reset_at"] = now
+		}
+		m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionReset), quotaPlanIDString(planID), "", quotaPlanParamToMap(oldPlan), afterMap, err)
 		return err
 	}
 
@@ -180,7 +213,7 @@ func (m *QuotaPlanManager) ResetBalance(ctx context.Context, planID int64, newQu
 		now := time.Now()
 		afterMap["last_reset_at"] = now
 	}
-	m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionReset), quotaPlanIDString(planID), "", quotaPlanParamToMap(oldPlan), afterMap)
+	m.recordQuotaPlanOperation(ctx, string(ioperlog.ActionReset), quotaPlanIDString(planID), "", quotaPlanParamToMap(oldPlan), afterMap, nil)
 
 	// 5. 重置该 quota_plan 下所有 API-Key / Entity 的 Redis 剩余量（事务外，最终一致）
 	if m.quotaCache == nil || resetQuota == nil {
@@ -238,10 +271,10 @@ func (m *QuotaPlanManager) ApplyQuotaPlanChange(ctx context.Context, planID int6
 // - 新建计划、unit 变化 或 unlimited 切换：used 清零，remaining 置为新配额（unlimited 时用 sentinel）。
 func (m *QuotaPlanManager) adjustQuota(ctx context.Context, planID int64, oldPlan, newPlan *shared.QuotaPlanParam) error {
 	var (
-		newQuota     *float64
-		oldQuota     *float64
-		planUnit     *string
-		useReset     bool
+		newQuota *float64
+		oldQuota *float64
+		planUnit *string
+		useReset bool
 	)
 
 	err := m.txn.AtomExecute(ctx, func(ctx context.Context) error {
@@ -448,4 +481,3 @@ func ptrStringEqual(a, b *string) bool {
 	}
 	return *a == *b
 }
-

--- a/model/rate_limit_policy/operation_log.go
+++ b/model/rate_limit_policy/operation_log.go
@@ -22,9 +22,16 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 )
 
-func (m *RateLimitPolicyManager) recordRateLimitPolicyOperation(ctx context.Context, action string, policyID, parentID string, before, after map[string]interface{}) {
+func (m *RateLimitPolicyManager) recordRateLimitPolicyOperation(ctx context.Context, action string, policyID, parentID string, before, after map[string]interface{}, err error) {
 	if m.operationLogManager == nil {
 		return
+	}
+
+	status := ioperlog.StatusSuccess
+	errorMsg := ""
+	if err != nil {
+		status = ioperlog.StatusFailed
+		errorMsg = ioperlog.TruncateErrorMessageDefault(err)
 	}
 
 	entry := &ioperlog.OperationLogEntry{
@@ -33,7 +40,8 @@ func (m *RateLimitPolicyManager) recordRateLimitPolicyOperation(ctx context.Cont
 		ResourceID:       policyID,
 		ResourceName:     "",
 		ResourceParentID: parentID,
-		Status:           ioperlog.StatusSuccess,
+		Status:           status,
+		ErrorMsg:         errorMsg,
 		CreatedAt:        time.Now(),
 	}
 

--- a/model/rate_limit_policy/rate_limit_policy_manager.go
+++ b/model/rate_limit_policy/rate_limit_policy_manager.go
@@ -58,10 +58,11 @@ func (m *RateLimitPolicyManager) SetOperationLogManager(manager ioperlog.Operati
 func (m *RateLimitPolicyManager) CreateRateLimitPolicy(ctx context.Context, param *RateLimitPolicyParam) (int64, error) {
 	id, err := m.storager.CreateRateLimitPolicy(ctx, param)
 	if err != nil {
+		m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionCreate), "", "", nil, rateLimitPolicyParamToMap(param), err)
 		return 0, err
 	}
 
-	m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionCreate), rateLimitPolicyIDString(id), "", nil, rateLimitPolicyParamToMap(param))
+	m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionCreate), rateLimitPolicyIDString(id), "", nil, rateLimitPolicyParamToMap(param), nil)
 	return id, nil
 }
 
@@ -77,40 +78,46 @@ func (m *RateLimitPolicyManager) FetchRateLimitPolicyList(ctx context.Context, f
 
 // UpdateRateLimitPolicy 更新限流策略
 func (m *RateLimitPolicyManager) UpdateRateLimitPolicy(ctx context.Context, filter *RateLimitPolicyFilter, param *RateLimitPolicyParam) (int64, error) {
+	resourceID := ""
+	if filter != nil && filter.ID != nil {
+		resourceID = rateLimitPolicyIDString(*filter.ID)
+	}
+
 	oldPolicy, err := m.storager.FetchRateLimitPolicy(ctx, filter)
 	if err != nil {
+		m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionUpdate), resourceID, "", nil, rateLimitPolicyParamToMap(param), err)
 		return 0, err
 	}
 
 	affected, err := m.storager.UpdateRateLimitPolicy(ctx, filter, param)
 	if err != nil {
+		m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionUpdate), resourceID, "", rateLimitPolicyParamToMap(oldPolicy), rateLimitPolicyParamToMap(param), err)
 		return affected, err
 	}
 
-	resourceID := ""
-	if filter != nil && filter.ID != nil {
-		resourceID = rateLimitPolicyIDString(*filter.ID)
-	}
-	m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionUpdate), resourceID, "", rateLimitPolicyParamToMap(oldPolicy), rateLimitPolicyParamToMap(param))
+	m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionUpdate), resourceID, "", rateLimitPolicyParamToMap(oldPolicy), rateLimitPolicyParamToMap(param), nil)
 	return affected, nil
 }
 
 // DeleteRateLimitPolicy 删除限流策略
 func (m *RateLimitPolicyManager) DeleteRateLimitPolicy(ctx context.Context, filter *RateLimitPolicyFilter) error {
-	oldPolicy, err := m.storager.FetchRateLimitPolicy(ctx, filter)
-	if err != nil {
-		return err
-	}
-
-	if err := m.storager.DeleteRateLimitPolicy(ctx, filter); err != nil {
-		return err
-	}
-
 	resourceID := ""
 	if filter != nil && filter.ID != nil {
 		resourceID = rateLimitPolicyIDString(*filter.ID)
 	}
-	m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionDelete), resourceID, "", rateLimitPolicyParamToMap(oldPolicy), nil)
+
+	oldPolicy, err := m.storager.FetchRateLimitPolicy(ctx, filter)
+	if err != nil {
+		m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionDelete), resourceID, "", nil, nil, err)
+		return err
+	}
+
+	if err := m.storager.DeleteRateLimitPolicy(ctx, filter); err != nil {
+		m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionDelete), resourceID, "", rateLimitPolicyParamToMap(oldPolicy), nil, err)
+		return err
+	}
+
+	m.recordRateLimitPolicyOperation(ctx, string(ioperlog.ActionDelete), resourceID, "", rateLimitPolicyParamToMap(oldPolicy), nil, nil)
 	return nil
 }
 

--- a/test/integration/tests/operation_log/list/list_test.go
+++ b/test/integration/tests/operation_log/list/list_test.go
@@ -236,3 +236,46 @@ func TestOperationLog_ListFilters(t *testing.T) {
 	_ = testutil.DeleteEntity(entityID)
 	_ = testutil.DeleteEntityType(typeName)
 }
+
+// TestOperationLog_FailedOperationRecordsError 验证写操作失败时同样会生成 status=2 的操作日志。
+// 该用例复现 GitHub issue #117：删除仍被路由规则引用的集群时接口返回 500，但此前操作日志为空。
+func TestOperationLog_FailedOperationRecordsError(t *testing.T) {
+	client := testutil.GetClient()
+
+	// 1. 清理全局路由规则，避免受其他测试影响。
+	require.NoError(t, testutil.ResetGlobalRouteRules(), "reset global route rules failed")
+
+	// 2. 创建 cluster。
+	clusterName := testutil.UniqueClusterName()
+	_, err := testutil.CreateCluster(clusterName)
+	require.NoError(t, err, "create cluster failed")
+
+	// 3. 设置 global route rules 引用该 cluster，使删除失败。
+	require.NoError(t, testutil.SetGlobalRouteRules([]interface{}{testutil.SimpleRouteRule("failed-op-ref", clusterName)}), "set global route rules failed")
+
+	// 4. 调用删除接口，预期失败。
+	resp, err := client.Delete("/open-api/v1/clusters/" + clusterName)
+	require.NoError(t, err, "delete cluster request failed")
+	assert.NotEqual(t, 200, resp.ErrNum, "expected delete cluster to fail")
+
+	// 5. 轮询等待失败的操作日志落库。
+	entry, err := testutil.WaitForOperationLog(map[string]string{
+		"resource_type": "cluster",
+		"action":        "delete",
+		"resource_name": clusterName,
+		"status":        "2",
+	}, 0)
+	require.NoError(t, err, "expected failed operation log not found")
+
+	assert.Equal(t, "delete", entry.Action)
+	assert.Equal(t, "cluster", entry.ResourceType)
+	assert.Equal(t, clusterName, entry.ResourceName)
+	assert.Equal(t, float64(2), entry.Status, "operation should be failed")
+	assert.NotEmpty(t, entry.ErrorMsg, "failed operation log should contain error message")
+	assert.NotEmpty(t, entry.RequestPath)
+	assert.NotEmpty(t, entry.CreatedAt)
+
+	// 6. 清理。
+	require.NoError(t, testutil.ResetGlobalRouteRules(), "cleanup global route rules failed")
+	_ = testutil.DeleteCluster(clusterName)
+}

--- a/test/integration/testutil/api_helpers.go
+++ b/test/integration/testutil/api_helpers.go
@@ -426,15 +426,16 @@ func FieldExists(resp *APIResponse, field string) (bool, error) {
 
 // OperationLogEntry 是查询操作日志返回的单个条目结构（仅包含测试常用字段）。
 type OperationLogEntry struct {
-	ID           float64                `json:"id"`
-	Action       string                 `json:"action"`
-	ResourceType string                 `json:"resource_type"`
-	ResourceID   string                 `json:"resource_id"`
-	ResourceName string                 `json:"resource_name"`
-	Status       float64                `json:"status"`
-	RequestPath  string                 `json:"request_path"`
-	RequestMethod string                `json:"request_method"`
-	CreatedAt    float64                `json:"created_at"`
+	ID            float64                `json:"id"`
+	Action        string                 `json:"action"`
+	ResourceType  string                 `json:"resource_type"`
+	ResourceID    string                 `json:"resource_id"`
+	ResourceName  string                 `json:"resource_name"`
+	Status        float64                `json:"status"`
+	ErrorMsg      string                 `json:"error_msg"`
+	RequestPath   string                 `json:"request_path"`
+	RequestMethod string                 `json:"request_method"`
+	CreatedAt     float64                `json:"created_at"`
 	ChangeSummary map[string]interface{} `json:"change_summary"`
 }
 
@@ -481,4 +482,42 @@ func WaitForOperationLog(filter map[string]string, timeout time.Duration) (*Oper
 		time.Sleep(200 * time.Millisecond)
 	}
 	return nil, fmt.Errorf("operation log not found after %v, filter=%v", timeout, filter)
+}
+
+// ResetGlobalRouteRules 清空全局路由规则。
+func ResetGlobalRouteRules() error {
+	resp, err := GetClient().Put("/open-api/v1/global-route-rules", map[string]interface{}{
+		"rules": []interface{}{},
+	})
+	if err != nil {
+		return err
+	}
+	if resp.ErrNum != 200 {
+		return fmt.Errorf("reset global route rules failed: %d %s", resp.ErrNum, resp.ErrMsg)
+	}
+	return nil
+}
+
+// SetGlobalRouteRules 设置全局路由规则。
+func SetGlobalRouteRules(rules []interface{}) error {
+	resp, err := GetClient().Put("/open-api/v1/global-route-rules", map[string]interface{}{
+		"rules": rules,
+	})
+	if err != nil {
+		return err
+	}
+	if resp.ErrNum != 200 {
+		return fmt.Errorf("set global route rules failed: %d %s", resp.ErrNum, resp.ErrMsg)
+	}
+	return nil
+}
+
+// SimpleRouteRule 构造一条最简单的 global route rule，用于集成测试。
+func SimpleRouteRule(name, clusterName string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":      name,
+		"cond":      "default_t()",
+		"targets":   []interface{}{map[string]interface{}{"cluster_name": clusterName, "model": "", "weight": 100}},
+		"fallbacks": []interface{}{},
+	}
 }


### PR DESCRIPTION
…sign docs

- Add ioperlog.TruncateErrorMessage to cap error_msg at 1024 chars

- Extend all recordXxxOperation helpers with err parameter

- Record failed logs before returning errors in all configured managers

- Add unit and integration tests for failed operation log scenarios

- Update sys-design docs and add details/操作日志模块.md

- Add design-docs/modifications/2026-08-31-operation-log-failure-records