### PR TITLE
fix: 导出配置版本号同秒碰撞导致版本推进楔死，版本号同 Topic 严格单调递增 (#142)

### DIFF
--- a/db_ddl.sql
+++ b/db_ddl.sql
@@ -234,7 +234,8 @@ CREATE TABLE `config_versions` (
   `version` varchar(255) NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_name_version` (`name`, `version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 

--- a/db_ddl_sqlite.sql
+++ b/db_ddl_sqlite.sql
@@ -238,7 +238,8 @@ CREATE TABLE config_versions (
   data_sign TEXT NOT NULL,
   version TEXT NOT NULL,
   created_at DATETIME NOT NULL,
-  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (name, version)
 );
 CREATE TRIGGER config_versions_updated_at AFTER UPDATE ON config_versions
   FOR EACH ROW BEGIN UPDATE config_versions SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;

--- a/design-docs/modifications/2026-09-07-issue-142-export-version-freeze/change-summary.md
+++ b/design-docs/modifications/2026-09-07-issue-142-export-version-freeze/change-summary.md
@@ -1,0 +1,74 @@
+# Issue #142：导出配置版本号同秒碰撞楔死修复方案
+
+## 1. 问题来源
+
+[rainway-ai-gateway/ai-gateway-api/issues/142](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/142)
+
+> inner-api `GET /inner-api/v1/configs/tls_conf/server_data_conf` 的 Version 字段是所有消费方（conf-agent、BFE 配置生成、自动化验证）判断"配置是否变更"的唯一信号。当两次配置变更落在同一墙钟秒内时，`t_config_version`（实际表名 `config_versions`）会产生同 `(name, version)` 重复行且 DataSign 相互矛盾；此后版本读取 `ORDER BY version DESC LIMIT 1` 钉住其中一行，若其签名恰等于当前内容签名，版本推进被永久短路——导出内容每轮重建都是新的，但版本号不再变化，直到某次无关的新变更才解开。同秒连续变更是 E2E 测试的常规节奏，也是运维脚本/GitOps 类自动化可能出现的模式。
+
+现象：E2E 用例 SC2101-TC018 六连失败；版本号楔死期间按版本号等待收敛的消费者无限挂起（观测到 120.1s / 202 轮不推进，解楔事件为 cleanup 的 DELETE 变更，属假自愈）；同一版本号先后承载不同内容，版本号失去"标识唯一配置状态"的语义。
+
+## 2. 目标
+
+1. 每次配置内容变更都产生新的、同 topic 内严格递增的 Version；
+2. `config_versions` 表不存在同 `(name, version)` 重复行（数据库层唯一约束兜底）；
+3. 并发/同秒导出请求不再出现 duplicate key 导致的导出整单 500；
+4. 版本串格式保持 `20060102150405`（14 位秒级时间串）不变，conf-agent 等消费方（以版本号命名输出目录、按版本号判等）零改动；
+5. 修复后 SC2101-TC018（亚秒 configure→remove 连发 + 版本收敛判据）可通过。
+
+## 3. 范围
+
+| 范围 | 说明 |
+|------|------|
+| 涉及仓库 | `ai-gateway-api` |
+| 主要文件 | `model/iversion_control/version_control.go`、`storage/rdb/version_control/version_control.go`、`storage/rdb/internal/dao/table_config_versions.go`、`db_ddl.sql`、`db_ddl_sqlite.sql` |
+| 数据库 | `config_versions` 表新增 `UNIQUE(name, version)`；需先清理存量重复行 |
+| 接口契约 | Inner API 请求/响应字段不变，Version 格式与语义不变（仅保证单调递增） |
+| 数据迁移 | 存量环境需执行重复行清理 + 唯一索引创建（见 design-changes.md 第 4 节） |
+| 数据兼容 | 旧版本行全部保留，不做改写；新增版本行与同 topic 既有最大版本保持单调 |
+
+## 4. 最终方案概览
+
+**采用 issue 建议的"方案 A + 方案 C"组合，改动集中在存储层：**
+
+- **唯一约束（方案 A 核心）**：`config_versions` 增加 `UNIQUE(name, version)`（MySQL 唯一索引 / SQLite 唯一索引），从数据库层根除重复版本行。
+- **单调版本计算（方案 A 的"version + 1s"落地）**：`UpsertConfigLastExportedVersion` 插入前读取最新版本行，候选版本取 `max(当前秒, 最新版本 + 1s)`（等长定宽时间串可直接字符串比较），同秒第二次变更天然获得 +1s 的版本号，从源头消除碰撞。
+- **duplicate key 重试路径**：插入冲突（两个并发导出请求同时读到同一最新行等残余竞态）用现成的 `lib.DuplicateEntryError`（`lib/xdb.go:138`，已覆盖 MySQL 1062 与 SQLite UNIQUE constraint）识别，重读最新行、版本再 +1s 后重试，上限若干次；不再整单 500。
+- **确定性读取（方案 C）**：最新行查询改为 `ORDER BY version DESC, id DESC`，消除平局行选取的执行计划不确定性。
+
+> **备选方案说明：**
+> - **方案 B（毫秒精度 + 序列号版本串）**：可彻底消除碰撞，但改变版本串格式（14 位 → 17 位），conf-agent 以版本号命名输出目录、消费方按版本号判等，存在兼容性风险，本次不采用。若未来版本串需承载更高频率变更，可再评估。
+> - **仅方案 C**：只消除平局不确定性，不消除重复行与 sign 短路，不能单独作为修复（与 issue 结论一致）。
+
+## 5. 机制链与修复点对照
+
+| # | 缺陷环节（源码定位） | 修复措施 |
+|---|----------------------|----------|
+| 1 | `CalculateVersion()` = `Version(time.Now())`，秒级时间串（`model/iversion_control/version_control.go:57-60`） | 存储层在秒级时间串基础上按"最新版本 + 1s"抬升，保证同 topic 单调递增；格式不变 |
+| 2 | `TConfigVersionCreate` 为 plain INSERT，无冲突处理（`storage/rdb/internal/dao/table_config_versions.go:80`） | 表上新增 `UNIQUE(name, version)`；插入冲突走重试路径（`lib.DuplicateEntryError` 识别），不再 500 |
+| 3 | `TConfigVersionOne(Name, OrderBy="version DESC")` 平局任取（`storage/rdb/version_control/version_control.go:43-46`） | 改为 `ORDER BY version DESC, id DESC`，取到同版本中最晚插入的行 |
+| 4 | sign 短路：钉住行签名 == 当前内容签名则永久返回旧版本（`storage/rdb/version_control/version_control.go:51-53`） | 重复行消除 + 确定性读取后，最新行签名即该 topic 当前真实内容签名，短路逻辑恢复正确语义：内容未变返回旧版本（预期行为），内容已变必然插入新版本 |
+
+## 6. 预期收益与风险
+
+| 项目 | 说明 |
+|------|------|
+| 收益 | 版本号恢复"标识唯一配置状态"语义；按版本轮询收敛的消费者（E2E / conf-agent / GitOps 脚本）不再无限挂起；同秒连发变更不再产生矛盾重复行或 500 |
+| 主要风险 | 存量环境存在重复行，直接加唯一索引会失败；需先执行清理 SQL（design-changes.md 第 4 节提供） |
+| 兼容性 | 版本串格式不变；既有消费方无需升级；`ExportConfig` 事务语义（`model/iversion_control/version_control.go:84-110`）不变 |
+| 残余竞态 | 两个并发导出请求可能交错"读最新 + 插入"，由唯一索引 + 重试路径兜底，重试上限内可收敛；极端重试耗尽返回错误优于静默写坏数据 |
+
+## 7. 回归验证
+
+1. **现成回归用例**：E2E SC2101-TC018（亚秒 configure→remove 连发 + 240 轮版本收敛判据），修复部署后 requeue 复跑即可实证；
+2. **复现脚本**：issue 附带的 `tc018_repro.py`（6 个 HTTP 请求，QA 环境 1/1 复现）可在修复后重跑，期望 `VERDICT: CONVERGED`；
+3. **DB 佐证 SQL**：修复前可用 issue 提供的 `GROUP BY name, version HAVING COUNT(*) > 1` 确认重复行；修复并清理后该查询应返回空。
+
+## 8. 参考文档
+
+- [Issue #142](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/142)（含完整机制链分析、复现脚本、DB 佐证 SQL）
+- `ai-gateway-api/model/iversion_control/version_control.go`（`ExportConfig` / `CalculateVersion` / `Sign`）
+- `ai-gateway-api/storage/rdb/version_control/version_control.go`（`UpsertConfigLastExportedVersion`）
+- `ai-gateway-api/storage/rdb/internal/dao/table_config_versions.go`（`TConfigVersionOne` / `TConfigVersionCreate`）
+- `ai-gateway-api/lib/xdb.go:130-144`（`DuplicateEntryError`，MySQL/SQLite 双兼容）
+- `design-docs/modifications/2026-09-04-issue-132-entity-id-race/`（同类型"并发/竞态 + 唯一约束兜底"修复的落地范例）

--- a/design-docs/modifications/2026-09-07-issue-142-export-version-freeze/design-changes.md
+++ b/design-docs/modifications/2026-09-07-issue-142-export-version-freeze/design-changes.md
@@ -1,0 +1,240 @@
+# Issue #142：导出配置版本号同秒碰撞楔死——设计变更说明
+
+## 1. 当前问题定位
+
+### 1.1 版本推进路径
+
+```text
+inner-api 导出请求（如 GET /inner-api/v1/configs/tls_conf/server_data_conf）
+    └── VersionControlManager.ExportConfig            model/iversion_control/version_control.go:84
+        └── 每请求全量重建导出内容（ConfigGenerator）
+        └── DataWithoutVersion.UpdateVersion(ZeroVersion)
+        └── Sign(DataWithoutVersion)                  // MD5 内容签名
+        └── storager.UpsertConfigLastExportedVersion  storage/rdb/version_control/version_control.go:37
+            ├── TConfigVersionOne(name, ORDER BY version DESC LIMIT 1)   // :43
+            ├── 若 DataSign == 当前签名 → 返回旧版本（短路）              // :51
+            └── CalculateVersion() = time.Now().Format("20060102150405") // :55
+                └── TConfigVersionCreate（plain INSERT）                 // :60
+```
+
+### 1.2 缺陷机制链（同秒两次内容变更）
+
+1. **秒级版本串**：同一秒内两次"内容已变"的导出计算出相同版本串；
+2. **plain INSERT**：产生同 `(name, version)` 重复行，两行 DataSign 分别对应变更前/后内容；
+3. **平局读取**：`ORDER BY version DESC LIMIT 1` 在重复行中取哪行由执行计划决定，稳定但任意；
+4. **sign 短路**：若钉住行的 DataSign 恰等于当前重建内容签名，直接返回旧版本号、不再插入——版本推进被永久短路；内容每轮新鲜，版本号恒定，直到某次无关变更使签名失配才解开（假自愈）；
+5. **500 风险**：一旦加上唯一索引而 INSERT 未处理冲突，duplicate key 将使导出请求整单 500（`UpsertConfigLastExportedVersion` 当前不捕获该错误）。
+
+### 1.3 触发条件与影响
+
+- 触发条件：**内容变更的导出轮询与上一个版本行的插入落在同一墙钟秒**；亚秒级连续变更（E2E create-export 收敛 → PATCH → PATCH 全程 <2s）必然触发，分钟级手工操作不会触发（排查时若以手工单步验证会得出"无问题"的误导结论）。
+- 影响：版本号楔死期间按版本轮询收敛的消费者无限挂起（SC2101-TC018 六连失败，TC034/TC005 同窗口被拖累）；版本号失去唯一标识语义；数据面内容多数时序下仍可收敛，核心危害在版本通道。
+
+## 2. 方案对比
+
+| 方案 | 思路 | 优点 | 缺点 | 结论 |
+|------|------|------|------|------|
+| **A. 唯一约束 + 冲突重试 + 版本抬升（推荐）** | `UNIQUE(name, version)`；插入冲突时版本 +1s 重试（上限若干次） | 彻底消除重复行；改动集中在存储层；版本串格式不变 | 存量重复行需先清理才能加索引 | **采用**（叠加方案 C） |
+| B. 毫秒精度 + 序列号版本串 | `CalculateVersion()` 引入同 topic 严格单调分量 | 消除碰撞根源 | 版本串格式 14 位 → 17 位，conf-agent 输出目录命名、消费方判等存在兼容性风险 | 未采用（issue 备选，格式兼容性排除） |
+| C. 确定性读取（辅助） | 读取改为 `ORDER BY version DESC, id DESC` | 消除平局不确定性，一行代码 | 不消除重复行与 sign 短路，不能单独作为修复 | **与 A 叠加采用** |
+
+## 3. 推荐方案详细设计
+
+### 3.1 存储层改造（核心）
+
+`storage/rdb/version_control/version_control.go` 的 `UpsertConfigLastExportedVersion` 重写为：
+
+```go
+func (vcs *VersionControlStorager) UpsertConfigLastExportedVersion(ctx context.Context, css *iversion_control.ExportData) (string, error) {
+    dbCtx, err := vcs.dbCtxFactory(ctx)
+    if err != nil {
+        return "", err
+    }
+
+    // 1. 确定性读取最新行（方案 C：平局取 id 最大即最晚插入的行）
+    latest, err := dao.TConfigVersionOne(dbCtx, &dao.TConfigVersionParam{
+        Name:    &css.Topic,
+        OrderBy: lib.PString("version DESC, id DESC"),
+    })
+    if err != nil {
+        return "", err
+    }
+
+    // 2. sign 短路：最新行即该 topic 当前真实内容（重复行消除后语义恢复正确）
+    if latest != nil && latest.DataSign == css.DataSignWithoutVersion {
+        return latest.Version, nil
+    }
+
+    // 3. 单调版本计算：候选 = max(当前秒, 最新版本 + 1s)
+    version := iversion_control.Version(time.Now())
+    if latest != nil && version <= latest.Version {
+        if t, err := time.ParseInLocation(versionLayout, latest.Version, time.Local); err == nil {
+            version = iversion_control.Version(t.Add(time.Second))
+        }
+    }
+
+    // 4. 插入，duplicate key 走重试路径（不再 500）
+    for i := 0; i < maxDuplicateRetry; i++ {
+        _, err = dao.TConfigVersionCreate(dbCtx, &dao.TConfigVersionParam{
+            Name:     &css.Topic,
+            DataSign: &css.DataSignWithoutVersion,
+            Version:  &version,
+        })
+        if err == nil {
+            return version, nil
+        }
+        if !lib.DuplicateEntryError(err) {
+            return "", err
+        }
+        // 并发插入抢先：重读最新行，版本再 +1s 后重试
+        latest, err = dao.TConfigVersionOne(dbCtx, /* 同上 */)
+        if err != nil {
+            return "", err
+        }
+        if latest == nil {
+            return "", err // 理论不可达（冲突行必存在），防御性返回
+        }
+        if t, perr := time.ParseInLocation(versionLayout, latest.Version, time.Local); perr == nil {
+            version = iversion_control.Version(t.Add(time.Second))
+        } else {
+            return "", err // 非预期版本格式，保留原始冲突错误
+        }
+    }
+    return "", err // 重试耗尽：返回最后一次冲突错误，优于静默写坏数据
+}
+```
+
+要点说明：
+
+- `versionLayout = "20060102150405"`。版本串为等长定宽数字串，字符串比较与时间比较等价，`version <= latest.Version` 即为"候选版本不晚于库内最新版本"。
+- `maxDuplicateRetry` 建议 3：正常路径（第 3 步单调抬升）已消除同进程同秒碰撞，重试仅兜并发导出交错/多实例部署的残余竞态。
+- 重试路径中若重读到的最新行 `DataSign == css.DataSignWithoutVersion`（并发请求已为本内容建过版本），可直接返回 `latest.Version` 提前收敛，避免无意义插入。
+- `lib.DuplicateEntryError`（`lib/xdb.go:130-144`）已覆盖 MySQL `Error 1062: Duplicate entry` 与 SQLite `UNIQUE constraint failed`，无需新增错误识别逻辑。
+- `ExportData.CalculateVersion()`（`model/iversion_control/version_control.go:57`）保留不动：模型层接口不变，最终版本号由存储层单调化后写回 `css.version`（`ExportConfig` 的 `UpdateVersion(lrv.version)` 流程不变）。
+
+### 3.2 DDL 变更
+
+#### MySQL（`db_ddl.sql`）
+
+```sql
+CREATE TABLE `config_versions` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `data_sign` varchar(255) NOT NULL,
+  `version` varchar(255) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_name_version` (`name`, `version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+```
+
+#### SQLite（`db_ddl_sqlite.sql`）
+
+```sql
+CREATE TABLE config_versions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  data_sign TEXT NOT NULL,
+  version TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (name, version)
+);
+```
+
+> 说明：`version` 列保持 `varchar(255)`（只存 14 位时间串，不改类型以免惊动既有部署的 ORM/工具链）；唯一约束只依赖 `(name, version)` 组合。新装环境随 DDL 自动获得唯一约束；存量环境需先执行第 4 节清理迁移。
+
+## 4. 数据迁移（存量环境上线前必须执行）
+
+### 4.1 清理重复版本行（保留每组 `(name, version)` 中 id 最大即最晚插入的行）
+
+```sql
+-- MySQL（多表 DELETE，保留 id 最大行）
+DELETE v1 FROM config_versions v1
+INNER JOIN config_versions v2
+  ON v1.name = v2.name AND v1.version = v2.version AND v1.id < v2.id;
+
+-- SQLite
+DELETE FROM config_versions WHERE id NOT IN (
+  SELECT MAX(id) FROM config_versions GROUP BY name, version);
+```
+
+> 清理前可用 issue 提供的佐证 SQL 评估影响面：
+> `SELECT name, version, COUNT(*) AS c FROM config_versions GROUP BY name, version HAVING c > 1;`
+> 同时建议比对同版本两行的 `data_sign` 确认签名矛盾（即楔死证据）。
+
+### 4.2 添加唯一约束
+
+```sql
+-- MySQL
+ALTER TABLE `config_versions` ADD UNIQUE KEY `uk_name_version` (`name`, `version`);
+
+-- SQLite（若原表未重建，采用 CREATE UNIQUE INDEX 等价生效）
+CREATE UNIQUE INDEX IF NOT EXISTS `uk_name_version` ON config_versions (name, version);
+```
+
+### 4.3 升级步骤
+
+1. 执行 4.1 清理 SQL（先SELECT佐证、再DELETE，建议备份或低峰执行）；
+2. 执行 4.2 添加唯一约束；
+3. 滚动升级 `ai-gateway-api` 实例（新代码对无唯一索引的旧库同样安全：无索引时 INSERT 不冲突，单调抬升逻辑仍生效）；
+4. 升级后复跑 SC2101-TC018 / `tc018_repro.py` 实证。
+
+> 顺序说明：代码与索引的升级顺序可互换——代码先行时单调抬升已消除新重复行产生；索引先行时靠清理 SQL 保证加索引成功。二者均兼容混合部署窗口。
+
+## 5. 涉及文件清单
+
+| 文件 | 修改内容 |
+|------|----------|
+| `db_ddl.sql` | `config_versions` 表新增 `UNIQUE KEY uk_name_version (name, version)` |
+| `db_ddl_sqlite.sql` | `config_versions` 表新增 `UNIQUE (name, version)` |
+| `storage/rdb/version_control/version_control.go` | `UpsertConfigLastExportedVersion` 重写：确定性读取、单调版本计算、duplicate key 重试 |
+| `storage/rdb/version_control/version_control_test.go` | 新增（当前目录无测试文件）：同秒双变更单调递增、内容回跳再变更再推进、sign 短路不变、duplicate key 重试路径 |
+| `design-docs/modifications/2026-09-07-issue-142-export-version-freeze/` | 本方案文档 |
+
+> 说明：`model/iversion_control/version_control.go`、`storage/rdb/internal/dao/table_config_versions.go` 无需修改（DAO 的 `OrderBy` 本就透传字符串，`, id DESC` 直接可用）。
+
+## 6. 测试计划
+
+### 6.1 单元测试（新增 `storage/rdb/version_control/version_control_test.go`）
+
+1. **同秒双变更单调递增**：mock/真实 DAO 连续两次内容不同的导出（第二次冻结时间戳在同一秒），断言第二次返回的版本 = 第一次 + 1s；
+2. **内容回跳再变更**：内容 A → B → A，断言版本号 V1 < V2 < V3 且第三次不再复用 V1（验证 sign 短路只发生在内容真未变时）；
+3. **sign 短路保留**：内容未变重复导出，断言返回同一版本且不产生新行；
+4. **duplicate key 重试**：注入第一次 `TConfigVersionCreate` 返回 duplicate 错误（fake storager/DAO 错误桩），断言重试后版本 +1s 且最终成功；
+5. **非冲突错误直通**：注入非 duplicate 错误，断言原样返回、不重试。
+
+### 6.2 集成 / E2E 验证
+
+1. **SC2101-TC018 requeue**：修复部署后复跑，亚秒 configure→remove 连发 + 版本收敛判据应通过；
+2. **`tc018_repro.py` 重跑**（issue 附带，QA 环境 1/1 复现脚本）：期望输出 `VERDICT: CONVERGED - freeze NOT reproduced`；
+3. **手工对照**：分钟级间隔两次 PATCH，版本正常推进、conf-agent 生成文件正常更新（回归不退化）。
+
+### 6.3 验收对照（issue 期望结果）
+
+| 验收标准 | 验证方式 |
+|----------|----------|
+| 每次内容变更产生新的严格递增 Version | 单元测试 1/2 + SC2101-TC018 |
+| 消费方按版本轮询能可靠感知变更 | SC2101-TC018 收敛判据 + tc018_repro.py |
+| 不再产生同 `(name, version)` 重复行 | 唯一约束 + 单元测试 4；QA 库佐证 SQL 修复后返回空 |
+| duplicate key 不导致导出 500 | 单元测试 4/5 |
+
+## 7. 风险与缓解
+
+| 风险 | 说明 | 缓解措施 |
+|------|------|----------|
+| 存量重复行导致加索引失败 | QA 等环境已存在楔死产生的重复行 | 第 4.1 节清理 SQL 先行；SELECT 佐证后再 DELETE；低峰执行 |
+| 并发导出交错（读最新→插入窗口） | 两请求读到同一最新行，候选版本相同 | 唯一索引拦截后到者；重试路径 +1s 重读重插；上限 3 次 |
+| 多实例部署下时钟回拨/漂移 | NTP 回拨使 `time.Now()` 小于库内最新版本 | 单调抬升逻辑天然免疫（候选永远 ≥ 最新版本 + 1s，不依赖本地时钟前进） |
+| 重试耗尽 | 极端竞争下 3 次重试均冲突 | 返回错误并记录日志；导出请求失败可重入（每请求全量重建，无半状态），优于静默楔死 |
+| 清理误删版本行 | 重复行清理保留 id 最大行，若执行计划误判... | 清理语句按 `(name, version)` 分组保留 MAX(id)，与修复后 `ORDER BY version DESC, id DESC` 读取语义一致；清理前备份 |
+
+## 8. 上线前检查清单
+
+1. **佐证**（可选）：在目标库执行重复行 SELECT，确认影响范围；
+2. **清理**：执行第 4.1 节 DELETE（保留 MAX(id) 行）；
+3. **加约束**：执行第 4.2 节 `ALTER TABLE` / `CREATE UNIQUE INDEX`；
+4. **升级**：滚动升级 `ai-gateway-api`；
+5. **验证**：SC2101-TC018 requeue 通过；`tc018_repro.py` 输出 CONVERGED；重复行佐证 SQL 返回空；
+6. **回滚预案**：回滚代码即可（旧代码在无唯一索引库上行为不变；若已加唯一索引，旧代码同秒碰撞时 INSERT 会 500 而非楔死——错误显式化，可监控发现，重复行不再产生）。

--- a/design-docs/sys-design/details/InnerAPI配置导出与版本控制.md
+++ b/design-docs/sys-design/details/InnerAPI配置导出与版本控制.md
@@ -8,7 +8,9 @@
 
 - 每次导出时计算配置数据的 **MD5 签名**；
 - 与上一次导出的签名比较，若相同则返回 `Data: nil`，避免重复下发；
-- 若不同则生成新的版本号（时间戳格式），并持久化到 `config_versions` 表。
+- 若不同则生成新的版本号（14 位秒级时间戳格式），并持久化到 `config_versions` 表。
+
+版本号在同一 Topic 内**严格单调递增**：即使多次配置变更落在同一墙钟秒内，版本号也会逐次 +1 秒抬升，消费方按版本号轮询始终能感知变更（issue #142 修复，见 `design-docs/modifications/2026-09-07-issue-142-export-version-freeze/`）。
 
 这样下游组件通过携带 `version` 查询参数即可实现 **增量同步**。
 
@@ -83,7 +85,16 @@ var ZeroVersion = Version(time.Time{})
 | `data_sign` | 配置数据 MD5 签名 |
 | `version` | 对应版本号 |
 
-同一 Topic 下可有多条记录，按时间顺序递增。`VersionControlStorager.UpsertConfigLastExportedVersion` 会返回最新签名对应的版本号；若签名不存在则新增记录。
+同一 Topic 下可有多条记录，按版本号严格递增。表上具有 `UNIQUE(name, version)` 约束（`uk_name_version`），数据库层保证同一主题不会出现重复版本行。
+
+`VersionControlStorager.UpsertConfigLastExportedVersion` 的行为：
+
+1. 按 `ORDER BY version DESC, id DESC` 读取该 Topic 的最新一行（平局时取 `id` 最大即最晚插入的行）；
+2. 若最新行 `data_sign` 与当前重建内容的签名一致，直接返回其版本号（内容未变，不新增记录）；
+3. 否则计算候选版本 `max(当前秒, 最新版本 + 1s)` 并插入新记录；
+4. 若插入命中唯一约束（并发导出交错等残余竞态），重读最新行、版本再 +1s 重试（上限 3 次），不再整单报错。
+
+> 说明：第 3 步的 +1s 抬升使版本号不依赖墙钟前进——同秒连续变更、时钟回拨/偏移场景下，版本号仍保持同 Topic 内严格单调递增。修复前版本号直接取 `time.Now()` 的秒级时间串，同秒第二次"内容已变"的导出会产生同 `(name, version)` 重复行，且 sign 短路可能将版本推进永久楔死（issue #142）。
 
 ---
 
@@ -362,7 +373,9 @@ Authorization: Token <token>
 |------|------|
 | 首次导出（`config_versions` 无记录） | 生成新记录，返回全量配置 |
 | 配置未变化 | 返回 `Data: nil`，不生成新记录 |
-| 配置变化但版本号相同 | 不可能，因为版本号基于当前时间生成 |
+| 配置变化但版本号相同 | 不可能：候选版本取 `max(当前秒, 最新版本 + 1s)`，同秒连续变更也会逐次 +1 秒抬升（issue #142） |
+| 并发导出竞争同一版本号 | 唯一约束拦截后到者，重读最新行 +1s 重试（上限 3 次）；若并发请求已为相同内容建过版本则直接返回其版本号 |
+| 本地时钟回拨/慢于库内最新版本 | 版本抬升至 `最新版本 + 1s`，不产生重复或倒退版本 |
 | `generator` 返回错误 | 直接返回错误，不更新 `config_versions` |
 | `DataWithoutVersion.UpdateVersion` 失败 | 中断导出流程 |
 | `extra_files` 不存在 | 返回 `Record Not Exist`（404） |

--- a/design-docs/sys-design/summary.md
+++ b/design-docs/sys-design/summary.md
@@ -22,7 +22,7 @@
 |---------|---------|---------|
 | 操作日志模块 | [details/操作日志模块.md](./details/操作日志模块.md) | 描述 `model/ioperlog` 操作日志设计：覆盖 entity / api-key / provider / cluster 等域的变更记录、成功与失败双路径日志、异步批量写入、敏感字段脱敏与 `GET /operation-logs` 查询接口。 |
 | 认证授权机制 | [details/认证授权机制.md](./details/认证授权机制.md) | 描述 `model/iauth` 的认证授权设计，包括用户与 Token 共用 `users` 表、`Visitor` 统一抽象、Scope 作用域、Feature-Action 权限模型、四种认证方式以及中间件集成与数据库表设计。 |
-| InnerAPI 配置导出与版本控制 | [details/InnerAPI配置导出与版本控制.md](./details/InnerAPI配置导出与版本控制.md) | 描述面向 BFE/Conf Agent 的 InnerAPI 配置导出机制，包括 `VersionControlManager` 的 MD5 签名比对、版本号生成、`config_versions` 表持久化、9 类配置导出主题、增量同步流程，以及 `mod-api-key` 的批量预加载 + 内存回溯性能优化。 |
+| InnerAPI 配置导出与版本控制 | [details/InnerAPI配置导出与版本控制.md](./details/InnerAPI配置导出与版本控制.md) | 描述面向 BFE/Conf Agent 的 InnerAPI 配置导出机制，包括 `VersionControlManager` 的 MD5 签名比对、版本号生成与同 Topic 严格单调递增保证（`uk_name_version` 唯一约束 + 版本 +1s 抬升 + 冲突重试，issue #142）、`config_versions` 表持久化、9 类配置导出主题、增量同步流程，以及 `mod-api-key` 的批量预加载 + 内存回溯性能优化。 |
 | API-Key 与 Entity 关联及模型继承 | [details/API-Key与Entity关联及模型继承.md](./details/API-Key与Entity关联及模型继承.md) | 描述 API-Key 与 Entity 的挂载关系、Entity 层级树约束、模型白名单交集与黑名单继承、配额计划层级合并、限流策略与路由规则的层级收集，以及导出到 BFE 时的最终生效规则。 |
 | 限流策略与导出 | [details/限流策略与导出.md](./details/限流策略与导出.md) | 描述限流策略的数据模型（TPM/RPM/并发数）、JSON 配置结构、CRUD 校验、API-Key/Entity 引用关系、按 Entity 层级向上合并导出到 BFE 的流程，以及 BFE 侧预期行为与边界情况。 |
 | 路由规则管理 | [details/路由规则管理.md](./details/路由规则管理.md) | 区分产品级 BFE 路由规则与 AI 路由规则，描述 `route_rules` 表的三级（Global/Entity/API-Key）管理、校验规则、与 API-Key/Entity 生命周期的一致性、导出到 BFE 的绑定顺序与文件格式。 |

--- a/design-docs/sys-design/存储层设计文档.md
+++ b/design-docs/sys-design/存储层设计文档.md
@@ -472,8 +472,10 @@ type TxnStorager interface {
 
 `storage/rdb/version_control/version_control.go` 中的 `UpsertConfigLastExportedVersion`：
 
-- 比较 `config_versions` 中最新记录的 `data_sign`。
-- 若签名不同则新增一条记录，`version` 递增；若相同则不插入。
+- 按 `ORDER BY version DESC, id DESC` 读取该主题最新记录的 `data_sign` 并比较。
+- 若签名相同则不插入，直接返回既有版本；若签名不同则新增一条记录。
+- 候选版本取 `max(当前秒, 最新版本 + 1s)`，保证同 Topic 内版本号严格单调递增（同秒连续变更、时钟回拨均不会重复或倒退，issue #142）。
+- 插入命中 `uk_name_version` 唯一约束（并发导出交错）时，重读最新行、版本 +1s 重试，上限 3 次，不整单报错。
 
 ### 3.5 存储层变更说明
 

--- a/design-docs/sys-design/数据库设计文档.md
+++ b/design-docs/sys-design/数据库设计文档.md
@@ -202,18 +202,21 @@ CREATE TABLE `config_versions` (
   `version` varchar(255) NOT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_name_version` (`name`, `version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
 | 字段 | 类型 | 约束 | 说明 |
 |------|------|------|------|
 | `id` | bigint(20) | 主键、自增 | 主键 ID |
-| `name` | varchar(255) | NOT NULL | 配置名 |
+| `name` | varchar(255) | NOT NULL，联合唯一 | 配置主题（Topic） |
 | `data_sign` | varchar(255) | NOT NULL | 数据签名 |
-| `version` | varchar(255) | NOT NULL | 版本号 |
+| `version` | varchar(255) | NOT NULL，联合唯一 | 版本号（14 位秒级时间串，同 Topic 内严格单调递增） |
 | `created_at` | datetime | NOT NULL | 创建时间 |
 | `updated_at` | timestamp | 自动更新 | 更新时间 |
+
+> 说明：`uk_name_version` 唯一约束保证同一主题下版本号不重复（issue #142）。版本号虽为秒级时间串，但存储层写入时按 `max(当前秒, 最新版本 + 1s)` 抬升，同秒连续变更不会产生重复版本。存量环境加唯一索引前需先清理重复行，迁移步骤见 `design-docs/modifications/2026-09-07-issue-142-export-version-freeze/design-changes.md` 第 4 节。
 
 ---
 

--- a/storage/rdb/version_control/version_control.go
+++ b/storage/rdb/version_control/version_control.go
@@ -16,10 +16,16 @@ package version_control
 
 import (
 	"context"
+	"time"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iversion_control"
 	"github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/internal/dao"
+)
+
+const (
+	versionLayout       = "20060102150405"
+	maxDuplicateRetries = 3
 )
 
 var _ iversion_control.VersionControlStorager = &VersionControlStorager{}
@@ -40,27 +46,70 @@ func (vcs *VersionControlStorager) UpsertConfigLastExportedVersion(ctx context.C
 		return "", err
 	}
 
-	lastestConfigVersion, err := dao.TConfigVersionOne(dbCtx, &dao.TConfigVersionParam{
-		Name:    &css.Topic,
-		OrderBy: lib.PString("version DESC"),
-	})
+	latest, err := latestConfigVersion(dbCtx, css.Topic)
 	if err != nil {
 		return "", err
 	}
 
-	if lastestConfigVersion != nil && lastestConfigVersion.DataSign == css.DataSignWithoutVersion {
-		return lastestConfigVersion.Version, nil
+	if latest != nil && latest.DataSign == css.DataSignWithoutVersion {
+		return latest.Version, nil
 	}
 
-	version, err := css.CalculateVersion()
-	if err != nil {
-		return "", err
+	version := iversion_control.Version(time.Now())
+	if latest != nil {
+		version = bumpVersion(latest.Version, version)
 	}
 
-	_, err = dao.TConfigVersionCreate(dbCtx, &dao.TConfigVersionParam{
-		Name:     &css.Topic,
-		DataSign: &css.DataSignWithoutVersion,
-		Version:  &version,
+	for i := 0; i < maxDuplicateRetries; i++ {
+		_, err = dao.TConfigVersionCreate(dbCtx, &dao.TConfigVersionParam{
+			Name:     &css.Topic,
+			DataSign: &css.DataSignWithoutVersion,
+			Version:  &version,
+		})
+		if err == nil {
+			return version, nil
+		}
+		if !lib.DuplicateEntryError(err) {
+			return "", err
+		}
+
+		// A concurrent export inserted the same version first: re-read the
+		// latest row and bump past it, instead of failing the whole export
+		// with a duplicate key error (issue #142).
+		latest, err = latestConfigVersion(dbCtx, css.Topic)
+		if err != nil {
+			return "", err
+		}
+		if latest == nil {
+			return "", err
+		}
+		if latest.DataSign == css.DataSignWithoutVersion {
+			return latest.Version, nil
+		}
+		version = bumpVersion(latest.Version, version)
+	}
+
+	return "", err
+}
+
+func latestConfigVersion(dbCtx lib.DBContexter, topic string) (*dao.TConfigVersion, error) {
+	return dao.TConfigVersionOne(dbCtx, &dao.TConfigVersionParam{
+		Name:    &topic,
+		OrderBy: lib.PString("version DESC, id DESC"),
 	})
-	return version, err
+}
+
+// bumpVersion returns latest+1s when it is not before candidate, so the
+// result is strictly greater than every existing version of the topic even
+// when several config changes are exported within the same wall-clock second.
+func bumpVersion(latest string, candidate string) string {
+	lt, err := time.ParseInLocation(versionLayout, latest, time.Local)
+	if err != nil {
+		return candidate
+	}
+	next := iversion_control.Version(lt.Add(time.Second))
+	if candidate < next {
+		return next
+	}
+	return candidate
 }

--- a/storage/rdb/version_control/version_control_test.go
+++ b/storage/rdb/version_control/version_control_test.go
@@ -1,0 +1,274 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version_control
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iversion_control"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
+	"github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/internal/dao"
+)
+
+func setupVersionControlTestDB(t *testing.T) (*sql.DB, lib.DBContextFactory) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	// Use a single connection so the in-memory database is stable across the
+	// pooled connection lifecycle.
+	db.SetMaxOpenConns(1)
+
+	oldConfig := stateful.DefaultConfig
+	stateful.DefaultConfig = &stateful.Config{
+		RunTime: stateful.RunTimeConfig{
+			RecordSQL: false,
+		},
+	}
+	t.Cleanup(func() { stateful.DefaultConfig = oldConfig })
+
+	_, err = db.Exec(`
+CREATE TABLE config_versions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  data_sign TEXT NOT NULL,
+  version TEXT NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (name, version)
+);`)
+	require.NoError(t, err)
+
+	factory := func(ctx context.Context, ops ...*lib.Op) (*lib.DBContext, error) {
+		return lib.NewDBContext(ctx, db), nil
+	}
+	return db, factory
+}
+
+func exportData(topic string, sign string) *iversion_control.ExportData {
+	return &iversion_control.ExportData{
+		Topic:                  topic,
+		DataSignWithoutVersion: sign,
+	}
+}
+
+func listVersions(t *testing.T, db *sql.DB, topic string) []string {
+	rows, err := db.Query("SELECT version FROM config_versions WHERE name = ? ORDER BY version", topic)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	versions := []string{}
+	for rows.Next() {
+		var v string
+		require.NoError(t, rows.Scan(&v))
+		versions = append(versions, v)
+	}
+	require.NoError(t, rows.Err())
+	return versions
+}
+
+func TestUpsertConfigLastExportedVersion_FirstCreate(t *testing.T) {
+	db, factory := setupVersionControlTestDB(t)
+	vcs := NewVersionControllerStorage(factory)
+
+	version, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-a"))
+	require.NoError(t, err)
+	assert.Equal(t, iversion_control.Version(time.Now()), version)
+	assert.Len(t, listVersions(t, db, "topic-a"), 1)
+}
+
+func TestUpsertConfigLastExportedVersion_SameContentShortCircuit(t *testing.T) {
+	db, factory := setupVersionControlTestDB(t)
+	vcs := NewVersionControllerStorage(factory)
+
+	v1, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-a"))
+	require.NoError(t, err)
+
+	v2, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-a"))
+	require.NoError(t, err)
+	assert.Equal(t, v1, v2)
+	assert.Len(t, listVersions(t, db, "topic-a"), 1, "unchanged content must not create a new version row")
+}
+
+func TestUpsertConfigLastExportedVersion_SameSecondChangesMonotonic(t *testing.T) {
+	db, factory := setupVersionControlTestDB(t)
+	vcs := NewVersionControllerStorage(factory)
+
+	v1, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-a"))
+	require.NoError(t, err)
+
+	// Issue #142: two content changes exported within the same wall-clock
+	// second must still get strictly increasing versions.
+	v2, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-b"))
+	require.NoError(t, err)
+	assert.Greater(t, v2, v1, "second change must get a newer version than the first")
+
+	t1, err := time.ParseInLocation(versionLayout, v1, time.Local)
+	require.NoError(t, err)
+	t2, err := time.ParseInLocation(versionLayout, v2, time.Local)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, t2, t1.Add(time.Second), "version must advance by at least one second granularity")
+
+	assert.Equal(t, []string{v1, v2}, listVersions(t, db, "topic-a"))
+}
+
+func TestUpsertConfigLastExportedVersion_ContentBounceStillAdvances(t *testing.T) {
+	db, factory := setupVersionControlTestDB(t)
+	vcs := NewVersionControllerStorage(factory)
+
+	v1, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-a"))
+	require.NoError(t, err)
+	v2, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-b"))
+	require.NoError(t, err)
+
+	// Content changes back to sign-a. The sign-a row is not the latest one,
+	// so a new version is required; reusing v1 would freeze version progress.
+	v3, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-a"))
+	require.NoError(t, err)
+	assert.Greater(t, v3, v2)
+	assert.NotEqual(t, v1, v3)
+	assert.Len(t, listVersions(t, db, "topic-a"), 3)
+}
+
+func TestUpsertConfigLastExportedVersion_BumpsPastFutureLatest(t *testing.T) {
+	db, factory := setupVersionControlTestDB(t)
+	vcs := NewVersionControllerStorage(factory)
+
+	// A latest version ahead of the wall clock (e.g. clock rollback, or a row
+	// written by a clock-skewed peer) must not cause a duplicate or a
+	// backwards version.
+	_, err := db.Exec("INSERT INTO config_versions (name, data_sign, version, created_at) VALUES (?, ?, ?, ?)",
+		"topic-a", "sign-old", "29990101000000", time.Now())
+	require.NoError(t, err)
+
+	version, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-new"))
+	require.NoError(t, err)
+	assert.Equal(t, "29990101000001", version)
+	assert.Equal(t, []string{"29990101000000", "29990101000001"}, listVersions(t, db, "topic-a"))
+}
+
+func TestUpsertConfigLastExportedVersion_ConcurrentExports(t *testing.T) {
+	db, factory := setupVersionControlTestDB(t)
+	vcs := NewVersionControllerStorage(factory)
+
+	// Two exports racing on an empty topic must both succeed with distinct
+	// monotonic versions: the loser of the (name, version) race retries with
+	// a bumped version instead of failing the export (issue #142).
+	const workers = 2
+	versions := make(chan string, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sign, err := iversion_control.Sign(map[string]int{"worker": i})
+			require.NoError(t, err)
+			version, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", sign))
+			require.NoError(t, err)
+			versions <- version
+		}(i)
+	}
+	wg.Wait()
+	close(versions)
+
+	got := listVersions(t, db, "topic-a")
+	assert.Len(t, got, workers, "each racing export must create its own version row")
+	seen := map[string]struct{}{}
+	for v := range versions {
+		assert.NotContains(t, seen, v)
+		seen[v] = struct{}{}
+	}
+	for i := 1; i < len(got); i++ {
+		assert.Greater(t, got[i], got[i-1], "versions must be strictly increasing")
+	}
+}
+
+func TestUpsertConfigLastExportedVersion_NonDuplicateErrorPassthrough(t *testing.T) {
+	db, _ := setupVersionControlTestDB(t)
+	db.Close()
+
+	factory := func(ctx context.Context, ops ...*lib.Op) (*lib.DBContext, error) {
+		return lib.NewDBContext(ctx, db), nil
+	}
+	vcs := NewVersionControllerStorage(factory)
+
+	_, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-a"))
+	require.Error(t, err)
+	assert.False(t, lib.DuplicateEntryError(err))
+}
+
+func TestUpsertConfigLastExportedVersion_DBCtxFactoryError(t *testing.T) {
+	factory := func(ctx context.Context, ops ...*lib.Op) (*lib.DBContext, error) {
+		return nil, errors.New("factory boom")
+	}
+	vcs := NewVersionControllerStorage(factory)
+
+	_, err := vcs.UpsertConfigLastExportedVersion(context.Background(), exportData("topic-a", "sign-a"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "factory boom")
+}
+
+func TestBumpVersion(t *testing.T) {
+	base := iversion_control.Version(time.Now())
+	next := iversion_control.Version(time.Now().Add(time.Second))
+
+	assert.Equal(t, next, bumpVersion(base, base), "same-second collision must be bumped by one second")
+	assert.Equal(t, next, bumpVersion(base, next), "candidate already ahead stays unchanged")
+	assert.Equal(t, "29990101000001", bumpVersion("29990101000000", base))
+	assert.Equal(t, base, bumpVersion("not-a-version", base), "unparseable latest keeps candidate")
+}
+
+func TestLatestConfigVersion_OrdersByVersionThenIDDesc(t *testing.T) {
+	_, factory := setupVersionControlTestDB(t)
+
+	dbCtx, err := factory(context.Background())
+	require.NoError(t, err)
+
+	old := "20200101000000"
+	mid := "20200101000001"
+	for _, v := range []string{old, mid} {
+		_, err = dao.TConfigVersionCreate(dbCtx, &dao.TConfigVersionParam{
+			Name:     lib.PString("topic-a"),
+			DataSign: lib.PString("sign-" + v),
+			Version:  lib.PString(v),
+		})
+		require.NoError(t, err)
+	}
+	_, err = dao.TConfigVersionCreate(dbCtx, &dao.TConfigVersionParam{
+		Name:     lib.PString("topic-b"),
+		DataSign: lib.PString("sign-b"),
+		Version:  lib.PString("29990101000000"),
+	})
+	require.NoError(t, err)
+
+	latest, err := latestConfigVersion(dbCtx, "topic-a")
+	require.NoError(t, err)
+	require.NotNil(t, latest)
+	assert.Equal(t, mid, latest.Version, "must return the newest version of the topic")
+
+	latest, err = latestConfigVersion(dbCtx, "topic-none")
+	require.NoError(t, err)
+	assert.Nil(t, latest)
+}


### PR DESCRIPTION
config_versions 版本号为秒级时间串且 plain INSERT 无冲突处理，两次配置 变更落在同一墙钟秒时产生同 (name, version) 重复行，sign 短路可能将版本
推进永久楔死，按版本号轮询收敛的消费者（E2E/conf-agent/GitOps）无限挂起。

- config_versions 新增 UNIQUE(name, version)（MySQL/SQLite DDL）
- UpsertConfigLastExportedVersion 重写：ORDER BY version DESC, id DESC 确定性读取；候选版本取 max(当前秒, 最新版本+1s)，同秒连续变更与 时钟回拨均保持严格单调递增；duplicate key 识别后重读 +1s 重试 （上限 3 次），不再整单 500
- 新增存储层单元测试 10 个（单调递增/内容回跳/并发竞态/错误直通等）
- 同步更新 sys-design（InnerAPI 配置导出与版本控制/数据库/存储层设计文档）

存量环境上线前需先清理重复行再加唯一索引，迁移步骤见
design-docs/modifications/2026-09-07-issue-142-export-version-freeze/