### PR TITLE
fix(operation-log): include diff_keys in update change_summary

### DIFF
--- a/design-docs/sys-design/details/操作日志模块.md
+++ b/design-docs/sys-design/details/操作日志模块.md
@@ -150,7 +150,11 @@ func MaskSensitiveFields(data map[string]interface{}) map[string]interface{}
 | `certificate`、`cert_body`、`private_key_body` 等 | 替换为 `[已更新]`，不记录具体内容 |
 | 嵌套 map | 递归脱敏 |
 
-各业务 Manager 在构造 `change_summary` 后调用 `MaskSensitiveFields`，确保持久化前完成脱敏。
+各业务 Manager 通过 `model/ioperlog/change_summary.go` 提供的 `BuildChangeSummary` 统一构造 `change_summary`，该函数会：
+
+- 对 `before` / `after` 调用 `MaskSensitiveFields` 完成脱敏；
+- 对 `update` 动作计算并写入 `diff_keys`，用于详情页展示差异字段；
+- `diff_keys` 按 `after` 中存在的 key 与 `before` 比较，值不同或 `before` 不存在时计入差异，并按字母序排序。
 
 ## 7. 接入域与调用模式
 

--- a/model/api_key/api_key_operation_log.go
+++ b/model/api_key/api_key_operation_log.go
@@ -60,16 +60,7 @@ func (rppm *APIKeyManager) recordAPIKeyOperation(ctx context.Context, action str
 		CreatedAt:        time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	rppm.operationLogManager.Record(ctx, entry)
 }

--- a/model/entity/operation_log.go
+++ b/model/entity/operation_log.go
@@ -44,16 +44,7 @@ func (m *EntityManager) recordEntityOperation(ctx context.Context, action string
 		CreatedAt:        time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	m.operationLogManager.Record(ctx, entry)
 }
@@ -89,16 +80,7 @@ func (m *EntityTypeManager) recordEntityTypeOperation(ctx context.Context, actio
 		CreatedAt:    time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	m.operationLogManager.Record(ctx, entry)
 }

--- a/model/entity/operation_log_test.go
+++ b/model/entity/operation_log_test.go
@@ -98,6 +98,8 @@ func TestEntityManager_UpdateEntity_RecordsOperationLog(t *testing.T) {
 	entry := recorder.entries[0]
 	assert.Equal(t, string(ioperlog.ActionUpdate), entry.Action)
 	assert.Equal(t, entityID, entry.ResourceID)
+	require.NotNil(t, entry.ChangeSummary)
+	assert.Equal(t, []string{"name"}, entry.ChangeSummary["diff_keys"])
 }
 
 func TestEntityTypeManager_CreateEntityType_RecordsOperationLog(t *testing.T) {
@@ -159,6 +161,8 @@ func TestEntityTypeManager_UpdateEntityType_RecordsOperationLog(t *testing.T) {
 	entry := recorder.entries[0]
 	assert.Equal(t, string(ioperlog.ActionUpdate), entry.Action)
 	assert.Equal(t, typeName, entry.ResourceID)
+	require.NotNil(t, entry.ChangeSummary)
+	assert.Equal(t, []string{"description"}, entry.ChangeSummary["diff_keys"])
 }
 
 func TestEntityTypeManager_DeleteEntityType_RecordsOperationLog(t *testing.T) {

--- a/model/iauth/operation_log.go
+++ b/model/iauth/operation_log.go
@@ -88,16 +88,7 @@ func recordAuthOperation(recorder ioperlog.OperationLogRecorder, ctx context.Con
 		CreatedAt:        time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	recorder.Record(ctx, entry)
 }

--- a/model/icluster_conf/cluster_operation_log.go
+++ b/model/icluster_conf/cluster_operation_log.go
@@ -45,16 +45,7 @@ func (cm *ClusterManager) recordClusterOperation(ctx context.Context, action str
 		CreatedAt:    time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	cm.operationLogManager.Record(ctx, entry)
 }

--- a/model/imodel_price/operation_log.go
+++ b/model/imodel_price/operation_log.go
@@ -45,16 +45,7 @@ func (m *Manager) recordModelPriceOperation(ctx context.Context, action, resourc
 		CreatedAt:        time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	m.operationLogManager.Record(ctx, entry)
 }

--- a/model/ioperlog/change_summary.go
+++ b/model/ioperlog/change_summary.go
@@ -1,0 +1,76 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package ioperlog
+
+import (
+	"reflect"
+	"sort"
+)
+
+// BuildChangeSummary constructs the change_summary map for an operation log.
+// It applies MaskSensitiveFields to before/after, and for update actions it
+// also computes the list of changed field keys (diff_keys).
+//
+// diff_keys is computed from the keys present in the "after" map:
+//   - keys that exist in both before and after but have different values
+//   - keys that only exist in after (newly added fields)
+//
+// Keys that only exist in "before" are intentionally excluded, because many
+// update requests are partial and omit unchanged fields. Including them would
+// produce false-positive diffs.
+func BuildChangeSummary(action string, before, after map[string]interface{}) map[string]interface{} {
+	var diffKeys []string
+	if ActionType(action) == ActionUpdate {
+		diffKeys = computeDiffKeys(before, after)
+	}
+
+	changeSummary := map[string]interface{}{}
+	if len(before) > 0 {
+		changeSummary["before"] = MaskSensitiveFields(before)
+	}
+	if len(after) > 0 {
+		changeSummary["after"] = MaskSensitiveFields(after)
+	}
+	if len(changeSummary) == 0 {
+		return nil
+	}
+
+	if ActionType(action) == ActionUpdate {
+		changeSummary["diff_keys"] = diffKeys
+	}
+
+	return changeSummary
+}
+
+func computeDiffKeys(before, after map[string]interface{}) []string {
+	if len(after) == 0 {
+		return []string{}
+	}
+
+	diffs := make([]string, 0, len(after))
+	for key, afterVal := range after {
+		beforeVal, ok := before[key]
+		if !ok {
+			diffs = append(diffs, key)
+			continue
+		}
+		if !reflect.DeepEqual(beforeVal, afterVal) {
+			diffs = append(diffs, key)
+		}
+	}
+
+	sort.Strings(diffs)
+	return diffs
+}

--- a/model/ioperlog/change_summary_test.go
+++ b/model/ioperlog/change_summary_test.go
@@ -1,0 +1,107 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package ioperlog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildChangeSummary_UpdateWithDiff(t *testing.T) {
+	before := map[string]interface{}{
+		"allow_models": []string{"gpt-4"},
+		"name":         "old-name",
+	}
+	after := map[string]interface{}{
+		"allow_models": []string{"gpt-4", "gpt-4o"},
+		"name":         "old-name",
+	}
+
+	summary := BuildChangeSummary(string(ActionUpdate), before, after)
+
+	assert.NotNil(t, summary)
+	assert.Contains(t, summary, "before")
+	assert.Contains(t, summary, "after")
+	assert.Equal(t, []string{"allow_models"}, summary["diff_keys"])
+}
+
+func TestBuildChangeSummary_UpdatePartialRequest(t *testing.T) {
+	// Simulates a PATCH update where only "allow_models" is sent.
+	before := map[string]interface{}{
+		"allow_models": []string{"gpt-4"},
+		"block_models": []string{"gpt-3"},
+		"name":         "entity-1",
+	}
+	after := map[string]interface{}{
+		"allow_models": []string{"gpt-4", "gpt-4o"},
+	}
+
+	summary := BuildChangeSummary(string(ActionUpdate), before, after)
+
+	assert.NotNil(t, summary)
+	assert.Equal(t, []string{"allow_models"}, summary["diff_keys"])
+}
+
+func TestBuildChangeSummary_UpdateNoDiff(t *testing.T) {
+	before := map[string]interface{}{"name": "same"}
+	after := map[string]interface{}{"name": "same"}
+
+	summary := BuildChangeSummary(string(ActionUpdate), before, after)
+
+	assert.NotNil(t, summary)
+	assert.Equal(t, []string{}, summary["diff_keys"])
+}
+
+func TestBuildChangeSummary_CreateHasNoDiffKeys(t *testing.T) {
+	after := map[string]interface{}{"name": "new"}
+
+	summary := BuildChangeSummary(string(ActionCreate), nil, after)
+
+	assert.NotNil(t, summary)
+	assert.Contains(t, summary, "after")
+	assert.NotContains(t, summary, "diff_keys")
+}
+
+func TestBuildChangeSummary_DeleteHasNoDiffKeys(t *testing.T) {
+	before := map[string]interface{}{"name": "old"}
+
+	summary := BuildChangeSummary(string(ActionDelete), before, nil)
+
+	assert.NotNil(t, summary)
+	assert.Contains(t, summary, "before")
+	assert.NotContains(t, summary, "diff_keys")
+}
+
+func TestBuildChangeSummary_MasksSensitiveFields(t *testing.T) {
+	before := map[string]interface{}{
+		"password": "old-pass",
+	}
+	after := map[string]interface{}{
+		"password": "new-pass",
+	}
+
+	summary := BuildChangeSummary(string(ActionUpdate), before, after)
+
+	assert.NotNil(t, summary)
+	assert.Equal(t, maskPlaceholder, summary["before"].(map[string]interface{})["password"])
+	assert.Equal(t, maskPlaceholder, summary["after"].(map[string]interface{})["password"])
+	assert.Equal(t, []string{"password"}, summary["diff_keys"])
+}
+
+func TestBuildChangeSummary_EmptyReturnsNil(t *testing.T) {
+	assert.Nil(t, BuildChangeSummary(string(ActionUpdate), nil, nil))
+	assert.Nil(t, BuildChangeSummary(string(ActionUpdate), map[string]interface{}{}, map[string]interface{}{}))
+}

--- a/model/iprotocol/operation_log.go
+++ b/model/iprotocol/operation_log.go
@@ -44,16 +44,7 @@ func (pm *CertificateManager) recordCertificateOperation(ctx context.Context, ac
 		CreatedAt:        time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	pm.operationLogManager.Record(ctx, entry)
 }

--- a/model/iprovider/provider_operation_log.go
+++ b/model/iprovider/provider_operation_log.go
@@ -44,16 +44,7 @@ func (m *ProviderManager) recordProviderOperation(ctx context.Context, action, n
 		CreatedAt:    time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	m.operationLogManager.Record(ctx, entry)
 }

--- a/model/iroute_conf/operation_log.go
+++ b/model/iroute_conf/operation_log.go
@@ -46,16 +46,7 @@ func (rm *RouteRuleManager) recordRouteRuleOperation(ctx context.Context, action
 		CreatedAt:        time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	rm.operationLogManager.Record(ctx, entry)
 }
@@ -115,16 +106,7 @@ func (m *DomainManager) recordDomainOperation(ctx context.Context, action, resou
 		CreatedAt:        time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	m.operationLogManager.Record(ctx, entry)
 }

--- a/model/quota/operation_log.go
+++ b/model/quota/operation_log.go
@@ -45,16 +45,7 @@ func (m *QuotaPlanManager) recordQuotaPlanOperation(ctx context.Context, action 
 		CreatedAt:        time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	m.operationLogManager.Record(ctx, entry)
 }

--- a/model/rate_limit_policy/operation_log.go
+++ b/model/rate_limit_policy/operation_log.go
@@ -45,16 +45,7 @@ func (m *RateLimitPolicyManager) recordRateLimitPolicyOperation(ctx context.Cont
 		CreatedAt:        time.Now(),
 	}
 
-	changeSummary := map[string]interface{}{}
-	if len(before) > 0 {
-		changeSummary["before"] = ioperlog.MaskSensitiveFields(before)
-	}
-	if len(after) > 0 {
-		changeSummary["after"] = ioperlog.MaskSensitiveFields(after)
-	}
-	if len(changeSummary) > 0 {
-		entry.ChangeSummary = changeSummary
-	}
+	entry.ChangeSummary = ioperlog.BuildChangeSummary(action, before, after)
 
 	m.operationLogManager.Record(ctx, entry)
 }

--- a/test/integration/tests/operation_log/list/list_test.go
+++ b/test/integration/tests/operation_log/list/list_test.go
@@ -279,3 +279,42 @@ func TestOperationLog_FailedOperationRecordsError(t *testing.T) {
 	require.NoError(t, testutil.ResetGlobalRouteRules(), "cleanup global route rules failed")
 	_ = testutil.DeleteCluster(clusterName)
 }
+
+// TestOperationLog_UpdateEntityTypeHasDiffKeys 验证 update 动作的操作日志包含 diff_keys。
+func TestOperationLog_UpdateEntityTypeHasDiffKeys(t *testing.T) {
+	client := testutil.GetClient()
+
+	typeName := testutil.UniqueEntityTypeName()
+	_, err := testutil.CreateEntityType(typeName, 1)
+	require.NoError(t, err, "setup entity type failed")
+
+	// 更新 entity-type 的 description，产生 update 日志。
+	resp, err := client.Patch("/open-api/v1/entity-types/"+typeName, map[string]interface{}{
+		"description": "updated description for diff_keys test",
+	})
+	require.NoError(t, err, "update entity-type request failed")
+	testutil.AssertSuccess(t, resp)
+
+	entry, err := testutil.WaitForOperationLog(map[string]string{
+		"resource_type": "entity_type",
+		"action":        "update",
+		"resource_id":   typeName,
+	}, 0)
+	require.NoError(t, err, "expected update operation log not found")
+
+	assert.Equal(t, "update", entry.Action)
+	assert.Equal(t, "entity_type", entry.ResourceType)
+	assert.Equal(t, typeName, entry.ResourceID)
+
+	require.NotNil(t, entry.ChangeSummary, "change_summary should be present")
+	assert.Contains(t, entry.ChangeSummary, "before")
+	assert.Contains(t, entry.ChangeSummary, "after")
+	require.Contains(t, entry.ChangeSummary, "diff_keys")
+
+	diffKeys, ok := entry.ChangeSummary["diff_keys"].([]interface{})
+	require.True(t, ok, "diff_keys should be an array")
+	assert.Contains(t, diffKeys, "description")
+
+	// 清理
+	_ = testutil.DeleteEntityType(typeName)
+}


### PR DESCRIPTION
Build change_summary via ioperlog.BuildChangeSummary so that update actions compute and persist diff_keys, matching the OpenAPI contract.

Fixes https://github.com/rainway-ai-gateway/ai-gateway-api/issues/120