### PR TITLE
fix: DELETE model-prices/providers 返回 Data 为 null，与接口文档契约一致

### DIFF
--- a/endpoints/openapi_v1/model_price/delete.go
+++ b/endpoints/openapi_v1/model_price/delete.go
@@ -58,7 +58,7 @@ func DeleteAction(req *http.Request) (interface{}, error) {
 	if err := container.ModelPriceManager.DeleteModelPrice(req.Context(), &imodel_price.ModelPriceFilter{ID: id}); err != nil {
 		return nil, err
 	}
-	return map[string]interface{}{"deleted": true}, nil
+	return nil, nil
 }
 
 // DeleteByQueryAction handles DELETE /model-prices?provider=&model=&mode=.
@@ -79,5 +79,5 @@ func DeleteByQueryAction(req *http.Request) (interface{}, error) {
 	if err := container.ModelPriceManager.DeleteModelPrice(req.Context(), filter); err != nil {
 		return nil, err
 	}
-	return map[string]interface{}{"deleted": true}, nil
+	return nil, nil
 }

--- a/endpoints/openapi_v1/provider/delete.go
+++ b/endpoints/openapi_v1/provider/delete.go
@@ -48,7 +48,7 @@ func DeleteAction(req *http.Request) (interface{}, error) {
 		return nil, err
 	}
 
-	return map[string]interface{}{"deleted": true}, nil
+	return nil, nil
 }
 
 // ProviderDeleteCheckerFunc adapts a manager method to the signature expected by ProviderManager.

--- a/test/integration/tests/model_price/delete/delete_test.go
+++ b/test/integration/tests/model_price/delete/delete_test.go
@@ -1,13 +1,11 @@
 package model_price_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
-	"github.com/stretchr/testify/assert"
 )
 
 var sm *testutil.ServerManager
@@ -45,12 +43,7 @@ func TestModelPrice_Delete(t *testing.T) {
 			t.Fatalf("request failed: %v", err)
 		}
 		testutil.AssertSuccess(t, resp)
-
-		var data map[string]interface{}
-		if err := json.Unmarshal(resp.Data, &data); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-		assert.Equal(t, true, data["deleted"])
+		testutil.AssertDataNull(t, resp)
 
 		getResp, err := testutil.GetClient().Get("/open-api/v1/model-prices/" + fmt.Sprintf("%d", id))
 		if err != nil {
@@ -92,12 +85,7 @@ func TestModelPrice_Delete(t *testing.T) {
 			t.Fatalf("request failed: %v", err)
 		}
 		testutil.AssertSuccess(t, resp)
-
-		var data map[string]interface{}
-		if err := json.Unmarshal(resp.Data, &data); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-		assert.Equal(t, true, data["deleted"])
+		testutil.AssertDataNull(t, resp)
 
 		getResp, err := testutil.GetClient().Get("/open-api/v1/model-prices/" + fmt.Sprintf("%d", id))
 		if err != nil {

--- a/test/integration/testutil/assert.go
+++ b/test/integration/testutil/assert.go
@@ -30,6 +30,17 @@ func AssertErrCode(t *testing.T, resp *APIResponse, expectedErrNum int) {
 	}
 }
 
+// AssertDataNull 验证 Data 为 null
+func AssertDataNull(t *testing.T, resp *APIResponse) {
+	t.Helper()
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if len(resp.Data) != 0 && string(resp.Data) != "null" {
+		t.Errorf("expected Data null, got %s", string(resp.Data))
+	}
+}
+
 // AssertDataNotEmpty 验证 Data 不为空
 func AssertDataNotEmpty(t *testing.T, resp *APIResponse) {
 	t.Helper()


### PR DESCRIPTION
model_price 两个删除 handler 及 provider 删除 handler 原先返回 {"deleted": true}，与同族 entity/entity_type/certificate 及 model-prices.md、providers.md 文档约定（Data 为 null）不一致。 同步更新集成测试断言，新增 testutil.AssertDataNull 辅助函数。

Closes https://github.com/rainway-ai-gateway/ai-gateway-api/issues/138