### PR TITLE
fix: model-prices PUT 部分更新 prices/tier_prices 按键级合并 (#140)

### DIFF
--- a/design-docs/api-define/OpenAPI接口定义/model-prices.md
+++ b/design-docs/api-define/OpenAPI接口定义/model-prices.md
@@ -566,6 +566,10 @@ models:
 
 字段同 [1. 数据模型](#1-数据模型)，仅传需修改字段，未传入字段保持原值。请求体中无需传入 `id`、`price_currency`、`create_time`、`update_time`。
 
+> map/切片字段更新粒度：
+> - `prices`、`tier_prices`：**键级合并**。请求中传入的键覆盖对应键，未传入的键保留原值；`tier_prices` 未传入的 tier 整档保留（见 issue #140 修复）。
+> - `limits`、`metadata`（map）、`capabilities`、`supported_parameters`（切片）：**整块替换**。传入即整体覆盖，未传入则保持原值不变。
+
 **返回数据（Data内容）**
 
 返回更新后的完整记录，字段同 [1. 数据模型](#1-数据模型)。
@@ -594,6 +598,10 @@ models:
 **输入参数（Body）**
 
 字段同 [1. 数据模型](#1-数据模型)，仅传需修改字段，未传入字段保持原值。请求体中无需传入 `price_currency`、`create_time`、`update_time`。
+
+> map/切片字段更新粒度：
+> - `prices`、`tier_prices`：**键级合并**。请求中传入的键覆盖对应键，未传入的键保留原值；`tier_prices` 未传入的 tier 整档保留（见 issue #140 修复）。
+> - `limits`、`metadata`（map）、`capabilities`、`supported_parameters`（切片）：**整块替换**。传入即整体覆盖，未传入则保持原值不变。
 
 **返回数据（Data内容）**
 

--- a/design-docs/modifications/2026-09-07-issue-140-model-price-partial-update-merge/change-summary.md
+++ b/design-docs/modifications/2026-09-07-issue-140-model-price-partial-update-merge/change-summary.md
@@ -1,0 +1,100 @@
+# Issue #140：Model Price PUT 部分更新按键合并修复方案
+
+## 1. 问题来源
+
+[rainway-ai-gateway/ai-gateway-api/issues/140](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/140)
+
+> 按合同 OpenAPI 接口定义 model-prices.md §3.7/§3.8，PUT 部分更新语义为"仅传需修改字段，未传入字段保持原值"。实际行为：请求里只要带了 `prices` 或 `tier_prices`（哪怕只想改其中一个键），整个 map 被请求体替换，未传入的价格键被静默清除，HTTP 200 无任何告警。
+
+危害：任何"只调一个价"的运维操作都会静默丢失同 map 内其余价格（`output_cost_per_token`、`cache_read_input_token_cost` 等），下游 BFE 计费按缺失键回退，属静默计费配置数据丢失。E2E SC1301-TC014（指纹 dbf76872）保持 REAL_VERIFICATION_BLOCKED/FAILED_PRODUCT 终态等待本修复。
+
+## 2. 根因
+
+`endpoints/openapi_v1/model_price/update.go` 的 `mergeModelPrice`（被 `UpdateByIDAction` 与 `UpdateByQueryAction` 两条 PUT 路径共用）只对标量字段做了"非空才覆盖"，所有 map 字段是整块指针赋值：
+
+```go
+// update.go:125-129（修复前）
+if len(src.Prices) > 0 {
+    merged.Prices = src.Prices // 整 map 替换，无按键合并
+}
+if len(src.TierPrices) > 0 {
+    merged.TierPrices = src.TierPrices // 两层嵌套（tier→价格键）同样整块替换
+}
+```
+
+即"部分更新"的粒度实现到了字段级（map 有没有传），没有下钻到键级（map 里哪些键传了）。DB 写入侧（`UpdateModelPrice` 收到 merged 记录）没有问题，缺陷收敛在这一个 merge 函数。
+
+## 3. 目标
+
+1. `prices`：PUT 传入的键覆盖对应键，未传入的键保留存量值；
+2. `tier_prices`：两层合并——请求中出现的 tier 名按键级合并，未传入的 tier 整档保留；
+3. 合并不得污染调用方持有的 `existing` 记录（`merged := *dst` 是浅拷贝，必须新建 map 写入，不能原地改 `dst` 的 map）；
+4. 补齐 handler 层单测回归防护；
+5. 在 `model-prices.md` §3.7/§3.8 明确 map/切片字段的合并语义契约。
+
+## 4. 范围
+
+| 范围 | 说明 |
+|------|------|
+| 涉及仓库 | `ai-gateway-api` |
+| 主要文件 | `endpoints/openapi_v1/model_price/update.go`（`mergeModelPrice`） |
+| 接口契约 | PUT 响应字段不变；仅 `prices` / `tier_prices` 的合并粒度从"整块替换"修正为"键级合并" |
+| 同族字段 | `limits`、`metadata`（map）、`capabilities`、`supported_parameters`（切片）**保持现状整块替换**，本次仅在合同文档中显式写明语义（见 §6） |
+| 数据迁移 | 无 |
+
+## 5. 最终方案
+
+### 5.1 键级深合并实现
+
+`mergeModelPrice` 中两个价格 map 改为调用合并辅助函数：
+
+```go
+if len(src.Prices) > 0 {
+    merged.Prices = mergePriceMap(dst.Prices, src.Prices)
+}
+if len(src.TierPrices) > 0 {
+    merged.TierPrices = mergeTierPriceMap(dst.TierPrices, src.TierPrices)
+}
+```
+
+- `mergePriceMap(dst, src)`：新建 map，先拷贝 `dst` 全键，再用 `src` 键覆盖——`src` 未传的键保留 `dst` 原值；
+- `mergeTierPriceMap(dst, src)`：新建外层 map；`src` 中已存在的 tier 按键级合并（新建内层 map），`src` 中新增的 tier 整档加入，`dst` 有而 `src` 未传的 tier 整档保留；
+- 全程不原地修改 `dst`/`src` 持有的任何 map，避免污染 `existing` 记录。
+
+### 5.2 修复后行为对照（issue 复现路径）
+
+PUT `{"prices":{"input_cost_per_token":3.1e-06},"tier_prices":{"peak":{"input_cost_per_token":1.11e-05}}}`：
+
+| 字段 | 修复前 | 修复后 |
+|------|--------|--------|
+| `prices` | 只剩 `input`，`output` 被静默清除 | `input` 更新为 3.1e-06，`output` 保留 6.2e-06 |
+| `tier_prices.peak` | 只剩 `input`，`output`/`cache_read` 被静默清除 | `input` 更新，同档未传键保留；其他 tier 整档保留 |
+
+## 6. 合同文档补充（model-prices.md §3.7/§3.8）
+
+在"仅传需修改字段，未传入字段保持原值"处补充 map/切片字段的粒度说明：
+
+- `prices`、`tier_prices`：**键级合并**。传入的键覆盖对应键，未传入的键/档保留原值；
+- `limits`、`metadata`（map）、`capabilities`、`supported_parameters`（切片）：**整块替换**。传入即整体覆盖，未传入保持原值不变。
+
+## 7. 回归防护
+
+1. **handler 单测**（`endpoints/openapi_v1/model_price/update_test.go`，直接测纯函数 `mergeModelPrice`）：
+   - PUT 只传单键 → 同 map 其余键保留；
+   - PUT 传同档部分键 → 同档未传键保留、其他 tier 整档保留；PUT 传新 tier 名 → 旧 tier 全档保留；
+   - 不传 map → 存量 map 完全不变；
+   - 合并不修改 `dst` 持有的 map（别名/污染断言）；
+   - 标量字段合并不受影响。
+2. **E2E**：SC1301-TC014 修复部署后走 requeue-real-verification 重跑，全链验证并解除 FAILED_PRODUCT 终态。
+
+## 8. 风险与兼容性
+
+| 项目 | 说明 |
+|------|------|
+| 兼容性 | PUT 请求/响应结构不变；仅 `prices`/`tier_prices` 语义从"整块替换"修正为合同约定的"键级合并"，属于缺陷修复而非行为变更 |
+| 主要风险 | 若下游已依赖"整块替换"副作用（先 PUT 清空再重建），修复后空键不再被清除；该用法本身不符合合同语义，如有需要应改用显式空值键覆盖 |
+| 同族字段 | `limits`/`metadata`/切片字段维持整块替换并在合同写明，避免本次扩大变更面 |
+
+---
+
+*文档生成日期：2026-09-07*

--- a/endpoints/openapi_v1/model_price/update.go
+++ b/endpoints/openapi_v1/model_price/update.go
@@ -98,6 +98,41 @@ func UpdateByQueryAction(req *http.Request) (interface{}, error) {
 	return container.ModelPriceManager.FetchModelPrice(req.Context(), filter)
 }
 
+// mergePriceMap returns a new PriceMap with all keys from dst, overridden by
+// keys present in src. Keys absent from src keep their original values, so a
+// partial update never silently drops existing price entries (issue #140).
+// Neither dst nor src is modified.
+func mergePriceMap(dst, src imodel_price.PriceMap) imodel_price.PriceMap {
+	merged := make(imodel_price.PriceMap, len(dst)+len(src))
+	for k, v := range dst {
+		merged[k] = v
+	}
+	for k, v := range src {
+		merged[k] = v
+	}
+	return merged
+}
+
+// mergeTierPriceMap merges tier prices two levels deep: tiers present in src
+// are merged key-by-key (via mergePriceMap), tiers only in src are added
+// whole, and tiers absent from src are retained whole. Neither dst nor src is
+// modified.
+func mergeTierPriceMap(dst, src imodel_price.TierPriceMap) imodel_price.TierPriceMap {
+	merged := make(imodel_price.TierPriceMap, len(dst)+len(src))
+	for tier, prices := range dst {
+		// deep-copy retained tiers so merged never aliases dst's inner maps
+		merged[tier] = mergePriceMap(prices, nil)
+	}
+	for tier, prices := range src {
+		if existing, ok := merged[tier]; ok {
+			merged[tier] = mergePriceMap(existing, prices)
+		} else {
+			merged[tier] = prices
+		}
+	}
+	return merged
+}
+
 // mergeModelPrice merges non-empty fields from src into dst for partial update.
 func mergeModelPrice(dst, src *imodel_price.ModelPrice) *imodel_price.ModelPrice {
 	merged := *dst
@@ -123,10 +158,10 @@ func mergeModelPrice(dst, src *imodel_price.ModelPrice) *imodel_price.ModelPrice
 		merged.Limits = src.Limits
 	}
 	if len(src.Prices) > 0 {
-		merged.Prices = src.Prices
+		merged.Prices = mergePriceMap(dst.Prices, src.Prices)
 	}
 	if len(src.TierPrices) > 0 {
-		merged.TierPrices = src.TierPrices
+		merged.TierPrices = mergeTierPriceMap(dst.TierPrices, src.TierPrices)
 	}
 	if strings.TrimSpace(src.PriceCurrency) != "" {
 		merged.PriceCurrency = src.PriceCurrency

--- a/endpoints/openapi_v1/model_price/update_test.go
+++ b/endpoints/openapi_v1/model_price/update_test.go
@@ -1,0 +1,171 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model_price
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/imodel_price"
+)
+
+// TestMergeModelPricePricesKeyLevelMerge verifies that a PUT carrying only one
+// price key keeps the other keys of the prices map (issue #140).
+func TestMergeModelPricePricesKeyLevelMerge(t *testing.T) {
+	dst := &imodel_price.ModelPrice{
+		Provider: "p1",
+		Model:    "m1",
+		Mode:     "chat",
+		Prices: imodel_price.PriceMap{
+			"input_cost_per_token":  5.1e-06,
+			"output_cost_per_token": 6.2e-06,
+		},
+	}
+	src := &imodel_price.ModelPrice{
+		Prices: imodel_price.PriceMap{
+			"input_cost_per_token": 3.1e-06,
+		},
+	}
+
+	merged := mergeModelPrice(dst, src)
+
+	assert.Equal(t, 3.1e-06, merged.Prices["input_cost_per_token"])
+	assert.Equal(t, 6.2e-06, merged.Prices["output_cost_per_token"], "unsubmitted key must keep its value")
+	assert.Len(t, merged.Prices, 2)
+}
+
+// TestMergeModelPriceTierPricesTwoLevelMerge verifies two-level tier merging:
+// submitted tier keys override, unsubmitted keys of the same tier are kept,
+// unsubmitted tiers are retained whole, and new tiers are added (issue #140).
+func TestMergeModelPriceTierPricesTwoLevelMerge(t *testing.T) {
+	dst := &imodel_price.ModelPrice{
+		TierPrices: imodel_price.TierPriceMap{
+			"peak": {
+				"input_cost_per_token":        9.1e-06,
+				"output_cost_per_token":       1.02e-05,
+				"cache_read_input_token_cost": 3.1e-06,
+			},
+			"offpeak": {
+				"input_cost_per_token": 1.0e-06,
+			},
+		},
+	}
+	src := &imodel_price.ModelPrice{
+		TierPrices: imodel_price.TierPriceMap{
+			"peak": {
+				"input_cost_per_token": 1.11e-05,
+			},
+			"night": {
+				"input_cost_per_token": 5.0e-07,
+			},
+		},
+	}
+
+	merged := mergeModelPrice(dst, src)
+
+	peak := merged.TierPrices["peak"]
+	assert.Equal(t, 1.11e-05, peak["input_cost_per_token"], "submitted key overridden")
+	assert.Equal(t, 1.02e-05, peak["output_cost_per_token"], "same-tier unsubmitted key kept")
+	assert.Equal(t, 3.1e-06, peak["cache_read_input_token_cost"], "same-tier unsubmitted key kept")
+
+	assert.Equal(t, map[string]float64{"input_cost_per_token": 1.0e-06}, merged.TierPrices["offpeak"],
+		"tier absent from src retained whole")
+	assert.Equal(t, map[string]float64{"input_cost_per_token": 5.0e-07}, merged.TierPrices["night"],
+		"new tier added whole")
+	assert.Len(t, merged.TierPrices, 3)
+}
+
+// TestMergeModelPriceEmptySrcMapsUnchanged verifies that omitting the maps
+// leaves the existing maps untouched.
+func TestMergeModelPriceEmptySrcMapsUnchanged(t *testing.T) {
+	dst := &imodel_price.ModelPrice{
+		Prices: imodel_price.PriceMap{
+			"input_cost_per_token": 5.1e-06,
+		},
+		TierPrices: imodel_price.TierPriceMap{
+			"peak": {"input_cost_per_token": 9.1e-06},
+		},
+	}
+	src := &imodel_price.ModelPrice{Mode: "chat"}
+
+	merged := mergeModelPrice(dst, src)
+
+	assert.Equal(t, dst.Prices, merged.Prices)
+	assert.Equal(t, dst.TierPrices, merged.TierPrices)
+	assert.Equal(t, "chat", merged.Mode)
+}
+
+// TestMergeModelPriceDoesNotMutateDst verifies the merge never writes into the
+// maps held by the existing record (merged := *dst is a shallow copy; maps
+// must be rebuilt instead of edited in place).
+func TestMergeModelPriceDoesNotMutateDst(t *testing.T) {
+	dst := &imodel_price.ModelPrice{
+		Prices: imodel_price.PriceMap{
+			"input_cost_per_token": 5.1e-06,
+		},
+		TierPrices: imodel_price.TierPriceMap{
+			"peak": {
+				"input_cost_per_token":  9.1e-06,
+				"output_cost_per_token": 1.02e-05,
+			},
+		},
+	}
+	src := &imodel_price.ModelPrice{
+		Prices: imodel_price.PriceMap{
+			"output_cost_per_token": 6.2e-06,
+		},
+		TierPrices: imodel_price.TierPriceMap{
+			"peak": {
+				"input_cost_per_token": 1.11e-05,
+			},
+		},
+	}
+
+	merged := mergeModelPrice(dst, src)
+
+	// mutate every merged map; the existing record must stay intact
+	merged.Prices["input_cost_per_token"] = -1
+	merged.TierPrices["peak"]["output_cost_per_token"] = -1
+	merged.TierPrices["peak"]["cache_read_input_token_cost"] = -1
+
+	assert.Equal(t, imodel_price.PriceMap{"input_cost_per_token": 5.1e-06}, dst.Prices)
+	assert.Equal(t, imodel_price.TierPriceMap{
+		"peak": {
+			"input_cost_per_token":  9.1e-06,
+			"output_cost_per_token": 1.02e-05,
+		},
+	}, dst.TierPrices)
+}
+
+// TestMergeModelPriceScalarFields verifies scalar merge semantics are
+// unaffected by the map merge fix.
+func TestMergeModelPriceScalarFields(t *testing.T) {
+	dst := &imodel_price.ModelPrice{
+		Provider: "p1",
+		Model:    "m1",
+		Mode:     "chat",
+	}
+	src := &imodel_price.ModelPrice{
+		Model: "m2",
+		Mode:  " ",
+	}
+
+	merged := mergeModelPrice(dst, src)
+
+	assert.Equal(t, "p1", merged.Provider, "empty src keeps dst value")
+	assert.Equal(t, "m2", merged.Model, "non-empty src overrides")
+	assert.Equal(t, "chat", merged.Mode, "blank src keeps dst value")
+}

--- a/test/integration/tests/model_price/design.md
+++ b/test/integration/tests/model_price/design.md
@@ -687,6 +687,7 @@ models:
 | MP-6-002 | 更新不存在的记录 | 异常参数 | 返回 404 |
 | MP-6-003 | 更新为非法 mode | 合法性条件 | 返回 422 |
 | MP-6-004 | 更新 limits 为负数 | 合法性条件 | 返回 422 |
+| MP-6-005 | 只传单个价格键时其余键保留 | 正常参数 | PUT 仅传 `prices` 单键，未传入的价格键保留原值（issue #140） |
 
 ### 12.4 测试场景详细设计
 
@@ -781,6 +782,7 @@ models:
 | MP-7-001 | 按组合键更新 prices | 正常参数 | 更新成功 |
 | MP-7-002 | 缺少 query 参数 | 必填校验 | 返回 422 |
 | MP-7-003 | 按组合键更新 limits 为负数 | 合法性条件 | 返回 422 |
+| MP-7-004 | 按组合键只传单个价格键时其余键保留 | 正常参数 | PUT 仅传 `prices` 单键，未传入的价格键保留原值（issue #140） |
 
 ---
 
@@ -974,6 +976,7 @@ models:
 | MTP-1-004 | tier_prices 含负数价格 | 合法性条件 | `tier_prices.peak.input_cost_per_token=-0.001`，返回 422 |
 | MTP-1-005 | 更新 tier_prices | 正常参数 | PUT `/model-prices/{id}` 可单独更新 `tier_prices` |
 | MTP-1-006 | model-list.yaml 导入含 tier_prices | 正常参数 | 导入的 YAML 携带 `tier_prices`，列表查询返回一致 |
+| MTP-1-007 | 部分更新 tier_prices 同档未传键保留 | 正常参数 | PUT 只传 `tier_prices.peak` 单键时同档未传键保留原值（issue #140；未传 tier 整档保留、新 tier 加入由 `mergeTierPriceMap` 单测覆盖，当前校验仅允许 `peak` 档） |
 
 ### 17.3 请求参数示例
 

--- a/test/integration/tests/model_price/tier_prices/tier_prices_test.go
+++ b/test/integration/tests/model_price/tier_prices/tier_prices_test.go
@@ -239,6 +239,76 @@ models:
 		}
 		assert.True(t, found, "imported model price should be listed")
 	})
+
+	t.Run("MTP-1-007 部分更新 tier_prices 同档未传键保留", func(t *testing.T) {
+		provider := testutil.UniqueName("provider")
+		model := testutil.UniqueName("model")
+
+		id, err := testutil.CreateModelPrice(map[string]interface{}{
+			"provider":   provider,
+			"model":      model,
+			"base_model": model,
+			"mode":       "chat",
+			"prices": map[string]interface{}{
+				"input_cost_per_token": 0.000001,
+			},
+			"tier_prices": map[string]interface{}{
+				"peak": map[string]interface{}{
+					"input_cost_per_token":        0.0000091,
+					"output_cost_per_token":       0.0000102,
+					"cache_read_input_token_cost": 0.0000031,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("create model price failed: %v", err)
+		}
+		defer testutil.DeleteModelPrice(id)
+
+		resp, err := testutil.GetClient().Put("/open-api/v1/model-prices/"+int64ToStr(id), map[string]interface{}{
+			"tier_prices": map[string]interface{}{
+				"peak": map[string]interface{}{
+					"input_cost_per_token": 0.0000111,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("update model price failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		assertTierPrices := func(tag string, data map[string]interface{}) {
+			tierPrices, ok := data["tier_prices"].(map[string]interface{})
+			if !assert.True(t, ok, "%s: tier_prices should be an object", tag) {
+				return
+			}
+			peak, ok := tierPrices["peak"].(map[string]interface{})
+			if !assert.True(t, ok, "%s: tier_prices.peak should be an object", tag) {
+				return
+			}
+			assert.InDelta(t, 0.0000111, peak["input_cost_per_token"], 0.0000001, "%s: submitted key overridden", tag)
+			assert.InDelta(t, 0.0000102, peak["output_cost_per_token"], 0.0000001, "%s: same-tier unsubmitted key kept (issue #140)", tag)
+			assert.InDelta(t, 0.0000031, peak["cache_read_input_token_cost"], 0.0000001, "%s: same-tier unsubmitted key kept (issue #140)", tag)
+		}
+
+		var data map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			t.Fatalf("unmarshal data: %v", err)
+		}
+		assertTierPrices("put response", data)
+
+		// verify persisted state via GET
+		getResp, err := testutil.GetClient().Get("/open-api/v1/model-prices/" + int64ToStr(id))
+		if err != nil {
+			t.Fatalf("get model price failed: %v", err)
+		}
+		testutil.AssertSuccess(t, getResp)
+		var got map[string]interface{}
+		if err := json.Unmarshal(getResp.Data, &got); err != nil {
+			t.Fatalf("unmarshal get data: %v", err)
+		}
+		assertTierPrices("get response", got)
+	})
 }
 
 func int64ToStr(v int64) string {

--- a/test/integration/tests/model_price/update/update_test.go
+++ b/test/integration/tests/model_price/update/update_test.go
@@ -135,6 +135,58 @@ func TestModelPrice_Update(t *testing.T) {
 		testutil.AssertErrCode(t, resp, 422)
 	})
 
+	t.Run("MP-6-005 按 id 只传单个价格键时其余键保留", func(t *testing.T) {
+		provider := testutil.UniqueName("provider")
+		model := "update-partial-merge"
+		id, err := testutil.CreateModelPrice(map[string]interface{}{
+			"provider":   provider,
+			"model":      model,
+			"base_model": model,
+			"mode":       "chat",
+			"prices": map[string]interface{}{
+				"input_cost_per_token":  0.0000051,
+				"output_cost_per_token": 0.0000062,
+			},
+		})
+		if err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		defer testutil.DeleteModelPrice(id)
+
+		resp, err := testutil.GetClient().Put("/open-api/v1/model-prices/"+fmt.Sprintf("%d", id), map[string]interface{}{
+			"prices": map[string]interface{}{
+				"input_cost_per_token": 0.0000031,
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		var data map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		prices := data["prices"].(map[string]interface{})
+		assert.InDelta(t, 0.0000031, prices["input_cost_per_token"], 0.0000001)
+		assert.InDelta(t, 0.0000062, prices["output_cost_per_token"], 0.0000001,
+			"unsubmitted price key must keep its value (issue #140)")
+
+		// verify persisted state via GET
+		getResp, err := testutil.GetClient().Get("/open-api/v1/model-prices/" + fmt.Sprintf("%d", id))
+		if err != nil {
+			t.Fatalf("get failed: %v", err)
+		}
+		testutil.AssertSuccess(t, getResp)
+		var got map[string]interface{}
+		if err := json.Unmarshal(getResp.Data, &got); err != nil {
+			t.Fatalf("unmarshal get: %v", err)
+		}
+		gotPrices := got["prices"].(map[string]interface{})
+		assert.InDelta(t, 0.0000031, gotPrices["input_cost_per_token"], 0.0000001)
+		assert.InDelta(t, 0.0000062, gotPrices["output_cost_per_token"], 0.0000001)
+	})
+
 	t.Run("MP-7-001 按组合键更新 prices", func(t *testing.T) {
 		provider := testutil.UniqueName("provider")
 		model := "update-query-model"
@@ -219,5 +271,47 @@ func TestModelPrice_Update(t *testing.T) {
 			t.Fatalf("request failed: %v", err)
 		}
 		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("MP-7-004 按组合键只传单个价格键时其余键保留", func(t *testing.T) {
+		provider := testutil.UniqueName("provider")
+		model := "update-query-partial-merge"
+		id, err := testutil.CreateModelPrice(map[string]interface{}{
+			"provider":   provider,
+			"model":      model,
+			"base_model": model,
+			"mode":       "chat",
+			"prices": map[string]interface{}{
+				"input_cost_per_token":        0.0000051,
+				"cache_read_input_token_cost": 0.0000031,
+			},
+		})
+		if err != nil {
+			t.Fatalf("setup failed: %v", err)
+		}
+		defer testutil.DeleteModelPrice(id)
+
+		resp, err := testutil.GetClient().PutWithQuery("/open-api/v1/model-prices", map[string]string{
+			"provider": provider,
+			"model":    model,
+			"mode":     "chat",
+		}, map[string]interface{}{
+			"prices": map[string]interface{}{
+				"input_cost_per_token": 0.0000041,
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		var data map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		prices := data["prices"].(map[string]interface{})
+		assert.InDelta(t, 0.0000041, prices["input_cost_per_token"], 0.0000001)
+		assert.InDelta(t, 0.0000031, prices["cache_read_input_token_cost"], 0.0000001,
+			"unsubmitted price key must keep its value (issue #140)")
 	})
 }


### PR DESCRIPTION
PUT 部分更新语义为"仅传需修改字段，未传入字段保持原值"，但
mergeModelPrice 对 map 字段做整块指针赋值：请求里只要带了 prices 或
tier_prices（哪怕只想改其中一个键），整个 map 被替换，未传入的价格键
被静默清除，HTTP 200 无任何告警，导致静默计费配置数据丢失。

- mergeModelPrice 中 prices/tier_prices 改为键级深合并：传入键覆盖、 未传键保留原值；tier_prices 同档按键合并、未传 tier 整档保留； 全程新建 map，不原地修改 existing 记录
- model-prices.md §3.7/§3.8 显式补充 map/切片字段更新粒度契约 （limits/metadata/切片保持整块替换现状）
- handler 单测覆盖：键级合并、两层 tier 合并、不污染 dst、空 src 不变
- 集成测试新增 MP-6-005 / MP-7-004 / MTP-1-007，对 PUT 响应与 GET 持久化状态双重验证

Fixes #140