### PR TITLE
feat: model-prices 支持科学计数法与超8位小数精度价格

### DIFF
--- a/design-docs/api-define/OpenAPI接口定义/model-prices.md
+++ b/design-docs/api-define/OpenAPI接口定义/model-prices.md
@@ -50,8 +50,8 @@
 | `capabilities` | []string | 模型支持的能力列表 | 默认空数组；元素应为枚举值 |
 | `supported_parameters` | []string | 支持的请求参数列表 | 默认空数组；元素应为枚举值 |
 | `limits` | object | 限制对象 | 默认空对象；键名应为枚举值；所有限制字段必须为非负整数 |
-| `prices` | object | 价格对象 | 必填；至少包含一个价格字段；所有价格字段必须为非负数；键名应为枚举值；未命中 tier 时作为 fallback 价格；支持 8 位及以上小数精度，JSON 序列化使用十进制表示法（如 `0.0000015`），不使用科学计数法 |
-| `tier_prices` | object | 分时段价格对象 | 非必填；键为 tier name（**初期只支持 `peak`**），值为价格对象；内部键名应为 `prices` 枚举；与 provider 的 `tiers` 不做强制引用校验；同样支持 8 位及以上小数精度与十进制表示法 |
+| `prices` | object | 价格对象 | 必填；至少包含一个价格字段；所有价格字段必须为非负数；键名应为枚举值；未命中 tier 时作为 fallback 价格；支持科学计数法与十进制表示法（如 `1.5e-6` 与 `0.0000015` 等价），按 float64 解析 |
+| `tier_prices` | object | 分时段价格对象 | 非必填；键为 tier name（**初期只支持 `peak`**），值为价格对象；内部键名应为 `prices` 枚举；与 provider 的 `tiers` 不做强制引用校验；同样支持科学计数法与十进制表示法 |
 | `price_currency` | string | 价格货币 | 固定为 `RMB`，请求体中无需传入 |
 | `metadata` | object | 元数据 | 默认空对象；键名应为枚举值 |
 | `create_time` | int64 | 创建时间 | Unix 时间戳（秒） |
@@ -168,34 +168,36 @@
 
 ### 1.2 价格精度与 JSON 序列化
 
-`prices` 与 `tier_prices.<tier>` 中的价格字段为浮点数，业务上支持 8 位及更多小数精度（例如 `0.0000015`、`0.00000075`）。
+`prices` 与 `tier_prices.<tier>` 中的价格字段为浮点数（元），支持 8 位及以上小数精度（例如 `0.0000015`、`0.00000075`、`7.6234102728e-08`）。**科学计数法与十进制表示法等价合法**，输入（OpenAPI 请求体、`model-list.yaml`）按 `float64` 解析，两者解析结果完全一致。
 
-为避免默认 JSON encoder 将小数值输出为科学计数法（如 `1.5e-6`），系统在序列化时使用十进制表示法：
+序列化使用标准 JSON encoder：
 
-- 请求体、响应体、InnerAPI 导出的 `cluster_conf.data` 中，价格均显示为 `"0.0000015"`、`"0.00000075"` 等形式；
+- 请求体、响应体、InnerAPI 导出的 `cluster_conf.data` 中，价格可能以十进制（`0.0000015`）或科学计数法（`1.5e-6`）出现，均为同一数值的合法表示；
+- 精度上限来自 `float64`（有效数字约 15 位）；单价格折算 `价格 × 1e8` 不得超过 2^53（约 9e15），超出将被校验拒绝；
 - 该表示方式仅影响 JSON 文本，不改变 `float64` 数值语义与 BFE 定点整数扣减逻辑；
 - YAML 导入（`model-list.yaml`）与 OpenAPI CRUD 均按原浮点数值解析，无需额外处理。
 
-示例：
+示例（两种表示法等价）：
 
 ```json
 {
   "prices": {
-    "input_cost_per_token": 0.0000015,
+    "input_cost_per_token": 1.5e-6,
     "output_cost_per_token": 0.0000045,
-    "cache_read_input_token_cost": 0.0000005
+    "cache_read_input_token_cost": 5e-7
   },
   "tier_prices": {
     "peak": {
       "input_cost_per_token": 0.000003,
-      "output_cost_per_token": 0.000009,
+      "output_cost_per_token": 9e-6,
       "cache_read_input_token_cost": 0.000001
     }
   }
 }
 ```
 
-序列化后文本保持十进制表示，不包含 `1.5e-6`、`4.5e-6` 等科学计数法。
+> 说明：早期版本（issue-102）曾强制价格以十进制表示法序列化；v0.6 起放开学
+> 计数法，标准 encoder 对极小值（如 `1.5e-6`）可能输出科学计数法，属正常行为。
 
 ---
 
@@ -251,8 +253,8 @@ models:
 | `capabilities` | N | 能力列表，枚举值同第 1 节 `capabilities` 枚举 |
 | `supported_parameters` | N | 支持的请求参数列表，枚举值同第 1 节 `supported_parameters` 枚举 |
 | `limits` | N | 限制对象，键名枚举值同第 1 节 `limits` 枚举；所有限制字段必须为非负整数 |
-| `prices` | Y | 价格对象，键名枚举值同第 1 节 `prices` 枚举；至少包含一个价格字段；未命中 tier 时作为 fallback 价格；支持 8 位及以上小数精度 |
-| `tier_prices` | N | 分时段价格对象，键为 tier name（**初期只支持 `peak`**），值为价格对象；内部键名枚举值同第 1 节 `prices` 枚举；支持 8 位及以上小数精度 |
+| `prices` | Y | 价格对象，键名枚举值同第 1 节 `prices` 枚举；至少包含一个价格字段；未命中 tier 时作为 fallback 价格；支持科学计数法与十进制表示法 |
+| `tier_prices` | N | 分时段价格对象，键为 tier name（**初期只支持 `peak`**），值为价格对象；内部键名枚举值同第 1 节 `prices` 枚举；支持科学计数法与十进制表示法 |
 | `metadata` | N | 元数据，键名枚举值同第 1 节 `metadata` 枚举 |
 
 > **唯一性约束**：`(provider, model, mode)` 三元组必须唯一。
@@ -663,7 +665,7 @@ Data 为 null。
 2. `provider` 仅作为价格归集标识，不强制引用 `/providers` 中已存在的 provider；
 3. `(provider, model, mode)` 组合不能重复；
 4. `prices` 必填，至少包含一个价格字段；
-5. 所有价格字段必须为非负数；支持 8 位及以上小数精度；
+5. 所有价格字段必须为非负数；支持科学计数法与十进制表示法（等价合法）；单价格折算 `价格 × 1e8` 不得超过 2^53（约 9e15），超出拒绝写入；
 6. `tier_prices` 非必填；若传入：
    - **初期 tier name 只支持 `peak`**；
    - 每个 tier 对应的价格对象中，键名须为 `prices` 枚举；

--- a/design-docs/modifications/2026-09-08-model-price-scientific-notation/change-summary.md
+++ b/design-docs/modifications/2026-09-08-model-price-scientific-notation/change-summary.md
@@ -1,0 +1,60 @@
+# model-prices 价格放开科学计数法与更高小数精度
+
+## 1. 背景
+
+v0.6「RMB 计费精度提高」迭代中，控制面导入的模型目录（`model-list.yaml`，450 个模型）出现大量 **10~12 位小数** 价格，例如 `output_cost_per_token: 7.6234102728e-08`、`input_cost_per_token: 4.141631732e-06`。这些价格是 `unit_price_usd_per_1M × group_ratio / 1e6 × 6.8` 的计算结果，`group_ratio` 有 6 位有效小数，无法在源头约简。
+
+此前 issue-102 的方案（见 `2026-08-27-issue-102-eight-decimal-price-precision/`）为 `PriceMap` / `TierPriceMap` 增加自定义 `MarshalJSON`，强制价格以十进制表示法输出（如 `0.0000015`），不丢失 8 位小数的精度。该方案的两个前提已不再成立：
+
+1. **精度需求超过 8 位小数**：12 位小数以十进制表示为 `0.000000076234102728`，位数靠人工数，读写极易出错；科学计数法 `7.6234102728e-08` 一目了然。YAML / JSON 语法均原生支持科学计数法。
+2. **BFE 侧消费方式升级**：BFE 已改为价格保持 `float64`、请求计费时逐项 `quota.CalcCostUnits`（`round(用量 × (价格 × 1e8))`）再取整扣减（见 `bfe/docs/zh_cn/modifications/2026-09-08-rmb-price-float-precision/design-changes.md`），不再在配置加载期把价格截断为 1e-8 定点整数，超精度价格不再损失精度。
+
+## 2. 目标
+
+1. `prices` / `tier_prices` 的**输入**（OpenAPI 请求体、`model-list.yaml` 导入）显式支持科学计数法与十进制表示法，两者等价；
+2. `prices` / `tier_prices` 的**输出**（OpenAPI 响应、InnerAPI 导出的 `cluster_conf.data`）不再强制十进制，允许标准编码器输出科学计数法；
+3. 校验规则更新：非负校验不变，新增 float64 可精确表示的兜底上限；
+4. 数据库无需迁移（价格本就按 `float64` 存储，科学计数法只是文本表示）；
+5. 接口契约不变：字段名、数据类型（JSON number）均不变。
+
+## 3. 范围
+
+| 范围 | 说明 |
+|------|------|
+| 涉及仓库 | `ai-gateway-api`（本文）；`bfe` 侧见 `bfe/docs/zh_cn/modifications/2026-09-08-rmb-price-float-precision/` |
+| 主要文件 | `model/imodel_price/model_price.go`、`model/imodel_price/validate.go`、`design-docs/api-define/OpenAPI接口定义/model-prices.md` |
+| 数据库 | 无需迁移；浮点数值本身存储不变 |
+| 接口契约 | 不变；仅 JSON 文本表示方式与校验说明调整 |
+| 数据面影响 | BFE 解析到的 `float64` 数值不变（科学计数法本就是合法 JSON number） |
+
+## 4. 最终方案概览
+
+**删除** `PriceMap` / `TierPriceMap` 的自定义 `MarshalJSON`（issue-102 引入），回归 Go 标准 `encoding/json` 编码：
+
+- 输入解析（`yaml.v3` / `encoding/json`）本就支持科学计数法，**零改动**；
+- 输出序列化由标准编码器决定：极小值输出为科学计数法（如 `7.6234102728e-08`），常规值输出为十进制，两者均为合法表示；
+- `validate.go` 保留键名枚举与非负校验，新增 `|price × 1e8| < 2^53`（约 9e15）兜底校验，保证下游 BFE 浮点计费不溢出。
+
+`model-prices.md` 中"支持 8 位及以上小数精度，JSON 序列化使用十进制表示法，不使用科学计数法"等描述同步更新为"科学计数法与十进制表示法均合法，数值按 float64 解析（有效数字约 15 位）"。
+
+## 5. 预期收益与风险
+
+| 项目 | 说明 |
+|------|------|
+| 收益 | 12 位小数价格可无损导入、导出与计费；目录文件（`model-list.yaml`）可直接由生成工具以科学计数法输出，无需二次展开为十进制 |
+| 主要风险 | 导出配置文本中极小价格变为科学计数法，运维习惯需适应；下游消费方若对价格做**文本级**处理（如字符串比较、正则提取）需改为数值比较。已确认 BFE 按 `float64` 解析，无此问题 |
+| 兼容性 | 数值语义不变；十进制输入完全兼容；科学计数法输入此前亦能被标准解析器接受（只是文档禁止），实际为文档解禁 |
+
+## 6. 上线前检查清单
+
+1. `go test ./model/imodel_price/...` 通过（含新增科学计数法解析与序列化用例）；
+2. `make test-model-cover-gate` 通过；
+3. InnerAPI 导出含 `7.6234102728e-08` 类价格的 `cluster_conf.data`，BFE `bfe -t test_conf` 加载成功；
+4. `model-prices.md` 与代码行为一致。
+
+## 7. 参考文档
+
+- `2026-08-27-issue-102-eight-decimal-price-precision/`（前序方案，本次部分回退其序列化策略）
+- `model/imodel_price/model_price.go`、`model/imodel_price/validate.go`、`model/imodel_price/import.go`
+- `bfe/docs/zh_cn/modifications/2026-09-08-rmb-price-float-precision/design-changes.md`（BFE 侧配套改造）
+- `document-ai-gateway/迭代系统设计/v0.6/RMB计费精度提高/`（迭代需求来源）

--- a/design-docs/modifications/2026-09-08-model-price-scientific-notation/design-changes.md
+++ b/design-docs/modifications/2026-09-08-model-price-scientific-notation/design-changes.md
@@ -1,0 +1,176 @@
+# model-prices 科学计数法与高精度价格设计变更说明
+
+## 1. 当前问题定位
+
+### 1.1 问题表象
+
+`model-list.yaml`（450 个模型，由计费目录自动生成）中大量价格为 10~12 位小数，以科学计数法书写：
+
+```yaml
+models:
+  - provider: example-provider
+    model: qwen2.5-omni-7b
+    base_model: qwen2.5-omni-7b
+    mode: chat
+    prices:
+      input_cost_per_token: 6.0168984e-09
+      output_cost_per_token: 7.6234102728e-08
+```
+
+而接口定义文档（`design-docs/api-define/OpenAPI接口定义/model-prices.md`）规定价格"支持 8 位及以上小数精度，JSON 序列化使用十进制表示法（如 `0.0000015`），不使用科学计数法"。文档与真实数据脱节：
+
+1. `7.6234102728e-08` 展开为十进制是 `0.000000076234102728`，人工读写极易数错位数；
+2. 此前 issue-102 方案在 `PriceMap` / `TierPriceMap` 上定制的十进制 `MarshalJSON`，会把这类值序列化为超长十进制串，配置文本可读性差；
+3. BFE 侧旧的"加载期转 1e-8 定点整数"逻辑会把 `7.6234102728e-08` 截断为 `7`（相对误差 8.1%）——该问题由 BFE 侧改造（浮点价格 + 逐项取整）解决，本文不重复描述，见 `bfe/docs/zh_cn/modifications/2026-09-08-rmb-price-float-precision/design-changes.md`。
+
+### 1.2 根因
+
+- 表示层：issue-102 为避免科学计数法被误读为精度丢失，选择了"十进制 only"策略；当精度需求超过 8 位小数后，该策略的可读性优势反转为其最大缺点。
+- 语法层：YAML（`gopkg.in/yaml.v3`）与 JSON（`encoding/json`）均原生支持科学计数法数字字面量，当前限制 purely 是策略选择，不存在技术障碍。
+
+### 1.3 为什么现有测试没暴露
+
+`TestParseModelListYAMLEightDecimalPlaces` 覆盖的是十进制 8 位小数（`0.00000005`）的解析与序列化；目录文件一直未被纳入 ai-gateway-api 的测试资产，科学计数法输入路径（解析其实一直可用）从未被显式测试。
+
+## 2. 目标
+
+1. 输入（OpenAPI 请求体、YAML 导入）显式支持科学计数法与十进制表示法；
+2. 输出（OpenAPI 响应、InnerAPI 导出）回归标准 JSON 编码，允许科学计数法；
+3. 校验规则：键名枚举、非负、必填等不变；新增 float64 表示上限兜底；
+4. 数据库与接口契约（字段名、JSON number 类型）不变。
+
+## 3. 方案对比
+
+| 方案 | 思路 | 优点 | 缺点 | 结论 |
+|------|------|------|------|------|
+| A. 删除自定义 `MarshalJSON`，回归标准编码（推荐） | 回退 issue-102 的序列化定制 | 改动最小（净删代码）；标准行为、无维护成本；输入解析本就支持科学计数法 | 极小值输出为科学计数法，运维需适应 | **采用** |
+| B. 保留十进制 `MarshalJSON`，仅文档解禁输入 | 输入放开、输出维持十进制 | 输出格式不变 | 12 位小数十进制串可读性差；与"两种表示法等价"的语义自相矛盾（输出永远是十进制） | 不采用 |
+| C. 价格改字符串 / decimal 类型 | 契约层面支持任意精度 | 彻底避免浮点 | 改动 OpenAPI 契约、数据库、BFE 解析，影响面大；float64 的 15 位有效数字已覆盖现有数据 | 不采用 |
+
+> 注：issue-102 解决的原始问题（"科学计数法被误读为精度丢失"）随 BFE 计费链路改为浮点计算后自然消解——`1.5e-6` 与 `0.0000015` 解析为同一 float64，扣减精度由逐项取整保证。
+
+## 4. 详细改动
+
+### 4.1 `model/imodel_price/model_price.go`
+
+删除 `PriceMap.MarshalJSON` 与 `TierPriceMap.MarshalJSON`（及不再使用的 `bytes` / `strconv` import），类型定义与注释保留并更新：
+
+```go
+// PriceMap is a map of price keys to their numeric values (yuan per unit).
+// Prices may use more than 8 decimal places; both decimal and scientific
+// notation are accepted on input and may appear in JSON output.
+type PriceMap map[string]float64
+
+// TierPriceMap is a map of tier names to PriceMap values.
+type TierPriceMap map[string]map[string]float64
+```
+
+序列化行为变化（标准 `encoding/json` 对 float64 使用最短表示）：
+
+| 值 | 旧输出（十进制 MarshalJSON） | 新输出（标准编码） |
+|----|------------------------------|--------------------|
+| `0.000002` | `0.000002` | `2e-6` |
+| `0.0000015` | `0.0000015` | `1.5e-6` |
+| `7.6234102728e-08` | `0.000000076234102728` | `7.6234102728e-08` |
+| `0.03` | `0.03` | `0.03` |
+
+两种表示法解析后均为同一 float64，语义不变。
+
+### 4.2 `model/imodel_price/import.go`
+
+**无需改动**。`yaml.v3` 原生把 `6.0168984e-09` 解析为 float64。`ParseModelListYAML` 的既有流程（解析 → `ValidateModelPrice` → 入库）不变。
+
+### 4.3 `model/imodel_price/validate.go`
+
+`ValidateModelPrice` 中：
+
+- 键名枚举校验、非负校验、`prices` 必填、`peak` tier 限制：**全部保留**；
+- 新增兜底校验：`|v × 1e8| >= 2^53`（约 9e15）时拒绝。价格经 BFE 计费时以 `用量 × (价格 × 1e8)` 参与浮点运算，float64 整数精确表示上限为 2^53；该校验保证下游计算不溢出。正常价格（< 1 元/token）远不会触发，仅防御异常输入：
+
+```go
+for k, v := range m.Prices {
+    if !ValidPriceKeys[k] {
+        return xerror.WrapParamErrorWithMsg("invalid price key: %s", k)
+    }
+    if v < 0 {
+        return xerror.WrapParamErrorWithMsg("price %s must be >= 0", k)
+    }
+    // Guard the downstream float64 cost computation
+    // (usage * (price * 1e8)) against losing integer exactness beyond 2^53.
+    if v*quota.RmbPrecision >= (1<<53) {
+        return xerror.WrapParamErrorWithMsg("price %s exceeds the maximum representable precision", k)
+    }
+}
+```
+
+`tier_prices` 内层价格加同样校验。
+
+### 4.4 接口定义文档 `model-prices.md` 同步
+
+| 位置 | 修改 |
+|------|------|
+| 字段说明 `prices` / `tier_prices` 行 | "支持 8 位及以上小数精度，JSON 序列化使用十进制表示法……不使用科学计数法" → "支持科学计数法与十进制表示法；按 float64 解析（有效数字约 15 位）；必须为非负数" |
+| 1.2 节"价格精度与 JSON 序列化" | 重写：两种表示法等价；精度上限来自 float64；导出文本可能出现科学计数法 |
+| 2.2 节 YAML 字段说明 | `prices` / `tier_prices` 说明同步放开 |
+| 第 4 节校验规则 5 | "支持 8 位及以上小数精度" → "支持科学计数法与十进制表示法；单价格 × 1e8 不得超过 2^53" |
+
+## 5. 数据迁移
+
+无需迁移。价格字段数据库类型不变（`float64` / `REAL`），科学计数法仅是 JSON/YAML 文本层的表示方式，入库数值不变。
+
+## 6. 测试计划
+
+### 6.1 单元测试（`model/imodel_price/`）
+
+1. **新增** `TestParseModelListYAMLScientificNotation`：
+   - 解析含 `7.6234102728e-08`、`4.141631732e-06` 的 YAML；
+   - 断言 `Prices` 中 float64 值与字面量相等；
+   - `json.Marshal` 回写后 `json.Unmarshal` 往返一致（数值层面）。
+2. **改造** `TestParseModelListYAMLEightDecimalPlaces`：
+   - 保留十进制解析断言；
+   - 序列化断言由"输出不含 `e-`"改为"数值往返一致"（不再断言文本形式）。
+3. **新增** `TestValidateModelPriceExcessivePrecision`：
+   - 价格 `≥ 9e7`（×1e8 达 2^53）被拒绝；正常价格（如 `0.000000076234102728`）通过。
+
+### 6.2 回归验证命令
+
+```bash
+cd ai-gateway-api
+go test ./model/imodel_price/...
+make test-model-cover-gate
+```
+
+### 6.3 端到端
+
+配合 BFE 侧改造（`bfe/docs/zh_cn/modifications/2026-09-08-rmb-price-float-precision/`）：
+
+- 用含科学计数法价格的 `model-list.yaml` 走 `/v1/model-prices/import` → InnerAPI 导出 → BFE 加载 → 发起请求，核对 Redis 扣减金额与手算 `round(用量 × 价格 × 1e8)` 一致。
+
+## 7. 风险与缓解
+
+| 风险 | 说明 | 缓解措施 |
+|------|------|----------|
+| 导出文本出现科学计数法，运维误判精度丢失 | issue-102 曾为此定制十进制输出 | `model-prices.md` 1.2 节明确说明两种表示法等价；BFE 计费按 float64 数值计算，与文本表示无关 |
+| 下游对价格做文本级处理 | 如字符串比较、正则提取 | 全链路已确认按 JSON number 解析（BFE `encoding/json`、conf-agent 透传）；若第三方消费方存在文本处理，属其契约外用法，需在发布说明中告知 |
+| 超 15 位有效数字的价格 | float64 无法无损表示 | 导入校验阶段发现即拒绝并提示（本次新增 ×1e8 上限校验）；未来若出现真实需求再评估 decimal 存储 |
+| 删除自定义 MarshalJSON 引入回归 | 序列化路径变化 | 用例从"文本断言"改为"数值往返断言"，文本形式交由标准库保证合法性 |
+
+## 8. 实施状态
+
+- [x] `model/imodel_price/model_price.go` 删除 `PriceMap.MarshalJSON` / `TierPriceMap.MarshalJSON`；
+- [x] `model/imodel_price/validate.go` 新增 ×1e8 上限校验（`checkPricePrecision`，默认价格与 tier 价格均覆盖）；
+- [x] `import_test.go` 新增科学计数法用例、改造八位小数用例；
+- [x] `validate_test.go` 新增超精度拒绝用例（含 12 位小数放行用例）；
+- [x] `model-prices.md` 字段说明 / 1.2 节 / 2.2 节 / 校验规则同步；
+- [x] `design-docs/sys-design/details/RMB配额分时段定价.md` 历史描述标注 v0.6 变更；
+- [x] `design-docs/sys-design/模型层设计文档.md`（4.4 节校验要点、4.4.3 导入流程）与 `数据库设计文档.md`（model_prices 表说明）同步；
+- [x] `test/integration/tests/model_price/import/import_test.go` 新增 MP-1-009（科学计数法导入）/ MP-1-010（超精度拒绝，422），`tests/model_price/design.md` 用例总览同步（8 → 10 例）；
+- [x] `go test ./model/imodel_price/...` 与 `make test-model-cover-gate` 通过（覆盖率 78.4% ≥ 70%，环境无 make，手动执行等价命令）；
+- [x] `test/integration` 全量 model_price 用例通过（需先重新构建项目根目录 `ai-gateway-api.exe`，集成测试以子进程方式启动该二进制）。
+
+## 9. 参考文档
+
+- `2026-08-27-issue-102-eight-decimal-price-precision/`（前序方案）
+- `model/imodel_price/model_price.go`、`model/imodel_price/validate.go`、`model/imodel_price/import.go`、`model/imodel_price/import_test.go`
+- `bfe/docs/zh_cn/modifications/2026-09-08-rmb-price-float-precision/design-changes.md`（BFE 侧配套改造）
+- `design-docs/api-define/OpenAPI接口定义/model-prices.md`（接口定义，已同步）

--- a/design-docs/sys-design/details/RMB配额分时段定价.md
+++ b/design-docs/sys-design/details/RMB配额分时段定价.md
@@ -11,7 +11,7 @@
 3. 结合 provider/cluster 分离，时段模板放在 `/providers`，分时段价格放在 `/model-prices`。
 4. 保持对现有固定价格的向后兼容。
 5. 运行时成本计算仍保持纯整数运算，不引入浮点误差。
-6. `prices` / `tier_prices` 中的浮点价格在 JSON 序列化时使用十进制表示法，支持 8 位及更多小数精度，避免科学计数法导致可读性问题或中间层截断。
+6. `prices` / `tier_prices` 中的浮点价格 originally 在 JSON 序列化时使用十进制表示法（issue-102）；**v0.6 已改为科学计数法与十进制等价合法**，标准编码器输出，详见 `design-docs/modifications/2026-09-08-model-price-scientific-notation/`。
 
 ## 2. 核心概念
 
@@ -126,7 +126,7 @@ type ModelTable struct {
 - `model/imodel_price`：
   - `ModelPrice` / `ModelPriceParam` 新增 `tier_prices`。
   - CRUD 与 YAML 导入增加对 `tier_prices` 的校验（tier name、价格键名、非负价格）。
-  - `PriceMap` 与 `TierPriceMap` 实现自定义 `MarshalJSON`，使用 `strconv.FormatFloat(v, 'f', -1, 64)` 输出十进制表示法，避免 8 位小数价格被序列化为科学计数法。
+  - ~~`PriceMap` 与 `TierPriceMap` 实现自定义 `MarshalJSON`，使用 `strconv.FormatFloat(v, 'f', -1, 64)` 输出十进制表示法，避免 8 位小数价格被序列化为科学计数法。~~（v0.6 已删除自定义 `MarshalJSON`，回归标准编码，科学计数法与十进制等价合法；校验新增 `价格 × 1e8 < 2^53` 上限。）
 - `model/icluster_conf/exporter.go`：
   - 导出 `AIConf` 时，根据 `cluster.llm_config.provider` 查询 Provider，将 `time_zone` / `tiers` 填入 `ModelTable`。
   - 按同一 `provider` 查询 `model_prices`，将 `prices` / `tier_prices` 填入对应 `ModelPrice`。
@@ -139,7 +139,7 @@ type ModelTable struct {
 
 ## 6. BFE 数据面行为
 
-BFE 侧与 v0.4 方案基本一致，`AIConf.ModelTable` 结构未变，仅配置来源发生变化。为保持整条链路配置文本一致，BFE 侧同构的 `PriceMap` / `TierPriceMap` 也实现了自定义 `MarshalJSON`，使用相同的十进制表示法。
+BFE 侧与 v0.4 方案基本一致，`AIConf.ModelTable` 结构未变，仅配置来源发生变化。~~为保持整条链路配置文本一致，BFE 侧同构的 `PriceMap` / `TierPriceMap` 也实现了自定义 `MarshalJSON`，使用相同的十进制表示法。~~（v0.6 起 BFE 删除该自定义序列化，价格保持 `float64`、计费时逐项 `quota.CalcCostUnits` 取整，见 `bfe/docs/zh_cn/modifications/2026-09-08-rmb-price-float-precision/`。）
 
 ### 6.1 加载阶段
 
@@ -209,7 +209,7 @@ func (table *ModelTable) ActiveTierName(now time.Time) string {
 
 | 风险 | 影响 | 缓解措施 |
 |------|------|----------|
-| 浮点价格 JSON 序列化精度/可读性 | 默认 encoder 对 8 位小数会输出科学计数法，配置可读性差，中间层可能误解析 | `ai-gateway-api` 与 `bfe` 的 `PriceMap` / `TierPriceMap` 均自定义 `MarshalJSON`，使用 `strconv.FormatFloat(v, 'f', -1, 64)` 强制十进制表示。 |
+| 浮点价格 JSON 序列化精度/可读性 | 默认 encoder 对 8 位小数会输出科学计数法，配置可读性差，中间层可能误解析 | ~~`ai-gateway-api` 与 `bfe` 的 `PriceMap` / `TierPriceMap` 均自定义 `MarshalJSON`，使用 `strconv.FormatFloat(v, 'f', -1, 64)` 强制十进制表示。~~（v0.6 起两种表示法均合法，按 float64 数值消费；中间层须按 JSON number 解析而非文本处理。） |
 | tier name 首期约束 | 仅支持 `peak` | 设计时已通过 `Weekdays` 预留扩展能力，后续只需放开命名约束。 |
 | provider 与 model-prices 的 tier 松耦合 | `tier_prices` 可能引用 provider 未定义的 tier | 可记录告警，但不做强制引用校验以保持灵活性。 |
 | 时区解析依赖系统时区数据库 | 部署环境需包含 IANA 时区数据 | 使用 Go 标准库 `time.LoadLocation`，确保容器镜像包含时区数据。 |
@@ -221,6 +221,8 @@ func (table *ModelTable) ActiveTierName(now time.Time) string {
 本设计已于 `2026-08-25` 完成编码并全量测试通过（`go build ./...`、`go test ./...`）。
 
 后续于 `2026-08-27` 针对 Issue #102 补充了 8 位小数价格 JSON 序列化精度修复：为 `ai-gateway-api` 与 `bfe` 两侧的 `PriceMap` / `TierPriceMap` 增加自定义 `MarshalJSON`，使用十进制表示法替代科学计数法。
+
+再后续于 `2026-09-08`（v0.6 RMB 计费精度提高）回退上述序列化定制：目录数据出现 10~12 位小数价格，十进制表示可读性更差，且 BFE 计费链路已改为浮点价格 + 逐项取整；两侧删除自定义 `MarshalJSON`，科学计数法与十进制等价合法，ai-gateway-api 校验新增 `价格 × 1e8 < 2^53` 上限。详见 `design-docs/modifications/2026-09-08-model-price-scientific-notation/`。
 
 主要落地文件：
 

--- a/design-docs/sys-design/数据库设计文档.md
+++ b/design-docs/sys-design/数据库设计文档.md
@@ -960,7 +960,7 @@ CREATE TABLE `model_prices` (
 | `capabilities` | JSON | NULL | 能力列表 |
 | `supported_parameters` | JSON | NULL | 支持的请求参数列表 |
 | `limits` | JSON | NULL | 限制对象 |
-| `prices` | JSON | NOT NULL | 默认价格对象；至少包含一个价格字段；未命中 tier 时作为 fallback |
+| `prices` | JSON | NOT NULL | 默认价格对象；至少包含一个价格字段；未命中 tier 时作为 fallback；价格支持科学计数法与十进制表示法（等价合法，按 float64 存储） |
 | `tier_prices` | JSON | NULL | 分时段价格对象；key 为 tier name（**初期只支持 `peak`**），value 为价格对象；内部键名须为 `prices` 枚举 |
 | `price_currency` | VARCHAR(10) | NOT NULL DEFAULT 'RMB' | 价格货币；v0.4 固定为 RMB |
 | `metadata` | JSON | NULL | 元数据 |

--- a/design-docs/sys-design/模型层设计文档.md
+++ b/design-docs/sys-design/模型层设计文档.md
@@ -1217,8 +1217,8 @@ type ModelPriceManager struct {
 - `provider`、`model`、`base_model`、`mode` 必填；
 - `provider` 仅作为价格归集标识，不强制引用 `/providers` 中已存在的 Provider；
 - `(provider, model, mode)` 不能重复；
-- `prices` 必填且至少包含一个价格字段，所有价格字段非负；
-- `tier_prices` 非必填；若传入，tier name **初期只支持 `peak`**，内部价格键名须为 `prices` 枚举，所有 tier 价格字段非负；
+- `prices` 必填且至少包含一个价格字段，所有价格字段非负；价格支持科学计数法与十进制表示法（等价合法，按 float64 解析），且折算 `价格 × 1e8` 不得超过 2^53（约 9e15，保证下游 BFE 浮点成本计算不丢失整数精确性）；
+- `tier_prices` 非必填；若传入，tier name **初期只支持 `peak`**，内部价格键名须为 `prices` 枚举，所有 tier 价格字段非负并适用同样的表示法与精度上限校验；
 - `mode` 必须取自预定义枚举；
 - `capabilities`、`supported_parameters`、`limits`、`prices`、`tier_prices.<tier>`、`metadata` 的元素/键名必须取自对应枚举（非枚举值不可接受）。
 
@@ -1244,15 +1244,17 @@ type ImportResult struct {
 
 处理流程：
 
-1. 解析 YAML，校验 `version` 与 `default_currency`（必须为 `RMB`）；
+1. 解析 YAML，校验 `version` 与 `default_currency`（必须为 `RMB`）；YAML 数字字面量支持科学计数法（如 `7.6234102728e-08`），按 float64 解析；
 2. 校验每条记录的 `(provider, model, mode)` 唯一性；
 3. 校验必填字段：`provider`、`model`、`base_model`、`mode`、`prices`；
-4. 校验 `prices` 中至少包含一个价格字段且所有价格字段非负；
-5. 若记录包含 `tier_prices`：校验 tier name（**初期只支持 `peak`**），内部价格键名须为 `prices` 枚举，所有 tier 价格字段非负；
+4. 校验 `prices` 中至少包含一个价格字段且所有价格字段非负、折算 `价格 × 1e8` 小于 2^53；
+5. 若记录包含 `tier_prices`：校验 tier name（**初期只支持 `peak`**），内部价格键名须为 `prices` 枚举，所有 tier 价格字段非负并适用同样的精度上限校验；
 6. `replace` 模式：清空 `model_prices` 表后批量写入；
 7. `merge` 模式：对已有 `(provider, model, mode)` 记录执行更新，新增记录执行插入。
 
 > 说明：v0.4 仅支持人民币（RMB），不扩展美元、欧元等多币种。
+>
+> 说明（v0.6）：价格 JSON 序列化回归标准编码器，导出文本中极小值可能以科学计数法出现（如 `1.5e-6`），与十进制表示法等价；issue-102 引入的十进制定制序列化已删除，详见 `design-docs/modifications/2026-09-08-model-price-scientific-notation/`。
 
 #### 4.4.4 按 provider 查询（InnerAPI 导出）
 

--- a/model/imodel_price/import_test.go
+++ b/model/imodel_price/import_test.go
@@ -289,17 +289,52 @@ models:
 	assert.Equal(t, 0.000009, m.TierPrices["peak"]["output_cost_per_token"])
 	assert.Equal(t, 0.0000001, m.TierPrices["peak"]["cache_read_input_token_cost"])
 
-	// JSON should use decimal notation, not scientific notation.
+	// JSON round-trip preserves values regardless of textual notation
+	// (the standard encoder may emit scientific notation for small values).
 	data, err := json.Marshal(m)
 	require.NoError(t, err)
-	assert.Contains(t, string(data), "0.00000005")
-	assert.Contains(t, string(data), "0.0000001")
-	assert.NotContains(t, string(data), "5e-")
-	assert.NotContains(t, string(data), "1e-")
-
-	// Round-trip preserves values.
 	var back ModelPrice
 	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, 0.0000015, back.Prices["input_cost_per_token"])
+	assert.Equal(t, 0.0000045, back.Prices["output_cost_per_token"])
 	assert.Equal(t, 0.00000005, back.Prices["cache_read_input_token_cost"])
+	assert.Equal(t, 0.000003, back.TierPrices["peak"]["input_cost_per_token"])
+	assert.Equal(t, 0.000009, back.TierPrices["peak"]["output_cost_per_token"])
 	assert.Equal(t, 0.0000001, back.TierPrices["peak"]["cache_read_input_token_cost"])
+}
+
+func TestParseModelListYAMLScientificNotation(t *testing.T) {
+	yaml := `
+version: v1.0
+default_currency: RMB
+models:
+  - provider: example-provider
+    model: qwen2.5-omni-7b
+    base_model: qwen2.5-omni-7b
+    mode: chat
+    prices:
+      input_cost_per_token: 6.0168984e-09
+      output_cost_per_token: 7.6234102728e-08
+    tier_prices:
+      peak:
+        input_cost_per_token: 4.141631732e-06
+`
+	file, err := ParseModelListYAML(strings.NewReader(yaml))
+	require.NoError(t, err)
+	require.Len(t, file.Models, 1)
+
+	m := file.Models[0]
+	assert.Equal(t, 6.0168984e-09, m.Prices["input_cost_per_token"])
+	assert.Equal(t, 7.6234102728e-08, m.Prices["output_cost_per_token"])
+	assert.Equal(t, 4.141631732e-06, m.TierPrices["peak"]["input_cost_per_token"])
+
+	// Scientific notation and decimal notation are equivalent: JSON
+	// round-trip must preserve the float64 values.
+	data, err := json.Marshal(m)
+	require.NoError(t, err)
+	var back ModelPrice
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, 6.0168984e-09, back.Prices["input_cost_per_token"])
+	assert.Equal(t, 7.6234102728e-08, back.Prices["output_cost_per_token"])
+	assert.Equal(t, 4.141631732e-06, back.TierPrices["peak"]["input_cost_per_token"])
 }

--- a/model/imodel_price/model_price.go
+++ b/model/imodel_price/model_price.go
@@ -15,93 +15,21 @@
 package imodel_price
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/itxn"
 )
 
-// PriceMap is a map of price keys to their numeric values.
-// It marshals to JSON using decimal notation instead of scientific notation.
+// PriceMap is a map of price keys to their numeric values (yuan per unit).
+// Prices may use more than 8 decimal places; both decimal and scientific
+// notation are accepted on input and may appear in JSON output.
 type PriceMap map[string]float64
 
-// MarshalJSON serializes PriceMap using decimal notation for all values.
-func (p PriceMap) MarshalJSON() ([]byte, error) {
-	if p == nil {
-		return []byte("null"), nil
-	}
-	var buf bytes.Buffer
-	buf.WriteByte('{')
-	first := true
-	for k, v := range p {
-		if !first {
-			buf.WriteByte(',')
-		}
-		first = false
-		keyBytes, err := json.Marshal(k)
-		if err != nil {
-			return nil, err
-		}
-		buf.Write(keyBytes)
-		buf.WriteByte(':')
-		buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
-	}
-	buf.WriteByte('}')
-	return buf.Bytes(), nil
-}
-
 // TierPriceMap is a map of tier names to PriceMap values.
-// It marshals to JSON using decimal notation instead of scientific notation.
 type TierPriceMap map[string]map[string]float64
-
-// MarshalJSON serializes TierPriceMap using decimal notation for all nested values.
-func (t TierPriceMap) MarshalJSON() ([]byte, error) {
-	if t == nil {
-		return []byte("null"), nil
-	}
-	var buf bytes.Buffer
-	buf.WriteByte('{')
-	first := true
-	for tier, prices := range t {
-		if !first {
-			buf.WriteByte(',')
-		}
-		first = false
-		tierBytes, err := json.Marshal(tier)
-		if err != nil {
-			return nil, err
-		}
-		buf.Write(tierBytes)
-		buf.WriteByte(':')
-		if prices == nil {
-			buf.WriteString("null")
-			continue
-		}
-		innerFirst := true
-		buf.WriteByte('{')
-		for k, v := range prices {
-			if !innerFirst {
-				buf.WriteByte(',')
-			}
-			innerFirst = false
-			keyBytes, err := json.Marshal(k)
-			if err != nil {
-				return nil, err
-			}
-			buf.Write(keyBytes)
-			buf.WriteByte(':')
-			buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
-		}
-		buf.WriteByte('}')
-	}
-	buf.WriteByte('}')
-	return buf.Bytes(), nil
-}
 
 // ModelPrice represents a single model pricing/capability record.
 type ModelPrice struct {

--- a/model/imodel_price/validate.go
+++ b/model/imodel_price/validate.go
@@ -19,6 +19,8 @@ import (
 	"math"
 	"strings"
 
+	"github.com/bfenetworks/go-lib/quota"
+
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
 )
 
@@ -115,6 +117,21 @@ var ValidPriceKeys = map[string]bool{
 	"output_cost_per_video_per_second":           true,
 }
 
+// maxPriceFixedPoint is the largest price value (scaled by quota.RmbPrecision)
+// that still keeps the downstream float64 cost computation
+// (usage * (price * 1e8)) exactly representable: float64 integers stay exact
+// up to 2^53.
+const maxPriceFixedPoint = 1 << 53
+
+// checkPricePrecision rejects prices whose scaled value reaches 2^53, where
+// float64 can no longer represent the downstream cost computation exactly.
+func checkPricePrecision(key string, v float64) error {
+	if v*quota.RmbPrecision >= maxPriceFixedPoint {
+		return xerror.WrapParamErrorWithMsg("price %s exceeds the maximum representable precision", key)
+	}
+	return nil
+}
+
 // Metadata key enums.
 var ValidMetadataKeys = map[string]bool{
 	"source": true,
@@ -191,6 +208,9 @@ func ValidateModelPrice(m *ModelPrice) error {
 		if v < 0 {
 			return xerror.WrapParamErrorWithMsg("price %s must be >= 0", k)
 		}
+		if err := checkPricePrecision(k, v); err != nil {
+			return err
+		}
 	}
 
 	for tierName, tierPrices := range m.TierPrices {
@@ -207,6 +227,9 @@ func ValidateModelPrice(m *ModelPrice) error {
 			}
 			if v < 0 {
 				return xerror.WrapParamErrorWithMsg("tier price %s in tier %s must be >= 0", k, tierName)
+			}
+			if err := checkPricePrecision(fmt.Sprintf("%s in tier %s", k, tierName), v); err != nil {
+				return err
 			}
 		}
 	}

--- a/model/imodel_price/validate_test.go
+++ b/model/imodel_price/validate_test.go
@@ -92,6 +92,23 @@ func TestValidateModelPrice(t *testing.T) {
 			}
 			return p
 		}(), true},
+		{"excessive price precision", func() *ModelPrice {
+			p := validModelPrice()
+			p.Prices["input_cost_per_token"] = (1 << 53) / 1e8
+			return p
+		}(), true},
+		{"excessive tier price precision", func() *ModelPrice {
+			p := validModelPrice()
+			p.TierPrices = TierPriceMap{
+				"peak": {"input_cost_per_token": (1 << 53) / 1e8},
+			}
+			return p
+		}(), true},
+		{"valid high precision price", func() *ModelPrice {
+			p := validModelPrice()
+			p.Prices["input_cost_per_token"] = 7.6234102728e-08
+			return p
+		}(), false},
 		{"empty tier prices", func() *ModelPrice {
 			p := validModelPrice()
 			p.TierPrices = TierPriceMap{

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/alicebob/miniredis/v2 v2.34.0
-	github.com/bfenetworks/go-lib v0.0.3
+	github.com/bfenetworks/go-lib v0.0.4
 	github.com/glebarez/go-sqlite v1.21.2
 	github.com/rainway-ai-gateway/ai-gateway-api v0.0.0
 	github.com/stretchr/testify v1.11.1

--- a/test/integration/go.sum
+++ b/test/integration/go.sum
@@ -8,8 +8,8 @@ github.com/alicebob/miniredis/v2 v2.34.0 h1:mBFWMaJSNL9RwdGRyEDoAAv8OQc5UlEhLDQg
 github.com/alicebob/miniredis/v2 v2.34.0/go.mod h1:kWShP4b58T1CW0Y5dViCd5ztzrDqRWqM3nksiyXk5s8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bfenetworks/go-lib v0.0.3 h1:504FrMW0qTKTODuUgkVGCy6DORBdZOgC78zGD9LwpKU=
-github.com/bfenetworks/go-lib v0.0.3/go.mod h1:DNiKiff30CaX7uOUGJpP85VyTn+JSFoY9gfG2AxmPgM=
+github.com/bfenetworks/go-lib v0.0.4 h1:RcC+A4jUQoMvQS0ut5MLlgwp8lkJUlJq3Y3Qeop576E=
+github.com/bfenetworks/go-lib v0.0.4/go.mod h1:DNiKiff30CaX7uOUGJpP85VyTn+JSFoY9gfG2AxmPgM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/test/integration/tests/model_price/design.md
+++ b/test/integration/tests/model_price/design.md
@@ -30,7 +30,7 @@ Model Price 模块负责模型定价数据的管理，支持：
 
 | 接口 | 测试用例数 |
 |------|-----------|
-| 整表导入 | 8 |
+| 整表导入 | 10 |
 | 新增单条记录 | 8 |
 | 分页列表查询 | 4 |
 | 按 ID 查询单条 | 2 |
@@ -171,6 +171,8 @@ MTP-1-{场景编号}
 | MP-1-006 | 重复三元组 | 异常参数 | YAML 内 (provider,model,mode) 重复，返回 422 |
 | MP-1-007 | limits 包含负数 | 合法性条件 | 返回 422 |
 | MP-1-008 | 未知 provider 可导入 | 正常参数 | provider 不存在于 `/providers` 时仍可导入 |
+| MP-1-009 | 科学计数法价格导入 | 正常参数 | 10~12 位小数价格以科学计数法书写，导入后按 float64 等价解析 |
+| MP-1-010 | 超精度价格拒绝 | 合法性条件 | 价格 × 1e8 ≥ 2^53 时导入返回 422 |
 
 ### 7.4 测试场景详细设计
 
@@ -312,6 +314,67 @@ models:
 | imported_count | 1 | Equals |
 | skipped_count | 0 | Equals |
 | errors | 空数组 | Len=0 |
+
+---
+
+#### MP-1-009：科学计数法价格导入（正常参数）
+
+##### 设计思路
+
+验证 `model-list.yaml` 中的价格支持科学计数法表示（v0.6 放开，与十进制表示法等价合法）。目录数据中存在 10~12 位小数价格（如 `7.6234102728e-08`），十进制展开可读性差，科学计数法为权威书写方式。
+
+##### 执行步骤
+
+1. 构造 `model-list.yaml`，价格以科学计数法书写：`input_cost_per_token: 7.6234102728e-08`、`output_cost_per_token: 4.141631732e-06`。
+2. 以 `mode=replace` 调用导入接口。
+3. 验证返回 200，`imported_count=1`。
+4. 按 `(provider, model, mode)` 查询记录，验证价格为等价 float64 值（`7.6234102728e-08` 与 `0.000000076234102728` 相等）。
+
+##### 请求参数
+
+```yaml
+version: v1.0
+default_currency: RMB
+models:
+  - provider: <unique-provider>
+    model: sci-notation-model
+    base_model: sci-notation-model
+    mode: chat
+    prices:
+      input_cost_per_token: 7.6234102728e-08
+      output_cost_per_token: 4.141631732e-06
+```
+
+##### 预期返回结果
+
+**ErrNum**：200  
+**Data 字段校验**：
+
+| 字段 | 预期值 | 校验方式 |
+|------|--------|---------|
+| imported_count | 1 | Equals |
+| skipped_count | 0 | Equals |
+
+记录查询校验：`prices.input_cost_per_token` = `7.6234102728e-08`（InDelta，1e-20）。
+
+---
+
+#### MP-1-010：超精度价格拒绝（合法性条件）
+
+##### 设计思路
+
+验证价格折算 `价格 × 1e8` 不得超过 2^53（约 9e15）。该上限保证下游 BFE 浮点成本计算 `用量 × (价格 × 1e8)` 在 float64 整数精确表示范围内；正常价格（< 1 元/token）不会触发，仅防御异常输入。
+
+##### 执行步骤
+
+1. 构造 `model-list.yaml`，其中 `input_cost_per_token: 9e7`（`9e7 × 1e8 = 9e15 ≥ 2^53`）。
+2. 以 `mode=replace` 调用导入接口。
+3. 验证返回 422。
+
+##### 预期返回结果
+
+**ErrNum**：422  
+**ErrMsg**：包含 price exceeds the maximum representable precision 错误信息
 
 ---
 

--- a/test/integration/tests/model_price/import/import_test.go
+++ b/test/integration/tests/model_price/import/import_test.go
@@ -324,6 +324,74 @@ func TestModelPrice_Import(t *testing.T) {
 
 		_, _, _ = testutil.ImportModelPricesWithResult([]byte(buildYAML(nil)), "replace")
 	})
+
+	t.Run("MP-1-009 科学计数法价格导入", func(t *testing.T) {
+		provider := testutil.UniqueName("provider")
+		// buildYAML uses %v formatting, which prints small float64 values
+		// in scientific notation (e.g. 7.6234102728e-08).
+		yaml := buildYAML([]map[string]interface{}{
+			{
+				"provider": provider,
+				"model":    "sci-notation-model",
+				"mode":     "chat",
+				"prices": map[string]float64{
+					"input_cost_per_token":  7.6234102728e-08,
+					"output_cost_per_token": 4.141631732e-06,
+				},
+			},
+		})
+		assert.Contains(t, yaml, "7.6234102728e-08")
+
+		result, resp, err := testutil.ImportModelPricesWithResult([]byte(yaml), "replace")
+		if err != nil {
+			t.Fatalf("import failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+		assert.Equal(t, 1, result.ImportedCount)
+
+		list, err := fetchModelPriceList()
+		if err != nil {
+			t.Fatalf("list failed: %v", err)
+		}
+		var item *modelPriceDTO
+		for i := range list.List {
+			if list.List[i].Provider == provider {
+				item = &list.List[i]
+				break
+			}
+		}
+		if item == nil {
+			t.Fatalf("imported price not found for provider %s", provider)
+		}
+		// Scientific notation and decimal notation are equivalent float64 values.
+		assert.InDelta(t, 7.6234102728e-08, item.Prices["input_cost_per_token"], 1e-20)
+		assert.InDelta(t, 4.141631732e-06, item.Prices["output_cost_per_token"], 1e-20)
+
+		_, _, _ = testutil.ImportModelPricesWithResult([]byte(buildYAML(nil)), "replace")
+	})
+
+	t.Run("MP-1-010 超精度价格拒绝", func(t *testing.T) {
+		provider := testutil.UniqueName("provider")
+		yaml := buildYAML([]map[string]interface{}{
+			{
+				"provider": provider,
+				"model":    "excessive-precision-model",
+				"mode":     "chat",
+				"prices": map[string]float64{
+					// 1e8 * 1e8 = 1e16 >= 2^53 (~9.007e15), exceeds the representable limit.
+					"input_cost_per_token": 1e8,
+				},
+			},
+		})
+
+		resp, err := testutil.GetClient().PostMultipartFile("/open-api/v1/model-prices/import", "file", "model-list.yaml", []byte(yaml), map[string]string{
+			"mode": "replace",
+		})
+		if err != nil {
+			t.Fatalf("import failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
 }
 
 func buildYAML(models []map[string]interface{}) string {


### PR DESCRIPTION
- 删除 PriceMap/TierPriceMap 自定义 MarshalJSON，序列化交由标准库， 导出文本可为十进制或科学计数法（均为合法 JSON number，下游按数值解析）
- 新增 checkPricePrecision 校验：价格 ×1e8 不得超过 2^53， 保证 BFE 下游浮点计费结果可精确表示，Prices 与 TierPrices 均覆盖
- model-prices.md / 模型层设计文档 / 数据库设计文档同步
- 集成测试新增 MP-1-009（科学计数法导入）/ MP-1-010（超精度拒绝）
- test/integration 跟进 go-lib v0.0.4

配套：bfe/docs/zh_cn/modifications/2026-09-08-rmb-price-float-precision 方案：design-docs/modifications/2026-09-08-model-price-scientific-notation