### PR TITLE
feat: EPP 调度对接（balance_mode/epp_config/epp-pool/epp-assignments/epp_data 统一下发）

### DIFF
--- a/conf/ai_gateway_api.toml
+++ b/conf/ai_gateway_api.toml
@@ -105,6 +105,13 @@ DefaultAIInstancePoolName = "BFE.aipool"
 # default AI cluster name
 DefaultAIClusterName = "BFE-AI_product.szyf"
 
+# default EPP instance pool name (singleton, /epp-pool)
+DefaultEPPInstancePoolName = "EPP.pool"
+# epp pool group size check: "production" (default, exactly 2 instances per group) / "test" (>=1)
+EPPValidationMode = "production"
+# EPP assignment reconciler period in seconds (default 30)
+EPPReconcileIntervalSeconds = 30
+
 [RedisConf]
 # bns addr
 Bns = "BFE.poc-redis-wx"

--- a/db_ddl.sql
+++ b/db_ddl.sql
@@ -88,11 +88,38 @@ CREATE TABLE `clusters` (
   `failure_status` tinyint(1) NOT NULL DEFAULT '0',
   `max_conns_per_host` int(11) NOT NULL DEFAULT '0',
   `llm_config` text,
+  `balance_mode` varchar(16) NOT NULL DEFAULT 'WRR' COMMENT '均衡模式：WRR/EPP',
+  `epp_config` text COMMENT 'EPP调度配置（简化用户形态JSON）',
   `created_at` datetime NOT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name_index` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+-- create epp_instances (EPP实例池表)
+DROP TABLE IF EXISTS `epp_instances`;
+CREATE TABLE `epp_instances` (
+  `id` varchar(128) NOT NULL COMMENT '实例id，池内全局唯一',
+  `host` varchar(255) NOT NULL COMMENT '实例主机名或IP（IPv6字面量不带括号）',
+  `port` int(11) NOT NULL COMMENT '实例端口',
+  `group_name` varchar(128) NOT NULL COMMENT '实例组名',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_host_port` (`host`, `port`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='EPP实例池表';
+
+-- create epp_assignments (EPP分配表，只存主)
+DROP TABLE IF EXISTS `epp_assignments`;
+CREATE TABLE `epp_assignments` (
+  `cluster` varchar(255) NOT NULL COMMENT 'cluster名',
+  `group_name` varchar(128) NOT NULL COMMENT '实例组名',
+  `primary_instance_id` varchar(128) NOT NULL COMMENT '主实例id',
+  `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `update_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  PRIMARY KEY (`cluster`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='EPP分配表';
 
 
 -- create lb_matrices

--- a/db_ddl_sqlite.sql
+++ b/db_ddl_sqlite.sql
@@ -88,12 +88,40 @@ CREATE TABLE clusters (
   failure_status INTEGER NOT NULL DEFAULT 0,
   max_conns_per_host INTEGER NOT NULL DEFAULT 0,
   llm_config TEXT,
+  balance_mode TEXT NOT NULL DEFAULT 'WRR',
+  epp_config TEXT,
   created_at DATETIME NOT NULL,
   updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   UNIQUE (name)
 );
 CREATE TRIGGER clusters_updated_at AFTER UPDATE ON clusters
   FOR EACH ROW BEGIN UPDATE clusters SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+
+-- create epp_instances
+DROP TABLE IF EXISTS epp_instances;
+CREATE TABLE epp_instances (
+  id TEXT NOT NULL PRIMARY KEY,
+  host TEXT NOT NULL,
+  port INTEGER NOT NULL,
+  group_name TEXT NOT NULL,
+  create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (host, port)
+);
+CREATE TRIGGER epp_instances_update_time AFTER UPDATE ON epp_instances
+  FOR EACH ROW BEGIN UPDATE epp_instances SET update_time = CURRENT_TIMESTAMP WHERE id = OLD.id; END;
+
+-- create epp_assignments
+DROP TABLE IF EXISTS epp_assignments;
+CREATE TABLE epp_assignments (
+  cluster TEXT NOT NULL PRIMARY KEY,
+  group_name TEXT NOT NULL,
+  primary_instance_id TEXT NOT NULL,
+  create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TRIGGER epp_assignments_update_time AFTER UPDATE ON epp_assignments
+  FOR EACH ROW BEGIN UPDATE epp_assignments SET update_time = CURRENT_TIMESTAMP WHERE cluster = OLD.cluster; END;
 
 -- create lb_matrices
 DROP TABLE IF EXISTS lb_matrices;

--- a/design-docs/api-define/InnerAPI接口定义/02-interface-list.md
+++ b/design-docs/api-define/InnerAPI接口定义/02-interface-list.md
@@ -13,6 +13,7 @@
 | 7 | `/configs/mod-body-process` | 导出请求体处理配置 | `version` | [mod-body-process.md](./mod-body-process.md) |
 | 8 | `/configs/rate-limit-policy` | 导出限流策略配置 | `version` | [rate-limit-policy.md](./rate-limit-policy.md) |
 | 9 | `/configs/ai-route` | 导出 AI 路由配置 | `version` | [ai-route.md](./ai-route.md) |
+| 10 | `/configs/epp_data/config` | 导出 EPP 配置（epp_config + assignment 全量视图，合并单端点） | `version` | [epp-data.md](./epp-data.md) |
 
 ## 2. 特殊参数说明
 

--- a/design-docs/api-define/InnerAPI接口定义/README.md
+++ b/design-docs/api-define/InnerAPI接口定义/README.md
@@ -22,5 +22,6 @@
 | mod-body-process 接口 | [mod-body-process.md](./mod-body-process.md) |
 | rate-limit-policy 接口 | [rate-limit-policy.md](./rate-limit-policy.md) |
 | ai-route 接口 | [ai-route.md](./ai-route.md) |
+| epp_data 接口 | [epp-data.md](./epp-data.md) |
 | 数据模型定义 | [data-models.md](./data-models.md) |
 | 附录 | [appendix.md](./appendix.md) |

--- a/design-docs/api-define/InnerAPI接口定义/epp-data.md
+++ b/design-docs/api-define/InnerAPI接口定义/epp-data.md
@@ -1,0 +1,110 @@
+# epp_data 接口
+
+## 1. 接口信息
+
+| 项目 | 值 | 说明 |
+|------|------|------|
+| 含义 | 导出 EPP 配置（epp_config + assignment 全量视图，合并单端点） | 供 EPP 实例拉取调度配置与实例组分配视图；单 topic（`ConfigTopicEppData`），两段配置同一 version 快照 |
+| 端点 | `/configs/epp_data/config` | - |
+| Method | GET | - |
+| 鉴权 | `FeatureRoute + ActionExport` | - |
+
+## 2. 请求参数
+
+**Query 参数**
+
+| 参数名 | 类型 | 必填 | 说明 | 合法性条件 |
+|--------|------|------|------|------------|
+| version | string | 否 | 上次返回的版本号，用于增量同步 | 可选；无强制格式/长度校验；为空或未传时按首次拉取处理 |
+
+**请求示例**
+
+```shell
+curl -X GET "http://api-server:port/inner-api/v1/configs/epp_data/config?version=00010101000000" \
+  -H "Authorization:Token TOKEN_STRING"
+```
+
+## 3. 返回数据结构
+
+### 3.1 顶层结构
+
+```json
+{
+    "ErrNum": 200,
+    "ErrMsg": "success",
+    "Data": {
+        "Version": "20260906120000",
+        "Config": {
+            "epp_config": {
+                "cluster-a": {
+                    "featureGates": ["flowControl"],
+                    "plugins": [
+                        { "name": "ep-discover", "type": "cluster-table-discovery", "parameters": { "clusterName": "cluster-a" } },
+                        { "name": "util-filter", "type": "utilization-filter",
+                          "parameters": { "conditions": [ { "metric": "kv-cache-utilization", "maxValue": 0.9 } ] } },
+                        { "name": "kv-scorer", "type": "kv-cache-utilization-scorer", "parameters": {} },
+                        { "name": "max-score", "type": "max-score-picker", "parameters": {} }
+                    ],
+                    "schedulingProfiles": [
+                        { "name": "default",
+                          "plugins": [
+                            { "pluginRef": "util-filter" },
+                            { "pluginRef": "kv-scorer", "weight": 1.0 },
+                            { "pluginRef": "max-score" }
+                          ] }
+                    ],
+                    "dataLayer": { "discovery": { "endpoints": { "pluginRef": "ep-discover" } } },
+                    "flowControl": { "defaultRequestTTL": "30s", "noEndpointRequestTTL": "10m" }
+                }
+            },
+            "assignment": {
+                "cluster-a": { "primary": "epp-a", "standby": "epp-b" },
+                "cluster-b": { "primary": "epp-b", "standby": "epp-a" },
+                "cluster-c": { "primary": "epp-c", "standby": null }
+            }
+        }
+    },
+    "WorkMode": "ModeNormal"
+}
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| Version | string | 配置版本号，格式 `20060102150405` |
+| Config | object | EPP 配置，含 `epp_config` 与 `assignment` 两段 |
+
+### 3.2 Config.epp_config 段
+
+`epp_config` 为 `map[cluster名]EndpointPickerConfig`，由 OpenAPI 写入的简化 `epp_config`（见 OpenAPI 接口定义 [clusters.md](../OpenAPI接口定义/clusters.md)）在导出时**确定性编译**而来（编译规则见 `design-docs/modifications/2026-09-08-epp-scheduling-integration/api-changes.md` §3.2.1），出厂即合法。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| \<cluster名\> | object | 编译后的完整 `EndpointPickerConfig`，key 为集群名称 |
+
+范围为全部 `balance_mode=EPP` 的 cluster。OpenAPI 校验保证 EPP 模式 cluster 的 `epp_config` 必填，因此导出结果中 EPP cluster 必然有配置。
+
+### 3.3 Config.assignment 段（全量视图）
+
+`assignment` 为 `map[cluster名]{primary, standby}`，**所有 EPP 实例返回完全相同的内容**（同一 version 快照）。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| \<cluster名\>.primary | string | 主实例 id，为 `/epp-pool` 中配置的实例 id |
+| \<cluster名\>.standby | string \| null | 备实例 id；单实例组（无备）时为 `null` |
+
+**EPP 侧消费方式**：以自身 `-instance-id`（须与 `/epp-pool` 中某实例 id 一致）逐 cluster 匹配——`primary == 本实例 id` → 本实例为该 cluster 的 primary；`standby == 本实例 id` → standby；均未命中 → 跳过该 cluster。全量视图的附带收益：EPP 可获知同组 peer 实例 id（如备 Cell 建联、双活跃自检）。
+
+**异常态**：`epp_config` 中存在但 `assignment` 中无条目的 cluster = 未分配。EPP 侧应本地告警、不为该 cluster 建 cell；api 侧导出 server_data_conf 时该 cluster 降级为 `WRR` 并输出 error 日志（见 [server-data-conf.md](./server-data-conf.md) §3.3）。
+
+## 4. 配置未变化返回示例
+
+```json
+{
+    "ErrNum": 200,
+    "ErrMsg": "success",
+    "Data": null,
+    "WorkMode": "ModeNormal"
+}
+```
+
+---

--- a/design-docs/api-define/InnerAPI接口定义/server-data-conf.md
+++ b/design-docs/api-define/InnerAPI接口定义/server-data-conf.md
@@ -252,6 +252,14 @@ curl -X GET "http://api-server:port/inner-api/v1/configs/tls_conf/server_data_co
 
 > **说明**：`ModelTable` 由 InnerAPI 根据 `cluster.llm_config.provider` 查询 `/providers` 的 `time_zone` / `tiers` 与 `/model-prices` 的 `prices` / `tier_prices` 拼接后自动填充，不在 OpenAPI `/clusters` 端点中展示。`Currency` 固定为 `RMB`。
 
+### 3.3 GslbBasic.EPPAddr 有序主备语义
+
+`GslbBasic.EPPAddr` 为**有序列表**：`[0]`=主、`[1]`=备，仅 `BalanceMode=EPP` 时有值（`BalanceMode=WRR` 时为 `null`）。单实例组（测试环境）时仅 `[主]`。
+
+- 由 `epp_assignments` 分配驱动生成（见 OpenAPI 接口定义 [epp-assignments.md](../OpenAPI接口定义/epp-assignments.md)）：按 cluster 的分配记录取 `{primary, standby}`，实例地址由 `epp_instances` 的 host/port 经 `net.JoinHostPort` 拼接为 `host:port`（IPv6 自动加括号）。
+- EPP 模式 cluster 无有效分配记录时**降级导出**：该 cluster `BalanceMode` 置为 `WRR`、不生成 `EPPAddr`，同时 ai-gateway-api 输出 error 级日志（含 cluster 名与原因）；单 cluster 降级不阻塞整份 server_data_conf 下发，分配恢复后下轮导出自动回到 `EPP`。
+- 分配变更（cluster 进入 EPP 模式自动分配、`/epp-pool` 变更触发悬空修复、`PUT /api/v1/epp-assignments/{cluster}` 手工覆写）即时生效，下次导出自然带出。
+
 ## 4. 配置未变化返回示例
 
 ```json

--- a/design-docs/api-define/OpenAPI接口定义/README.md
+++ b/design-docs/api-define/OpenAPI接口定义/README.md
@@ -21,6 +21,8 @@
 | /certificates | [certificates.md](./certificates.md) |
 | /providers | [providers.md](./providers.md) |
 | /clusters | [clusters.md](./clusters.md) |
+| /epp-assignments | [epp-assignments.md](./epp-assignments.md) |
+| /epp-pool | [epp-pool.md](./epp-pool.md) |
 | /model-prices | [model-prices.md](./model-prices.md) |
 | /operation-logs | [operation-logs.md](./operation-logs.md) |
 | /expression/verify | [expression-verify.md](./expression-verify.md) |

--- a/design-docs/api-define/OpenAPI接口定义/clusters.md
+++ b/design-docs/api-define/OpenAPI接口定义/clusters.md
@@ -68,6 +68,36 @@
         "provider": "deepseek",
         "match_prefix": "deepseek/",
         "strip_prefix": true
+    },
+    "balance_mode": "WRR",
+    "epp_config": null
+}
+```
+
+**数据模型示例（EPP 模式集群）**
+
+```json
+{
+    "name": "cluster-a",
+    "description": "EPP 调度集群",
+    "balance_mode": "EPP",
+    "epp_config": {
+        "scheduling_profile": "balanced",
+        "cache_affinity": "medium",
+        "prefix_cache_affinity": true,
+        "session_affinity_enabled": true,
+        "session_affinity_header": "x-session-id",
+        "kv_cache_utilization_max": 0.9,
+        "flow_control": {
+            "max_requests": 1000,
+            "queue_ttl": 30,
+            "no_endpoint_queue_ttl": 600,
+            "enable_eviction": false
+        }
+    },
+    "llm_config": {
+        "models": ["deepseek-chat"],
+        "provider": "deepseek"
     }
 }
 ```
@@ -82,6 +112,8 @@
 | `sticky_sessions` | object | 会话保持 | 见下方 表：会话保持 | 非必填；未传时使用默认值 |
 | `passive_health_check` | object | 被动健康检查 | 见下方 表：被动健康检查 | 非必填；未传时使用默认值 |
 | `llm_config` | object | AI LLM 服务配置 | 见下方 表：LLM配置 | 必填 |
+| `balance_mode` | string | 集群均衡模式 | `WRR`、`EPP` | 非必填；默认值为 `WRR`；有效枚举：`WRR`、`EPP` |
+| `epp_config` | object | EPP 调度配置（简化用户形态：调度档位 + 少量调优参数，见下方 表：EPP调度配置）。仅 `balance_mode=EPP` 时生效；`WRR` 时保留但不生效（休眠），便于 EPP ↔ WRR 来回切换不丢配置 | - | 条件必填：`balance_mode=EPP` 时必填且通过字段校验；`balance_mode=WRR` 时可选（传入则保留并做格式校验，但不生效） |
 
 **表：连接设置**
 
@@ -175,6 +207,29 @@
 | source_model | string | 用户请求的模型名 | Y | - | 必填；非空；同一 `model_mappings` 内不能重复 |
 | target_model | string | 映射后的实际模型名 | Y | - | 必填；非空 |
 
+**表：EPP调度配置（`epp_config`）**
+
+| 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
+| - | -  | - | - | - | - |
+| scheduling_profile | string | 调度策略档位：调度激进程度/优化目标的预设组合 | N | `latency-first`（低延迟优先：队列等待权重最高）、`balanced`（均衡）、`throughput-first`（吞吐优先：KV cache 亲和最高） | 非必填；默认值为 `balanced`；有效枚举：`latency-first`、`balanced`、`throughput-first` |
+| cache_affinity | string | scorer 权重覆盖项，显式指定 KV cache 亲和强度 | N | 缺省（未显式设置）= `medium`，语义为**跟随 `scheduling_profile`，不覆盖其权重**；显式设置后覆盖 `scheduling_profile` 的 scorer 权重 | 非必填；有效枚举：`low`、`medium`、`high` |
+| prefix_cache_affinity | bool | 前缀缓存亲和（prefix-cache-scorer）：相同 prompt 前缀的请求经前缀哈希匹配**尽力收敛**到同一后端，提升 KV cache 复用；零参数、自主学习；**软亲和，不保证一定命中匹配后端** | N | 为 `true` 时注入亲和 scorer；为 `false` 时不注入 | 非必填；默认值为 `true`；必须为 bool |
+| session_affinity_enabled | bool | 会话亲和开关（session-affinity-scorer，session_id 策略）：开启后同一 session 的请求**尽力粘住**同一后端（有 binding 状态，亲和强度高于 prefix；但仍受利用率过滤与加权总分影响，非硬路由），绑定端点摘除后自动迁移重粘 | N | 为 `true` 时注入亲和 scorer（header 取 `session_affinity_header`）；为 `false` 时不注入 | 非必填；默认值为 `false`；必须为 bool |
+| session_affinity_header | string | session id 来源请求头（如 `x-session-id`），scorer 从该 header 解析 session id；`enabled=false` 时保留但不生效（休眠） | 条件必填 | 仅在 `session_affinity_enabled=true` 时生效 | `session_affinity_enabled=true` 时**必填**（非空 HTTP header 名）；`enabled=false`/缺省时可保留（非空 header 名，格式校验照常，不生效） |
+| kv_cache_utilization_max | float | 端点过滤阈值：KV cache 利用率超过该值的端点被过滤 | N | - | 非必填；默认值为 `0.9`；取值范围 `(0, 1]` |
+| flow_control | object | 流控参数；缺省则不下发流控段（EPP 用系统默认） | N | 见下方 表：epp_config.flow_control | 非必填；若传入，须满足 flow_control 结构约束 |
+
+**表：epp_config.flow_control**
+
+| 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
+| - | -  | - | - | - | - |
+| max_requests | int | 全局并发上限（跨全部优先级带）；`-1` 为显式"不限"（更新时用于明确恢复不限） | N | 缺省表示不限；`-1` 也表示不限 | 非必填；若传入，取值 `>0` 或 `-1` |
+| queue_ttl | int | 池**有端点**时的排队预算（**单位：秒**），超期以可重试背压错误拒绝 | N | 缺省由 EPP 决定（llm-d 默认 60 秒）；`0` 为显式禁用驱逐 | 非必填；取值 ≥ 0 的整数 |
+| no_endpoint_queue_ttl | int | 池**无端点**（冷启动扩容）时的排队预算（**单位：秒**），regime 切换时重新起算 | N | 默认值为跟随 `queue_ttl` | 非必填；同 `queue_ttl` |
+| enable_eviction | bool | 需求驱动驱逐：高优先级被饱和阻塞时终止负优先级在飞请求回收容量 | N | - | 非必填；默认值为 `false`；必须为 bool |
+
+> **注意**：`epp_config` 为简化用户形态，api 导出时编译为完整 `EndpointPickerConfig`，详细编译规则见 modifications 目录 `2026-09-08-epp-scheduling-integration/api-changes.md` §3.2.1。存储保留用户原始 JSON——未显式携带的字段不落盘、GET 回读与写入一致；默认值只体现在导出编译时。
+
 **约束**
 
 - `name` 必填，类型为 [ClusterName](./00-common.md#15-集群名称clustername)，全局唯一。
@@ -200,6 +255,10 @@
   - `strip_prefix=true` 时，`match_prefix` 必填且非空；
   - `match_prefix` 若传入，必须以 `/` 结尾。
 - `llm_config.model_table` 不在 OpenAPI `/clusters` 端点中展示，调用方传入时忽略或返回 `422`；该字段由 InnerAPI 根据 `provider` 自动填充后下发给 BFE。
+- `balance_mode` 非必填，默认值为 `WRR`；有效枚举：`WRR`（BFE 本地加权轮询）、`EPP`（由 EPP 调度器接管后端选择）；`balance_mode` 是 EPP 模式的唯一判定来源。
+- `epp_config` 条件必填：`balance_mode=EPP` 时必填且通过字段校验（简化字段校验：枚举、数值范围、秒数取值范围，全部 api 侧强制，不合法拒绝提交）；`balance_mode=WRR` 时可选——传入则保留并做格式校验，但不编译、不导出（休眠）。
+- `balance_mode` 更新规则：允许 `WRR → EPP`（须同时提供合法 `epp_config`）；`EPP → WRR` 仅改 `balance_mode` 即可，`epp_config` 与分配记录保留（休眠，不编译/不导出），再切回 `EPP` 时原配置与原分配继续生效（分配如已悬空由 `/epp-pool` 变更时的自动修复处理）。**任一写入中 `epp_config` 非空即须通过字段校验，与 `balance_mode` 无关**（含 `EPP → WRR` 时随请求一并携带或休眠保留的配置）。
+- 生效语义：`epp_config` 仅在 `balance_mode=EPP` 时生效；停用 EPP 调度 = 将 `balance_mode` 改回 `WRR`（无需清空 `epp_config`）。
 - `basic`、`sticky_sessions`、`passive_health_check` 若未传则使用 AI 网关场景默认值。
 - `basic.protocol` 有效值为 `http`、`https`。
 - `basic.connection.max_idle_conn_per_rs` 须为 >=0 的整数。
@@ -235,6 +294,8 @@
 | sticky_sessions| object |  会话保持| N | AI网关场景默认推荐值：enabled=false；若开启，hash_strategy=CLIENT_ID_ONLY、hash_header为空 | 非必填；未传时使用默认值；子字段合法性见 1 中各表 |
 | passive_health_check| object |  被动健康检查| N | AI网关场景默认推荐值：failnum=3、interval=1000ms、host为空（使用provider首个实例addr）、uri="/"、statuscode=0 | 非必填；未传时使用默认值；子字段合法性见 1 中各表 |
 | llm_config| object |  AI LLM服务配置| Y | 见 1 数据模型中表：LLM配置 | 必填；`provider` 必填且引用已存在 provider；`models` 至少1个非空元素且不能重复；子字段合法性见 1 中各表 |
+| balance_mode| string |  集群均衡模式| N | `WRR`：BFE 本地加权轮询；`EPP`：由 EPP 调度器接管后端选择 | 非必填；默认值为 `WRR`；有效枚举：`WRR`、`EPP` |
+| epp_config| object |  EPP 调度配置（简化用户形态）| N | 见 1 数据模型中表：EPP调度配置 | 条件必填：`balance_mode=EPP` 时必填且通过字段校验；`balance_mode=WRR` 时可选（传入则保留并做格式校验，不生效）；子字段合法性见 1 中各表 |
 
 **HTTP BODY参数示例**
 
@@ -327,6 +388,31 @@
 }
 ```
 
+**HTTP BODY参数示例（EPP 模式集群）**
+
+```json
+{
+    "name": "cluster-a",
+    "description": "EPP 调度集群",
+    "llm_config": { "provider": "p1", "models": ["m1"] },
+    "balance_mode": "EPP",
+    "epp_config": {
+        "scheduling_profile": "balanced",
+        "cache_affinity": "medium",
+        "prefix_cache_affinity": true,
+        "session_affinity_enabled": true,
+        "session_affinity_header": "x-session-id",
+        "kv_cache_utilization_max": 0.9,
+        "flow_control": {
+            "max_requests": 1000,
+            "queue_ttl": 30,
+            "no_endpoint_queue_ttl": 600,
+            "enable_eviction": false
+        }
+    }
+}
+```
+
 **执行逻辑**
 
 创建集群时，系统自动执行以下步骤：
@@ -337,6 +423,7 @@
 4. 根据 `llm_config.provider` 查找对应 provider，读取其 `instance_pool`，自动创建实例池（名称格式：`{product_name}.{cluster_name}`）
 5. 自动创建子集群（名称：`{cluster_name}`，绑定实例池）
 6. 自动绑定子集群到集群
+7. 若 `balance_mode=EPP`：该集群的后端选择与流量调度由 EPP 调度器接管（实例分配见 [epp-assignments.md](./epp-assignments.md)）
 
 **返回数据（Data内容）**
 
@@ -348,6 +435,8 @@
 | basic | object | 基本参数 |
 | sticky_sessions | object | 会话保持 |
 | passive_health_check | object | 被动健康检查 |
+| balance_mode | string | 集群均衡模式；默认 `WRR` |
+| epp_config | object \| null | EPP 调度配置（简化用户形态）；未配置过时为 `null`。**原样返回存储值**：`balance_mode=WRR` 时若创建/更新中传入过 `epp_config`，仍原样返回（休眠保留、不生效），切回 `EPP` 后继续生效 |
 
 > **注意**：返回数据中不再包含 `instance_pool`；实例池信息通过 `llm_config.provider` 关联到 provider 获取。
 
@@ -362,7 +451,9 @@
         "llm_config": { "...": "..." },
         "basic": { "...": "..." },
         "sticky_sessions": { "...": "..." },
-        "passive_health_check": { "...": "..." }
+        "passive_health_check": { "...": "..." },
+        "balance_mode": "WRR",
+        "epp_config": null
     }
 }
 ```
@@ -429,6 +520,13 @@
 **输入参数（Body）**
 
 可修改字段含义同创建接口，但**输入参数不包括 `name`，即不能修改 cluster 的 name**（名称由 URI 中的 `cluster_name` 指定）。若请求体中仍包含 `name`，返回 422。不支持直接修改 `instance_pool`；如需调整后端实例，请更新对应 provider 的 `instance_pool`。
+
+`balance_mode` / `epp_config` 更新规则：
+
+| 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
+| - | -  | - | - | - | - |
+| balance_mode | string | 集群均衡模式 | N | 允许 `WRR → EPP`（须同时提供合法 `epp_config`）与 `EPP → WRR`（`epp_config` 与分配记录保留休眠） | 非必填；有效枚举：`WRR`、`EPP` |
+| epp_config | object | EPP 调度配置（简化用户形态） | N | `WRR → EPP` 时须同时提供合法 `epp_config`；`EPP → WRR` 无需清空（保留休眠）；变更后即时 bump server_data_conf version | 条件必填与字段校验同创建接口；`balance_mode=WRR` 时可选（传入保留、不生效）；**非空一律做字段校验，与 balance_mode 无关** |
 
 > **注意：**
 > - `sub_clusters` 与 `scheduler` 为系统内部自动生成，更新时不支持手动修改。

--- a/design-docs/api-define/OpenAPI接口定义/epp-assignments.md
+++ b/design-docs/api-define/OpenAPI接口定义/epp-assignments.md
@@ -1,0 +1,149 @@
+# /epp-assignments
+
+## 1. 概述
+
+EPP 实例组与 cluster 之间的分配由**分配器自动生成**（触发时机与算法见 `design-docs/modifications/2026-09-08-epp-scheduling-integration/design-changes.md` §4.2：cluster 进入 EPP 模式时自动选组选主、`/epp-pool` 变更后自动修复悬空分配），本域仅提供**查询视图**与**手工覆写**（运维干预入口）；分配输入（实例组列表）来自 `/epp-pool`（见 [epp-pool.md](./epp-pool.md)）。
+
+## 2. 接口清单
+
+### 2.1 获取分配全量视图
+
+**基本信息**
+
+| 项目 | 值 | 说明 |
+| - | - | - |
+| 含义 | 分配全量视图（per-cluster 展开 + 未分配/空闲清单） | - |
+| 端点 | /epp-assignments | - |
+| 版本 | v1 | - |
+| method | GET | - |
+
+**输入参数（Query）**
+
+| 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
+| - | - | - | - | - | - |
+| cluster | string | 按 cluster 过滤 | N | 只返回该 cluster 的分配条目；不传返回全部 EPP 模式 cluster | 须为已存在且 `balance_mode=EPP` 的 cluster 名；否则返回 404 语义错误 |
+
+**执行逻辑**
+
+1. 查询全部（或指定）`balance_mode=EPP` 的 cluster 的分配记录。
+2. 与 EPP 实例池（`/epp-pool`）做读时 join，展开 `primary` / `standby` 实例详情。
+3. 不一致时（如 primary 指向的实例已被从池中移除，或组已不存在）该条目标记 `degraded`：`primary` 返回 `null` 并计入 `unassigned_clusters`。
+4. 汇总未分配 cluster 清单与空闲实例组清单，返回。
+
+**返回数据（Data内容）**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| clusters | []object | 全部 `balance_mode=EPP` 的 cluster 的分配展开视图（含未分配 cluster） |
+| clusters[].cluster | string | cluster 名 |
+| clusters[].group | string | 分配的实例组名；未分配时为 `null` |
+| clusters[].primary | object \| null | 主实例；未分配或 degraded 时为 `null`。结构同 /epp-pool 实例：`{id, host, port}` |
+| clusters[].standby | object \| null | 备实例；**读时展开**：`epp_assignments` 只存 `primary_instance_id`，standby = 同组中除 primary 外的实例；单实例组或未分配时为 `null` |
+| clusters[].degraded | bool | 异常标记：primary 不在实例池（实例已被移除）或组不存在时为 `true` |
+| unassigned_clusters | []string | `balance_mode=EPP` 但 `epp_assignments` 无有效记录的 cluster 名列表。这些 cluster 导出 server_data_conf 时会**降级为 `WRR`**（无 EPP 实例可调度），api 同时输出 error 日志，属需尽快处理的异常态，单独列出便于巡检 |
+| idle_groups | []string | 实例池中未承担任何 cluster 分配的组名列表（组内实例均未作为 primary 出现；备角色不计入占用）。扩容新组后、完成分配前会出现在此列表 |
+
+> **说明**：视图是 `epp_assignments`（cluster→{group, primary}）与 `epp_instances`（/epp-pool）的**读时 join**，不引入冗余存储。
+>
+> **说明**：实例在多个 cluster 间互为主备（如 `epp-a`/`epp-b` 同时担任 cluster-a 与 cluster-b 的主备）是**合法**的——分配以 cluster 为单位，不做组↔cluster 的一对一约束。
+
+**成功返回示例**
+
+```json
+{
+    "ErrNum": 200,
+    "ErrMsg": "success",
+    "Data": {
+        "clusters": [
+            {
+                "cluster": "cluster-a",
+                "group": "g1",
+                "primary":   { "id": "epp-a", "host": "10.0.0.1", "port": 9002 },
+                "standby":   { "id": "epp-b", "host": "10.0.0.2", "port": 9002 }
+            },
+            {
+                "cluster": "cluster-b",
+                "group": "g1",
+                "primary":   { "id": "epp-b", "host": "10.0.0.2", "port": 9002 },
+                "standby":   { "id": "epp-a", "host": "10.0.0.1", "port": 9002 }
+            },
+            {
+                "cluster": "cluster-c",
+                "group": "g2",
+                "primary":   { "id": "epp-c", "host": "10.0.0.3", "port": 9002 },
+                "standby":   null
+            }
+        ],
+        "unassigned_clusters": ["cluster-d", "cluster-e"],
+        "idle_groups": ["g3"]
+    }
+}
+```
+
+### 2.2 手工覆写单个 cluster 的分配
+
+**基本信息**
+
+| 项目 | 值 | 说明 |
+| - | - | - |
+| 含义 | 手工覆写单个 cluster 的分配（运维干预入口，触发 server_data_conf version bump） | - |
+| 端点 | /epp-assignments/{cluster} | - |
+| 版本 | v1 | - |
+| method | PUT | - |
+
+**输入参数（URI）**
+
+| 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
+| - | - | - | - | - | - |
+| cluster | string | 集群名 | Y | - | 必填；类型为 [ClusterName](./00-common.md#15-集群名称clustername)；必须引用已存在且 `balance_mode=EPP` 的集群 |
+
+**输入参数（Body）**
+
+| 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
+| - | - | - | - | - | - |
+| group_name | string | 目标实例组 | Y | - | 必填；非空；必须存在于 `/epp-pool` 当前实例池中 |
+| primary_instance_id | string | 主实例 id | Y | - | 必填；非空；必须存在于 `group_name` 组的实例列表中；须与 standby 实例不同地址 |
+
+**HTTP BODY参数示例**
+
+```json
+{
+    "group_name": "g1",
+    "primary_instance_id": "epp-a"
+}
+```
+
+**约束**
+
+- `group_name` 必须存在于 `/epp-pool` 当前实例池中。
+- `primary_instance_id` 必须存在于 `group_name` 组的实例列表中，且与 standby 实例不同地址。
+- 生产组覆写后应保持每组 2 实例（standby 自动为组内另一实例）。
+- `EPP → WRR` 反向变更（见 [clusters.md](./clusters.md)）后分配记录休眠保留，不删除；再切回 `EPP` 时继续生效（如分配已悬空由 `/epp-pool` 变更时的自动修复处理）。
+
+**执行逻辑**
+
+1. 校验请求参数合法性（组存在、primary 存在组实例列表中、与 standby 不同地址）。
+2. 写入/更新 `epp_assignments`（cluster 唯一键 upsert，分配只存主：standby 为读时展开）。
+3. bump server_data_conf version（EPPAddr 下次导出即带出；epp_data topic 在下一次导出时由 MD5 签名机制自然 bump）。
+4. 返回更新后的该 cluster 分配视图（结构同 [2.1](#21-获取分配全量视图) `clusters[]` 元素）。
+
+**返回数据（Data内容）**
+
+结构同 [2.1](#21-获取分配全量视图) `clusters[]` 元素：`{cluster, group, primary, standby}`。
+
+**成功返回示例**
+
+```json
+{
+    "ErrNum": 200,
+    "ErrMsg": "success",
+    "Data": {
+        "cluster": "cluster-a",
+        "group": "g1",
+        "primary":   { "id": "epp-a", "host": "10.0.0.1", "port": 9002 },
+        "standby":   { "id": "epp-b", "host": "10.0.0.2", "port": 9002 }
+    }
+}
+```
+
+---

--- a/design-docs/api-define/OpenAPI接口定义/epp-pool.md
+++ b/design-docs/api-define/OpenAPI接口定义/epp-pool.md
@@ -1,0 +1,177 @@
+# /epp-pool
+
+## 1. 数据模型
+
+**实例 id 约定（部署形态）**：EPP 以 StatefulSet 部署，实例 id = **Pod hostname**（EPP 的 `-instance-id` 缺省值即 hostname，同组副本共享完全相同的启动参数，无需按实例差异化配置）；`/epp-pool` 登记时实例 id 取 pod 名（如 `epp-0`/`epp-1`），部署流程 reconcile 池时从 StatefulSet pod 名生成 PATCH 内容。前提：StatefulSet 保证 hostname 稳定唯一（不可用随机名的 Deployment）；非 K8s 部署显式传 `-instance-id`。
+
+```json
+{
+    "name": "EPP.pool",
+    "groups": [
+        {
+            "name": "g1",
+            "instances": [
+                { "id": "epp-a", "host": "10.0.0.1", "port": 9002 },
+                { "id": "epp-b", "host": "10.0.0.2", "port": 9002 }
+            ]
+        }
+    ]
+}
+```
+
+**字段说明**
+
+| 字段 | 类型 | 说明 | 可能取值 | 合法性条件 |
+|------|------|------|----------|----------|
+| `name` | string | 实例池完整名称 | 如 `EPP.pool` | 请求中无需传入，由配置项 `RunTime.DefaultEPPInstancePoolName` 提供（默认值 `EPP.pool`） |
+| `groups` | []Group | 实例组列表 | - | 必填；至少1个元素；组名非空、唯一 |
+
+**Group 结构（`groups` 元素）**
+
+| 字段 | 类型 | 说明 | 可能取值 | 合法性条件 |
+|------|------|------|----------|----------|
+| `name` | string | 实例组名 | 如 `g1` | 必填；非空；池内唯一 |
+| `instances` | []Instance | 组内实例列表 | - | 必填；至少1个元素（拒绝空组） |
+
+**Instance 结构（`groups[].instances` 元素）**
+
+| 字段 | 类型 | 说明 | 可能取值 | 合法性条件 |
+|------|------|------|----------|----------|
+| `id` | string | 实例 id（EPP 以 `-instance-id` 启动参数对应此值） | 如 `epp-a` | 必填；非空；**池内全局唯一** |
+| `host` | string | 实例主机名或 IP（IPv6 字面量不带括号） | 无 DNS 时可填写 IP 地址 | 必填；非空；类型为 [Hostname](./00-common.md#公共参数类型) 或 IP |
+| `port` | int | 实例端口 | 如 `9002` | 必填；类型为 [Port](./00-common.md#公共参数类型) |
+
+**约束**
+
+- 实例池名称由配置项 `RunTime.DefaultEPPInstancePoolName` 提供（默认值 `EPP.pool`），请求中无需传入 `name`。
+- `groups` 至少包含1个元素；组名非空、唯一。
+- `groups[].instances` 至少包含1个元素（拒绝空组）。
+- 每个实例的 `id` 非空，且池内全局唯一。
+- 每个实例的 `host` 非空，类型为 [Hostname](./00-common.md#公共参数类型) 或 IP（IPv6 字面量不带括号）。
+- 每个实例的 `port` 类型为 [Port](./00-common.md#公共参数类型)。
+- `(host, port)` 组合池内全局唯一（等价于旧 host:port 唯一语义）。
+- 每组实例数：生产环境每组恰 2 实例（主备）；测试环境允许单实例组（仅主、无备）；校验强度由部署形态配置项控制。
+- 实例无 `status`/`last_heartbeat` 字段——存活感知在 BFE 侧（EPPAddr 连接滞回），api 侧不做存活标记。
+
+## 2. 接口清单
+
+### 2.1 获取 EPP 实例池详情
+
+**基本信息**
+
+| 项目 | 值 | 说明 |
+| - | - | - |
+| 含义 | 获取 EPP 实例池详情（实例组 + 实例列表） | - |
+| 端点 | /epp-pool | - |
+| 版本 | v1 | - |
+| method | GET | - |
+
+**输入参数（Query）**
+
+无。
+
+**执行逻辑**
+
+1. 从配置文件 `RunTime` 中读取 `DefaultEPPInstancePoolName`（默认值：`EPP.pool`）。
+2. 查询 EPP 实例池，若不存在则返回错误。
+3. 返回实例池详情（包含实例组 + 实例列表）。
+
+**返回数据（Data内容）**
+
+字段同 [1. 数据模型](#1-数据模型)。
+
+**成功返回示例**
+
+```json
+{
+    "ErrNum": 200,
+    "ErrMsg": "success",
+    "Data": {
+        "name": "EPP.pool",
+        "groups": [
+            {
+                "name": "g1",
+                "instances": [
+                    { "id": "epp-a", "host": "10.0.0.1", "port": 9002 },
+                    { "id": "epp-b", "host": "10.0.0.2", "port": 9002 }
+                ]
+            }
+        ]
+    }
+}
+```
+
+### 2.2 全量替换 EPP 实例池
+
+**基本信息**
+
+| 项目 | 值 | 说明 |
+| - | - | - |
+| 含义 | 全量替换 EPP 实例池（实例组 + 实例列表） | 该更新是全量替换语义，不支持仅添加部分数据；部署流程在实例变更（扩缩容、换机）后调用 |
+| 端点 | /epp-pool | - |
+| 版本 | v1 | - |
+| method | PATCH | - |
+
+**输入参数（Body）**
+
+| 参数名 | 类型 | 参数含义 | 必填 | 补充描述 | 合法性条件 |
+| - | - | - | - | - | - |
+| groups | []Group | 实例组列表 | Y | 全量替换当前实例池中的实例组与实例 | 必填；数组至少1个元素；组名非空、唯一 |
+| groups[].name | string | 实例组名 | Y | - | 必填；非空；池内唯一 |
+| groups[].instances | []Instance | 组内实例列表 | Y | 拒绝空组 | 必填；数组至少1个元素 |
+| groups[].instances[].id | string | 实例 id | Y | EPP 以 `-instance-id` 启动参数对应此值 | 必填；非空；池内全局唯一 |
+| groups[].instances[].host | string | 实例主机名或 IP | Y | IPv6 字面量不带括号 | 必填；非空；类型为 [Hostname](./00-common.md#公共参数类型) 或 IP |
+| groups[].instances[].port | int | 实例端口 | Y | - | 必填；类型为 [Port](./00-common.md#公共参数类型) |
+
+**约束**
+
+- 实例池名称由配置项 `RunTime.DefaultEPPInstancePoolName` 提供（默认值 `EPP.pool`），请求中无需传入 `name`。
+- `groups` 至少包含1个元素；组名非空、唯一。
+- `groups[].instances` 至少包含1个元素（拒绝空组）。
+- 每个实例的 `id` 非空，且池内全局唯一。
+- 每个实例的 `host` 非空，类型为 [Hostname](./00-common.md#公共参数类型) 或 IP（IPv6 字面量不带括号）。
+- 每个实例的 `port` 类型为 [Port](./00-common.md#公共参数类型)。
+- `(host, port)` 组合池内全局唯一（等价于旧 host:port 唯一语义）。
+- 每组实例数：生产环境每组恰 2 实例（主备）；测试环境允许单实例组（仅主、无备）；校验强度由部署形态配置项控制。
+
+**HTTP BODY参数示例**
+
+```json
+{
+    "groups": [
+        {
+            "name": "g1",
+            "instances": [
+                { "id": "epp-a", "host": "10.0.0.1", "port": 9002 },
+                { "id": "epp-b", "host": "10.0.0.2", "port": 9002 }
+            ]
+        },
+        {
+            "name": "g2",
+            "instances": [
+                { "id": "epp-c", "host": "10.0.0.3", "port": 9002 }
+            ]
+        }
+    ]
+}
+```
+
+**执行逻辑**
+
+1. 校验请求参数合法性（组名非空唯一、实例 id 池内全局唯一、`(host, port)` 池内全局唯一、host/port 格式、组规模）。
+2. 使用配置项 `DefaultEPPInstancePoolName` 定位 EPP 实例池。
+3. 全量替换实例池（`epp_instances` 表，实例组 + 实例列表）。
+4. 触发分配悬空自动修复：`/epp-pool` PATCH 后分配悬空（primary 实例已被移出池）时自动修复——① 组仍存在：同组剩余实例中重选 primary（不换组）；② 组已不存在（或组规模不再满足部署形态要求）：**跨组重分配**——以该 cluster 为目标对整个实例池重跑分配器选新组；池无可分配候选组时，清除该分配（cluster 进入未分配态，导出 server_data_conf 时降级为 `WRR` 并输出 error 日志，待容量恢复后自动修复路径重新分配）。
+5. 返回更新后的实例池详情。
+
+> **注意**：实例池变更不直接 bump `ConfigTopicEppData` topic（实例增减不改变 cluster→role 映射）；实例地址在生成 EPPAddr 时以 `net.JoinHostPort(host, strconv.Itoa(port))` 拼接为 `host:port`（IPv6 自动加括号），BFE 消费格式不变。
+
+**返回数据（Data内容）**
+
+同 [2.1 获取 EPP 实例池详情](#21-获取-epp-实例池详情)。
+
+**成功返回示例**
+
+同 [2.1 获取 EPP 实例池详情](#21-获取-epp-实例池详情)。
+
+---

--- a/design-docs/modifications/2026-09-08-epp-scheduling-integration/api-changes.md
+++ b/design-docs/modifications/2026-09-08-epp-scheduling-integration/api-changes.md
@@ -1,0 +1,360 @@
+# EPP 调度对接：API 接口变更说明
+
+## 1. 变更范围
+
+| 接口类型 | 变更内容 |
+|----------|----------|
+| InnerAPI | 新增 1 端点：`/configs/epp_data/config`（epp_config + assignment 合并导出）；server_data_conf 响应中 `GslbBasic.EPPAddr` 语义变为有序主备列表 |
+| OpenAPI | 新增 `/epp-pool`（GET/PATCH，替代实例自注册）、`epp-assignments`（2 端点查询与手工覆写）；既有 `/clusters` 新增可选字段 `balance_mode`（默认 `WRR`，可选 `EPP`）与 `epp_config`（EPP 模式必填） |
+| 既有接口 | 无破坏式变更；`/clusters` 仅新增可选字段（缺省行为与现状一致）；`pools.epp_server` 列保留（本期无消费方，后续版本清理） |
+
+新 InnerAPI 端点沿用通用约定（`InnerAPI接口定义/01-common.md`）：`Authorization: Token xxx`、`version` 增量同步（未变化返回 `Data: null`）、version 格式 `20060102150405`、错误响应包 `{ErrNum, ErrMsg, ...}`。鉴权为 `FeatureRoute + ActionExport`。
+
+---
+
+## 2. InnerAPI 新增端点
+
+注册于 `endpoints/innerapi_v1/endpoints.go`，清单编号续 `InnerAPI接口定义/02-interface-list.md`：
+
+| 序号 | 接口路径 | Method | 功能描述 | 特殊参数 | 鉴权 |
+|---|---|---|---|---|---|
+| 10 | `/configs/epp_data/config` | GET | 导出 EPP 配置（epp_config + assignment 全量视图，合并单端点） | `version` | `FeatureRoute + ActionExport |
+
+单 topic：`ConfigTopicEppData`（`model/iversion_control/version_control.go` 的 `ExportConfig` 框架，新 topic 零框架改动）。
+
+> **说明**：上游方案中的三个 InnerAPI 端点**不再实现**——`/epp/instances/register`、`/epp/instances/{id}/heartbeat` 由 OpenAPI `/epp-pool` 全量配置替代（§3.1），api 侧不做实例存活管理（详见 `design-changes.md` §5）；`/configs/epp_data/assignment/report` 取消，其消费者（就绪感知翻转、双活跃观测）均以 api 主动翻转分配为前提，与本设计（failover 由 BFE 滞回驱动）不符，P2 如需要就绪/健康信号届时统一设计。上游的 epp_config 与 assignment 两个导出端点合并为本端点（见 §2.1）。
+
+### 2.1 10. epp_data 导出（epp_config + assignment 合并）
+
+请求：`GET /inner-api/v1/configs/epp_data/config?version=00010101000000`
+
+返回：
+
+```json
+{
+    "ErrNum": 200,
+    "ErrMsg": "success",
+    "Data": {
+        "Version": "20260906120000",
+        "Config": {
+            "epp_config": {
+                "cluster-a": {
+                    "featureGates": ["flowControl"],
+                    "plugins": [
+                        { "name": "ep-discover", "type": "cluster-table-discovery", "parameters": { "clusterName": "cluster-a" } },
+                        { "name": "util-filter", "type": "utilization-filter",
+                          "parameters": { "conditions": [ { "metric": "kv-cache-utilization", "maxValue": 0.9 } ] } },
+                        { "name": "kv-scorer", "type": "kv-cache-utilization-scorer", "parameters": {} },
+                        { "name": "max-score", "type": "max-score-picker", "parameters": {} }
+                    ],
+                    "schedulingProfiles": [
+                        { "name": "default",
+                          "plugins": [
+                            { "pluginRef": "util-filter" },
+                            { "pluginRef": "kv-scorer", "weight": 1.0 },
+                            { "pluginRef": "max-score" }
+                          ] }
+                    ],
+                    "dataLayer": { "discovery": { "endpoints": { "pluginRef": "ep-discover" } } },
+                    "flowControl": { "defaultRequestTTL": "30s", "noEndpointRequestTTL": "10m" }
+                }
+            },
+            "assignment": {
+                "cluster-a": { "primary": "epp-a", "standby": "epp-b" },
+                "cluster-b": { "primary": "epp-b", "standby": "epp-a" },
+                "cluster-c": { "primary": "epp-c", "standby": null }
+            }
+        }
+    },
+    "WorkMode": "ModeNormal"
+}
+```
+
+**`epp_config` 段**：
+
+- `Config.epp_config` 为 `map[cluster名]EndpointPickerConfig`，由 OpenAPI 写入的简化 `epp_config`（§3.2）在导出时**确定性编译**而来（编译规则见 §3.2.1），出厂即合法。
+- 范围：全部 `balance_mode=EPP` 的 cluster。OpenAPI 校验保证 EPP 模式 cluster 的 `epp_config` 必填（§3.2），因此导出结果中 EPP cluster 必然有配置。
+
+**`assignment` 段（全量视图）**：
+
+- `Config.assignment` 为 `map[cluster名]{primary, standby}`，**所有 EPP 实例返回完全相同的内容**（同一 version 快照）。
+- `primary` / `standby` 为 `/epp-pool` 中配置的实例 id；单实例组（无备）时 `standby` 为 `null`。
+- **EPP 侧消费方式**：以自身 `-instance-id`（须与 `/epp-pool` 中某实例 id 一致）逐 cluster 匹配——`primary == 本实例 id` → 本实例为该 cluster 的 primary；`standby == 本实例 id` → standby；均未命中 → 跳过该 cluster。
+- 全量视图的附带收益：EPP 可获知同组 peer 实例 id（如备 Cell 建联、双活跃自检，后续如需）。
+- 异常态：`epp_config` 中存在但 `assignment` 中无条目的 cluster = 未分配（server_data_conf 导出会拒绝该状态），EPP 侧应本地告警、不为该 cluster 建 cell。
+
+**合并下发的理由**：数据量极小（两段配置 × 几十个 cluster），单 topic 全量重发代价可忽略；cluster 创建、模式变更、分配变更往往同时改变两段，单 topic 天然保证同一 version 快照，消除跨 topic 版本偏移；EPP 轮询端点减半。
+
+### 2.2 server_data_conf：`EPPAddr` 有序主备语义
+
+按《server-data-conf修改方案-EPPAddr字段语义.md》§2 草案，在 `InnerAPI接口定义/server-data-conf.md` 新增 §3.3：`GslbBasic.EPPAddr` 为有序列表，`[0]`=主、`[1]`=备。EPP 模式 cluster 无有效分配时**降级导出**：该 cluster `BalanceMode` 置为 `WRR`、不生成 `EPPAddr`，同时输出 error 级日志（含 cluster 名与原因），不阻塞整份 server_data_conf 下发。生成逻辑改造见 `design-changes.md` §4.3。
+
+---
+
+## 3. OpenAPI 变更（管理面）
+
+沿用 openapi_v1 现有鉴权与 `xreq` 请求/响应模式。
+
+### 3.1 /epp-pool（EPP 实例池管理，替代实例自注册）
+
+单例资源，模式对齐 `/alb-pool`（参考 `design-docs/api-define/OpenAPI接口定义/alb-pool.md`）：池名由配置项提供（建议 `RunTime.DefaultEPPInstancePoolName`，默认值如 `EPP.pool`），请求中无需传入 `name`。
+
+**实例 id 约定（部署形态）**：EPP 以 StatefulSet 部署，实例 id = **Pod hostname**（EPP 的 `-instance-id` 缺省值即 hostname，同组副本共享完全相同的启动参数，无需按实例差异化配置）；`/epp-pool` 登记时实例 id 取 pod 名（如 `epp-0`/`epp-1`），部署流程 reconcile 池时从 StatefulSet pod 名生成 PATCH 内容。前提：StatefulSet 保证 hostname 稳定唯一（不可用随机名的 Deployment）；非 K8s 部署显式传 `-instance-id`。
+
+**数据模型**：
+
+```json
+{
+    "name": "EPP.pool",
+    "groups": [
+        {
+            "name": "g1",
+            "instances": [
+                { "id": "epp-a", "host": "10.0.0.1", "port": 9002 },
+                { "id": "epp-b", "host": "10.0.0.2", "port": 9002 }
+            ]
+        }
+    ]
+}
+```
+
+| 端点 | Method | 说明 |
+|---|---|---|
+| `/api/v1/epp-pool` | GET | 获取 EPP 实例池详情（实例组 + 实例列表） |
+| `/api/v1/epp-pool` | PATCH | 全量替换实例池（实例组 + 实例列表）；部署流程在实例变更后调用 |
+
+**字段与约束**：
+
+| 字段 | 类型 | 必填 | 说明 | 合法性条件 |
+|------|------|------|------|------------|
+| `groups` | []Group | Y | 实例组列表 | 至少 1 个元素；组名非空、唯一 |
+| `groups[].instances` | []Instance | Y | 组内实例列表 | 至少 1 个元素 |
+| `groups[].instances[].id` | string | Y | 实例 id（EPP 以 `-instance-id` 启动参数对应此值） | 非空；**池内全局唯一** |
+| `groups[].instances[].host` | string | Y | 实例主机名或 IP（IPv6 字面量不带括号） | 非空；类型为 [Hostname](./00-common.md#公共参数类型) 或 IP |
+| `groups[].instances[].port` | int | Y | 实例端口 | 类型为 [Port](./00-common.md#公共参数类型) |
+| 地址唯一性 | - | - | 实例地址唯一性 | `(host, port)` 组合**池内全局唯一**（等价于旧 host:port 唯一语义） |
+| 组规模 | - | - | 每组实例数 | 生产环境每组恰 2 实例（主备）；测试环境允许单实例组（仅主、无备）；由部署形态配置项控制校验强度 |
+
+**执行逻辑（PATCH）**：校验 → 全量替换 `epp_instances` 表 → 返回更新后的池详情。实例池变更不直接 bump `ConfigTopicEppData` topic（实例增减不改变 cluster→role 映射）。
+
+**存储与下发**：`epp_instances` 表存 `host`、`port` 两列；生成 EPPAddr 时以 `net.JoinHostPort(host, strconv.Itoa(port))` 拼接为 `host:port`（IPv6 自动加括号），BFE 消费格式不变。
+
+**实例状态说明**：实例无 `status`/`last_heartbeat` 字段——存活感知在 BFE 侧（EPPAddr 连接滞回），api 侧不做存活标记（详见 `design-changes.md` §5）。
+
+### 3.2 既有 `/clusters` 接口变更：`balance_mode` 与 `epp_config`
+
+**变更原因**：
+
+- 现状 cluster 的 `BalanceMode` 由 SubCluster 的 pool `Role` 派生（`model/icluster_conf/cluster.go:295-302` 的 `getBalanceMode`），而设置 `Role=EPP` 的旧 `/instance-pools` 端点已被移除（`endpoints/openapi_v1/product_pool/endpoints.go` 注册表为空），**没有任何 OpenAPI 可以为 cluster 开启 EPP**。
+- EPP 调度配置（epp_config）是 per-cluster 配置且与均衡模式强耦合：EPP 模式必须有调度配置，非 EPP 模式不应有。因此不引入独立的 epp-picker-config CRUD 域，**随 `/clusters` 一并配置**，在 cluster 写入时强制校验。
+
+**变更内容**：`POST /clusters` 与 cluster 更新接口（`PUT /clusters/{name}`）请求体新增两个可选字段：
+
+| 参数名 | 类型 | 必填 | 说明 | 合法性条件 |
+|--------|------|------|------|------------|
+| `balance_mode` | string | 条件必填 | 集群均衡模式。`WRR`：BFE 本地加权轮询；`EPP`：由 EPP 调度器接管后端选择 | 枚举：`WRR`（默认）、`EPP` |
+| `epp_config` | object | 条件必填 | EPP 调度配置（**简化用户形态**：调度档位 + 少量调优参数，见 §3.2.1）；api 导出时确定性编译为完整 `EndpointPickerConfig` | `balance_mode=EPP` 时**必填**且通过字段校验；`balance_mode=WRR` 时可选（传入则保留并做格式校验，但不编译、不导出，见下"休眠语义"） |
+
+请求体示例（EPP 模式 cluster）：
+
+```json
+{
+    "name": "cluster-a",
+    "llm_config": { "provider": "p1", "models": ["m1"] },
+    "balance_mode": "EPP",
+    "epp_config": {
+        "scheduling_profile": "balanced",
+        "kv_cache_utilization_max": 0.9,
+        "flow_control": {
+            "max_requests": 1000,
+            "queue_ttl": 30,
+            "no_endpoint_queue_ttl": 600,
+            "enable_eviction": false
+        }
+    }
+}
+```
+
+**取值规则**：
+
+| `balance_mode` | `epp_config` | 行为 |
+|----------------|-----------------|------|
+| 缺省 / `WRR` | 缺省 | 与现状完全一致：创建 `Role=COMMON` 实例池，导出 `GslbBasic.BalanceMode=WRR`，不进 EPP 下发范围 |
+| 缺省 / `WRR` | 携带非空值 | 允许：保留并做格式校验，但不编译、不导出（休眠），再切回 `EPP` 时继续生效 |
+| `EPP` | 必填 | 导出 `GslbBasic.BalanceMode=EPP`；`GslbBasic.EPPAddr` 由实例组分配模型生成（有序 `[主, 备]`，见 `design-changes.md` §4.3）；epp_config 随集群写入即生效（epp_data topic 在下一次导出时由 MD5 签名机制自然 bump）；纳入 assignment 下发范围；无有效分配时导出**降级**：该 cluster `BalanceMode` 置为 `WRR`、不生成 `EPPAddr`，同时输出 error 级日志 |
+
+**约束与校验**：
+
+- `balance_mode=EPP` 的 cluster 不创建 `Role=COMMON` 的 BFE 实例池（与 WRR 池区分），但**池实例列表照常同步 provider `instance_pool`**——EPP 的 cluster-table-discovery 经 cluster_table 导出发现推理后端，EPP 故障时 BFE 回退本地 WRR 也依赖该列表；`BalanceMode=EPP` 下 BFE 不做本地 WRR。`llm_config` 校验照常（provider/models/keys 与模式无关）。
+- `balance_mode` 更新规则：允许 `WRR → EPP`（须同时提供合法 `epp_config`）；`EPP → WRR` 仅改 `balance_mode` 即可——`epp_config` 与分配记录保留（休眠：不编译、不导出），再切回 `EPP` 时原配置与原分配继续生效（分配如已悬空由 `/epp-pool` 变更时的自动修复处理）。**校验规则：`epp_config` 非空即须通过字段校验，与 `balance_mode` 无关**（休眠保留的配置同样保持合法）。
+- 生效语义：`epp_config` 仅在 `balance_mode=EPP` 时编译下发；停用 EPP 调度 = 将 `balance_mode` 改回 `WRR`，**无需清空** `epp_config`。
+- 响应（GET/List）中返回 `balance_mode` 与 `epp_config` 字段。
+
+**缺省语义**：两字段均可选，缺省即 `WRR`、无 epp_config；新列带默认值/可空，存量数据无需迁移。
+
+#### 3.2.1 `epp_config` 字段详细说明
+
+`epp_config` 采用**简化用户形态**设计：不直接暴露 llm-d `EndpointPickerConfig` 的插件声明细节，用户以"调度档位 + 少量一等公民调优参数"表达意图，由 ai-gateway-api 在导出时**确定性编译**为完整 `EndpointPickerConfig`（编译规则见下表，出厂即合法）。本期不提供原样透传的高级模式；如未来出现自定义插件链需求，届时再开放。
+
+**命名**：字段名取 `epp_config` 而非 llm-d 的 `picker_config`——简化形态已不再是 picker 配置的原始结构，叫 `picker_config` 会把实现命名泄漏到用户侧；`epp_config` 与 `balance_mode=EPP` 语义对称（开启 EPP ⇔ 提供 EPP 配置），也为未来容纳非 picker 类的 per-cluster EPP 设置（如超时、重试）预留空间。存储列、导出段、Go 字段同名（`clusters.epp_config` / `epp_config` 段 / `EppConfig`）。
+
+**字段说明**：
+
+| 字段 | 类型 | 必填 | 默认值 | 说明 | 合法性条件 |
+|------|------|------|--------|------|------------|
+| `scheduling_profile` | string | 否 | `balanced` | 调度策略档位：调度激进程度/优化目标的预设组合 | 枚举：`latency-first`（低延迟优先：队列等待权重最高）、`balanced`（均衡）、`throughput-first`（吞吐优先：KV cache 亲和最高） |
+| `cache_affinity` | string | 否 | `medium` | scorer 权重覆盖项，显式指定 KV cache 亲和强度 | 枚举：`low` / `medium` / `high`；缺省（未显式设置）= `medium`，语义为**跟随 `scheduling_profile`，不覆盖其权重**；显式设置后覆盖 `scheduling_profile` 的 scorer 权重 |
+| `prefix_cache_affinity` | bool | 否 | `true` | 前缀缓存亲和（`prefix-cache-scorer`）：相同 prompt 前缀的请求经前缀哈希匹配**尽力收敛**到同一后端，提升 KV cache 复用；零参数、自主学习（`approx-prefix-cache` producer）；**软亲和，不保证一定命中匹配后端**（见下"亲和语义"） | bool |
+| `session_affinity_enabled` | bool | 否 | `false` | 会话亲和开关（`session-affinity-scorer`，session_id 策略）：开启后同一 session 的请求**尽力粘住**同一后端（有 binding 状态，亲和强度高于 prefix；但仍受 utilization-filter 与加权总分影响，非硬路由），绑定端点摘除后自动迁移重粘 | bool |
+| `session_affinity_header` | string | 条件必填 | - | session id 来源请求头（如 `x-session-id`），scorer 从该 header 解析 session id；`enabled=false` 时保留但不生效（休眠） | `session_affinity_enabled=true` 时**必填**（非空 HTTP header 名）；`enabled=false`/缺省时可保留（做格式校验，不生效） |
+| `kv_cache_utilization_max` | float | 否 | `0.9` | 端点过滤阈值：KV cache 利用率超过该值的端点被过滤 | `(0, 1]` |
+| `flow_control` | object | 否 | - | 流控参数；缺省则不下发流控段（EPP 用系统默认） | 见下表 |
+
+**`flow_control` 子字段**：
+
+| 字段 | 类型 | 必填 | 默认值 | 说明 | 合法性条件 |
+|------|------|------|--------|------|------------|
+| `max_requests` | int | 否 | 不限 | 全局并发上限（跨全部优先级带）；`-1` 为显式"不限"，用于在更新中明确恢复不限（消除"缺省"与"保留原值"的合并语义二义） | 取值 `>0` 或 `-1`；缺省表示不限 |
+| `queue_ttl` | int | 否 | 缺省由 EPP 决定（llm-d 默认 60 秒） | 池**有端点**时的排队预算（**单位：秒**），超期以可重试背压错误拒绝 | 取值 ≥ 0 的整数；`0` 为显式禁用驱逐 |
+| `no_endpoint_queue_ttl` | int | 否 | 跟随 `queue_ttl` | 池**无端点**（冷启动扩容）时的排队预算（**单位：秒**），regime 切换时重新起算 | 同 `queue_ttl` |
+| `enable_eviction` | bool | 否 | `false` | 需求驱动驱逐：高优先级被饱和阻塞时终止负优先级在飞请求回收容量 | bool |
+
+**流控实现说明**（llm-d flow controller，`flowcontrol/`）：全部由 EPP 进程内实现、状态为本地内存，无外部存储——请求先进入 per-pool（≈per cluster）**优先级队列**（并发安全 heap，按优先级带排序，超 TTL 后台 sweep 拒绝），单 goroutine processor 每周期检查在飞计数是否达 `max_requests` ceiling，有空位才调度到后端，响应完成归还额度；`enable_eviction` 开启后 HoL 阻塞时可经 ext_proc ImmediateResponse 驱逐负优先级在飞请求。failover 切换后队列与在飞计数不保留、新 primary 从零开始（排队中请求由 BFE 侧断连/重试处理），与亲和状态冷启动同理。各优先级带另有 band 级限额，本期不暴露、用系统默认。
+
+**缺省语义与存储约定**：`cache_affinity` 缺省值为 `medium`，语义为"跟随 `scheduling_profile`、不覆盖其权重"；仅当用户在请求中**显式设置** `low` / `medium` / `high` 时才作为覆盖项生效（显式 `medium` = 覆盖为 (0.6, 0.6)，与缺省行为不同）。为区分这两种状态，存储保留用户原始 JSON——未显式携带的字段不落盘、GET 回读与写入一致；默认值只体现在导出编译时。
+
+**编译规则**（api 导出时把上述简化配置确定性展开为 `EndpointPickerConfig`，规则固化在代码中并单测覆盖）：
+
+| 简化字段 | 编译为 |
+|----------|--------|
+| 固定部分 | 注入 `cluster-table-discovery` 端点发现插件（`clusterName` 取本 cluster）、`utilization-filter`（阈值取 `kv_cache_utilization_max`）、`kv-cache-utilization-scorer` + `queue-scorer` 两个 scorer、`max-score-picker` picker、`openai-parser` |
+| `scheduling_profile` → scorer 权重 (kv, queue) | `latency-first` → (0.2, 1.0)；`balanced` → (1.0, 0.5)；`throughput-first` → (1.0, 0.2) |
+| `cache_affinity` → scorer 权重 (kv, queue)（覆盖 profile，仅在显式设置时生效；缺省 `medium` 不覆盖，跟随 `scheduling_profile`） | `low` → (0.2, 1.0)；`medium` → (0.6, 0.6)；`high` → (1.0, 0.2) |
+| `prefix_cache_affinity=true`（缺省即 true） | scorer 链追加 `prefix-cache-scorer`（权重固定 1.0）；`approx-prefix-cache` producer 为 EPP 默认注册，无需配置；`false` 则不注入 |
+| `session_affinity_enabled=true` 时 | scorer 链追加 `session-affinity-scorer`（strategy=session_id，`sessionIdConfig.sources=[{header: <session_affinity_header>}]`，权重固定 1.0）；`false`/缺省不注入；无 session header 的请求 scorer 弃权，不受影响 |
+
+**亲和类 scorer 与档位权重的关系**：`prefix-cache-scorer` / `session-affinity-scorer` 是**特性开关**（开/关 + 固定权重 1.0），与档位权重正交——`scheduling_profile` / `cache_affinity` 只调节 (kv, queue) 两个基础 scorer 的权重，不影响亲和 scorer。亲和 scorer 均为软打分：无前缀匹配 / 无 session header 时弃权，由基础 scorer 决定选端点，因此固定权重 1.0 对普通流量无副作用。
+
+**亲和语义（重要，避免误解为硬路由）**：调度为"加权求和 + 最高分选取"（llm-d `scheduler_profile.go`：端点总分 = Σ scorer输出[0,1] × 权重，`max-score-picker` 取总分最高者，同分确定性轮转让位），且 filter 先于打分执行。因此前缀/session 亲和是**尽力收敛**，以下情况会打破亲和、把请求调度到非匹配后端：
+
+- 匹配后端被 `utilization-filter` 过滤（KV cache 利用率超 `kv_cache_utilization_max`）——淘汰后请求必然去其他端点；
+- 匹配率不高（只匹配 prompt 一小段），而另一后端 kv/queue 加权总分反超；
+- 首次请求（无匹配数据）或 EPP 重启亲和数据未重建时，所有端点亲和分均为 0，退化为纯 kv/queue 打分。
+
+这是期望行为：亲和让高匹配后端"通常胜出"，负载/利用率因素仍可打断亲和，避免热点后端被拖死。需要强粘性的场景应使用 `session_affinity_enabled`（有 binding 状态，比 prefix 稳定），而非依赖 prefix 收敛。
+
+**亲和状态存放**：prefix 亲和索引是 EPP 实例**本地内存**中的 per-endpoint LRU（approx-prefix-cache producer 自学习写入，scorer 从 endpoint attribute 读取），**无需 Redis 等外部存储**。一个 cluster 同一时刻仅 primary EPP 做调度决策，本地索引即完备；failover/重启后新 primary 冷启动，经少量请求重新收敛（ai-gateway-epp SC11 已验证），与软亲和语义一致。会话亲和 binding 状态同为 EPP 本地内存。
+
+**运行时指标来源**：kv/queue scorer 消费的利用率与队列指标由 EPP **周期性 HTTP 抓取各推理后端 `/metrics`（Prometheus 格式）**获得（`RefreshMetricsInterval` 刷新、本地内存缓存），ai-gateway-epp `injectDefaults` 默认自动注入指标 source/extractor，**同样无需外部存储**。某后端指标不可用时相应得分中性化（kv 得分视为 1.0、filter 不生效），调度正常退化。EPP 全链路的对外依赖仅两类无状态拉取：控制面配置（epp_data / cluster_table）与数据面指标（后端 /metrics）。
+| `flow_control` 存在时 | 生成 `flowControl` 段：`max_requests`→`maxRequests`、`queue_ttl`→`defaultRequestTTL`、`no_endpoint_queue_ttl`→`noEndpointRequestTTL`、`enable_eviction`→`enableEviction`；`featureGates` 追加 `flowControl`。秒数由 api 在编译时转为 Go duration 下发（如 `30` → `30s`、`600` → `10m0s`）。特例：`max_requests` 缺省或为 `-1`（不限）时**不生成** `maxRequests` 字段（llm-d 缺省即不限） |
+
+**校验分工**：
+
+| 阶段 | 校验方 | 行为 |
+|------|--------|------|
+| 简化字段校验（枚举、数值范围、秒数取值范围） | ai-gateway-api | 不合法拒绝提交（422），全部 api 侧可强制 |
+| 编译产物结构 | ai-gateway-api generator（确定性模板，单测覆盖） | 模板自身保证引用完整、DAG 无环，正常路径不出现编译失败 |
+| 深度校验（插件存在性、层序约束等） | EPP 编译期 | 仅作为防御兜底；万一失败该 cluster 沿用旧引擎，不影响其他 cluster |
+
+### 3.3 域：epp-assignments（分配查询与手工覆写）
+
+| 端点 | Method | 说明 |
+|---|---|---|
+| `/api/v1/epp-assignments` | GET | 分配全量视图（per-cluster 展开 + 未分配/空闲清单，见下） |
+| `/api/v1/epp-assignments/{cluster}` | PUT | 手工覆写单个 cluster 的分配 `{group_name, primary_instance_id}`（运维干预入口，触发 server_data_conf version bump） |
+
+说明：分配由**分配器自动生成**（触发时机与算法见 `design-changes.md` §4.2：cluster 进入 EPP 模式时自动选组选主、`/epp-pool` 变更后自动修复悬空分配），本域提供查询视图与手工覆写（运维兜底）；分配输入（实例组列表）来自 `/epp-pool`（§3.1）；手工覆写校验 `primary_instance_id` 必须存在于对应组的实例列表中，且与 standby 实例不同地址。
+
+#### 3.3.1 GET `/api/v1/epp-assignments` 响应详情
+
+请求：`GET /api/v1/epp-assignments`（可选查询参数 `cluster=<name>` 过滤单个 cluster）
+
+成功返回示例：
+
+```json
+{
+    "ErrNum": 200,
+    "ErrMsg": "success",
+    "Data": {
+        "clusters": [
+            {
+                "cluster": "cluster-a",
+                "group": "g1",
+                "primary":   { "id": "epp-a", "host": "10.0.0.1", "port": 9002 },
+                "standby":   { "id": "epp-b", "host": "10.0.0.2", "port": 9002 }
+            },
+            {
+                "cluster": "cluster-b",
+                "group": "g1",
+                "primary":   { "id": "epp-b", "host": "10.0.0.2", "port": 9002 },
+                "standby":   { "id": "epp-a", "host": "10.0.0.1", "port": 9002 }
+            },
+            {
+                "cluster": "cluster-c",
+                "group": "g2",
+                "primary":   { "id": "epp-c", "host": "10.0.0.3", "port": 9002 },
+                "standby":   null
+            }
+        ],
+        "unassigned_clusters": ["cluster-d", "cluster-e"],
+        "idle_groups": ["g3"]
+    }
+}
+```
+
+**字段说明**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `clusters` | []object | 全部 `balance_mode=EPP` 的 cluster 的分配展开视图（含未分配 cluster，见下） |
+| `clusters[].cluster` | string | cluster 名 |
+| `clusters[].group` | string | 分配的实例组名；未分配时为 `null` |
+| `clusters[].primary` | object \| null | 主实例；未分配时为 `null`。结构同 /epp-pool 实例：`{id, host, port}` |
+| `clusters[].standby` | object \| null | 备实例；**读时展开**：`epp_assignments` 只存 `primary_instance_id`，standby = 同组中除 primary 外的实例；单实例组或未分配时为 `null` |
+| `unassigned_clusters` | []string | `balance_mode=EPP` 但 `epp_assignments` 无有效记录的 cluster 名列表。这些 cluster 导出 server_data_conf 时**降级为 `WRR`**（api 同时输出 error 日志），属需尽快处理的异常态，单独列出便于巡检 |
+| `idle_groups` | []string | 实例池中未承担任何 cluster 分配的组名列表（组内实例均未作为 primary 出现；备角色不计入占用）。扩容新组后、完成分配前会出现在此列表 |
+
+**语义规则**：
+
+- 视图是 `epp_assignments`（cluster→{group, primary}）与 `epp_instances`（/epp-pool）的**读时 join**，不引入冗余存储；两者不一致时（如 primary 指向的实例已被从池中移除）该 cluster 标记为异常：`primary` 返回 null 并计入 `unassigned_clusters`，同时在 `clusters[]` 该条目标记 `"degraded": true`。
+- `clusters` 默认返回全部 EPP 模式 cluster（含未分配）；传 `cluster=<name>` 时只返回该 cluster（`balance_mode != EPP` 的 cluster 返回 404 语义错误）。
+- 实例在多个 cluster 间互为主备（如 `epp-a`/`epp-b` 同时担任 cluster-a 与 cluster-b 的主备）是**合法**的——分配以 cluster 为单位，不做组↔cluster 的一对一约束。
+
+#### 3.3.2 PUT `/api/v1/epp-assignments/{cluster}` 请求详情
+
+请求体：
+
+```json
+{
+    "group_name": "g1",
+    "primary_instance_id": "epp-a"
+}
+```
+
+| 字段 | 类型 | 必填 | 说明 | 合法性条件 |
+|------|------|------|------|------------|
+| `group_name` | string | Y | 目标实例组 | 必须存在于 `/epp-pool` 当前实例池中 |
+| `primary_instance_id` | string | Y | 主实例 id | 必须存在于 `group_name` 组的实例列表中 |
+
+执行逻辑：校验 → 写入/更新 `epp_assignments`（cluster 唯一键 upsert）→ bump server_data_conf version（EPPAddr 下次导出即带出；epp_data topic 在下一次导出时由 MD5 签名机制自然 bump）→ 返回更新后的该 cluster 分配视图（结构同 §3.3.1 `clusters[]` 元素）。
+
+约束：生产组覆写后应保持每组 2 实例（standby 自动为组内另一实例）；`EPP → WRR` 反向变更（§3.2）后分配记录休眠保留，再切回 `EPP` 时继续生效（如分配已悬空由自动修复处理）。
+
+---
+
+## 4. 文档变更
+
+| 位置 | 变更 |
+|------|------|
+| `design-docs/api-define/InnerAPI接口定义/` | 新增 `epp-data.md`（合并端点契约，格式照 `cluster-table.md`）；`server-data-conf.md` 增加 §3.3；更新 `02-interface-list.md`、`README.md` 索引 |
+| `design-docs/api-define/OpenAPI接口定义/` | 新增 `epp-pool.md`（格式照 `alb-pool.md`）、`epp-assignments.md`；`clusters.md` 增加 `balance_mode`、`epp_config` 字段定义与校验规则 |
+
+---
+
+## 5. 边界语义
+
+| 场景 | 行为 |
+|------|------|
+| 单实例测试组 | EPPAddr 仅 `[主]`（`standby: null`）；主失联时 BFE 降级本地均衡（api 侧无动作） |
+| EPP 模式 cluster 无有效分配 | assignment 段无该 cluster 条目；server_data_conf 导出时该 cluster **降级为 `WRR`**（不生成 EPPAddr），同时 api 输出 error 级日志，不阻塞整份下发 |
+| `BalanceMode != EPP` 的 cluster | 不进 epp_config / assignment（EPP 侧对 unknown pool 告警，属 EPP 侧职责） |

--- a/design-docs/modifications/2026-09-08-epp-scheduling-integration/change-summary.md
+++ b/design-docs/modifications/2026-09-08-epp-scheduling-integration/change-summary.md
@@ -1,0 +1,64 @@
+# EPP 调度对接（ai-gateway-api 控制面改造）变更摘要
+
+## 1. 背景
+
+目标架构为 **ai-gateway-epp（多 cluster 调度器）+ BFE（ext-proc 接入）**。在该架构下，ai-gateway-api 需要承担三个新职责：
+
+1. **EPP 配置下发**：新增 `epp_data` InnerAPI，统一下发 epp_config（调度配置）与 assignment（实例角色全量视图），version 增量同步。
+2. **EPP 实例组分配与主备下发**：EPP 以"实例组（每组 2 实例互为主备）"为部署单元，ai-gateway-api 为每个 cluster 分配 `{group, primary}`，并翻译为 BFE 消费的 `GslbBasic.EPPAddr` 有序列表（`[0]`=主、`[1]`=备），随 server_data_conf 下发。
+3. **EPP 实例池管理**：实例与实例组由 OpenAPI `/epp-pool` 全量配置（参考 `/alb-pool` 单例模式），替代 InnerAPI 注册/心跳方式。
+
+上游改造方案见 `document-ai-gateway/迭代系统设计/v0.6/EPP支持/ai-gateway-api/ai-gateway-api改造方案-EPP调度对接.md`。BFE 侧改造见 `bfe/docs/zh_cn/modifications/2026-09-06-epp-ai-gateway-integration/design-changes.md`。EPP 侧改造见 `ai-gateway-epp/docs/zh_cn/modifications/2026-09-08-epp-scheduling-integration/`。
+
+## 2. 目标
+
+- 在 OpenAPI `/clusters` 上新增 `balance_mode` 参数（默认 `WRR`，可选 `EPP`），作为 cluster 开启 EPP 模式的显式配置入口（现状为 SubCluster Role 派生，且设置 Role=EPP 的入口已被移除，无 OpenAPI 可达路径）。
+- 在 OpenAPI `/clusters` 上新增 `epp_config` 字段（per-cluster，**简化用户形态**：调度档位 + 少量一等公民调优参数，api 导出时确定性编译为 llm-d `EndpointPickerConfig`）：`balance_mode=EPP` 时**必填**并生效；`WRR` 时可保留但休眠（不编译、不导出），EPP ↔ WRR 切换不丢配置；不引入独立的 epp-picker-config CRUD 域；本期不提供原样透传的高级模式。
+- 新增 OpenAPI `/epp-pool`（`GET` 详情 + `PATCH` 全量替换），维护 EPP 实例池（实例组 + 实例列表），**替代** InnerAPI `register` / `heartbeat` 自注册方式。
+- 新增 `GET /inner-api/v1/configs/epp_data/config` 导出端点：epp_config 与 assignment **合并下发**（单 topic、单 version 快照），assignment 为全量视图（所有 EPP 实例返回相同内容，由 EPP 按自身 id 选取角色）。
+- 新增 EPP 实例组/分配数据模型（`epp_instances`、`epp_assignments` 两张新表），`EPPAddr` 生成由"静态派生"改为"分配驱动"（旧 EPPServer 派生逻辑删除）。
+- 新增 OpenAPI 管理面：`epp-assignments` 查询与手工覆写。
+
+## 3. 范围
+
+| 范围 | 说明 |
+|------|------|
+| 涉及仓库 | `ai-gateway-api` |
+| 主要模块 | `endpoints/innerapi_v1/`、`endpoints/openapi_v1/`（新增 epp-pool / epp-assignments 域）、`model/iversion_control`、`model/icluster_conf`、`model/iroute_conf`、`model/epp_pool/`（新增）、`storage/rdb/epp_pool/`（新增） |
+| 接口契约 | InnerAPI 新增 1 端点（`epp_data/config`）；OpenAPI 新增 `/epp-pool`（2 端点）、`epp-assignments`（2 端点）；既有 `/clusters` 新增可选字段 `balance_mode` 与 `epp_config`（缺省行为不变） |
+| 数据库 | 新增 `epp_instances`、`epp_assignments` 两张表；`clusters` 表新增 `balance_mode` 列（默认 `WRR`）与 `epp_config` 列（JSON，可空） |
+| BFE 影响 | server_data_conf 中 EPP 模式 cluster 的 `GslbBasic.EPPAddr` 变为有序主备列表（`[0]`=主、`[1]`=备） |
+| EPP 影响 | EPP 经单端点增量拉取 epp_config + assignment 全量视图（以 `-instance-id` 匹配 primary/standby 得出自身角色）；prefix/session 亲和状态为 EPP 本地内存（LRU/binding），**无外部存储依赖**，failover 后重新收敛；无 EPP → api 方向的上报义务。EPP 无全局内存上限配置，内存边界靠容器/Pod 限额兜底；prefix 亲和 LRU 每后端有界（容量 = 后端 GPU block 数（autoTune）或默认 31250 blocks，约 5MB/后端），随集群后端数线性增长，是 EPP 内存主要消费者 |
+
+## 4. 关键决策
+
+| 决策 | 说明 |
+|------|------|
+| cluster 显式 `balance_mode` 参数 | OpenAPI `/clusters` 新增 `balance_mode`（默认 `WRR`，枚举 `WRR`/`EPP`），替代现状的 SubCluster Role 派生（`getBalanceMode`）。EPP 模式不再是"绑了 EPP pool 的副作用"，而是 cluster 的一等配置；epp_config / assignment 下发范围、EPPAddr 生成都以该字段为准。 |
+| epp_config 随 `/clusters` 配置（替代独立 CRUD 域），采用简化用户形态 | 与上游方案"独立建表 + 独立 CRUD"不同：epp_config 是 per-cluster 配置且与 `balance_mode` 强耦合（EPP⇒必填并生效、WRR⇒可保留休眠），随 cluster 生命周期由 `POST/PUT /clusters` 一并创建、校验、更新，存储于 `clusters.epp_config` 列（JSON），GET 回读与写入一致。与上游方案"原样透出 llm-d `EndpointPickerConfig`"也不同：那是插件实例/引用图/DAG 层的内部实现抽象，用户侧无法正确组装、api 侧只能做结构校验；改为"档位（latency-first/balanced/throughput-first）+ 少量一等公民参数（cache_affinity、kv_cache_utilization_max、prefix_cache_affinity、session_affinity_enabled、session_affinity_header、flow_control）"，由 api 在 epp_data 导出时**确定性编译**为完整 `EndpointPickerConfig`（固定注入 cluster-table-discovery / utilization-filter / scorer / max-score-picker / openai-parser，档位映射 scorer 权重），出厂即合法。本期不提供原样透传的高级模式。校验在 cluster 写入时强制，杜绝"EPP cluster 无调度配置"的悬空状态；生效语义 = `balance_mode=EPP` 时编译下发、`WRR` 时休眠保留（停用 EPP 调度只需改回 `WRR`，无需清空配置）。 |
+| epp_config 与 assignment 合并单端点下发 | 与上游方案"两个端点 + 两个独立 topic"不同：合并为 `GET /configs/epp_data/config`、单 topic `ConfigTopicEppData`。理由：数据量极小，全量重发代价可忽略；cluster 创建/分配变更往往同时改变两段，单 topic 天然保证两者同一 version 快照，消除跨 topic 版本偏移；EPP 轮询端点减半。 |
+| assignment 全量下发（替代 per-instance 视图） | 与上游方案"按 `instance` 参数返回本实例视图"不同：所有 EPP 实例返回**完全相同**的 assignment（cluster → {primary, standby}），由 EPP 以 `-instance-id` 匹配得出自身角色。优点：全部实例共享同一 version 快照；api 无需校验实例身份，`instance` 参数、"未知实例 4xx"等边缘消失；EPP 顺带获知同组 peer，为备 Cell 建联预留信息。 |
+| `/epp-pool` 替代实例自注册 | 不引入 InnerAPI register/heartbeat：EPP 实例与实例组由 OpenAPI `/epp-pool` 全量配置（单例资源，参考 `/alb-pool` 的 `GET` + `PATCH` 全量替换模式）。实例列表是部署事实的静态登记，由部署流程在实例变更后调用 PATCH 维护；实例身份即池中实例 id，EPP 以 `-instance-id` 启动参数（与池中 id 一致）在 assignment 全量视图中定位自身。 |
+| P0 阶段 api 不感知实例存活 | 无心跳、无失联标记、无就绪上报：实例存活与 failover 由 BFE 侧 EPPAddr 连接滞回判断驱动，api 侧只保证配置与分配视图稳定下发。上游方案的 `assignment/report` 端点同步取消（其消费者均以 api 主动翻转为前提，与本设计不符；P2 如需要就绪/健康信号，届时在"上报通道 / 心跳 / BFE 健康回调"中统一设计）。 |
+| 复用 ExportConfig 版本框架 | 新 topic `ConfigTopicEppData` 走既有"生成→MD5 签名→变化才发新 version"机制，零框架改动。 |
+| EPPAddr 改为分配驱动 | `buildEPPAddrsFromSubClusters` 静态派生逻辑替换为按 `epp_assignments` 生成有序 `[主, 备]`；EPP 模式 cluster 无有效分配时导出降级为该 cluster `BalanceMode=WRR` + error 日志，不阻塞整份配置下发。 |
+| 分配自动生成 + 手工覆写兜底 | `epp_assignments` 由分配器自动生成：cluster 进入 EPP 模式时按"贪心 + 确定性 tie-break"算法自动选组（组间负载均衡）选主（组内负载均衡）；`/epp-pool` 变更导致分配悬空时自动修复。`PUT /api/v1/epp-assignments/{cluster}` 仅作运维干预入口。算法详见 `design-changes.md` §4.2.2。 |
+| 实例组固定 2 实例（测试环境允许单实例组） | 与《EPP主备池化部署方案》一致；单实例组 cluster 仅有主、无备，主失联时 BFE 侧降级本地均衡。 |
+| EPP 模式 cluster 无有效分配时导出降级 | 原方案为导出校验拒绝（整份生成失败）；改为单 cluster 降级：`BalanceMode` 置为 `WRR`、不生成 `EPPAddr`，同时输出 error 级日志（含 cluster 名与原因），不阻塞整份 server_data_conf 下发。 |
+
+## 5. 分期落地
+
+| 期 | 内容 |
+|----|------|
+| P0 | cluster `balance_mode` + `epp_config` 字段 + `/epp-pool` 实例池管理 + epp_data 统一下发 + 实例组/分配模型 + EPPAddr 有序生成 + server-data-conf.md §3.3 文档（约 1 周） |
+| P1 | （预留；视 P0 运行情况定） |
+| P2 | 自动失效检测翻转（信号来源届时在"上报通道 / 心跳 / BFE 健康回调"中统一设计）、加组扩容、反亲和分配约束（视运行情况） |
+
+## 6. 关联文档
+
+- 上游改造方案：`document-ai-gateway/迭代系统设计/v0.6/EPP支持/ai-gateway-api/ai-gateway-api改造方案-EPP调度对接.md`
+- 接口变更：本目录 `api-changes.md`
+- 设计变更：本目录 `design-changes.md`
+- `/alb-pool` 参考：`design-docs/api-define/OpenAPI接口定义/alb-pool.md`（单例 + 全量替换模式）
+- 关联分析文档（`document-ai-gateway/EPP分析/`）：《ai-gateway-epp/EPP配置定义说明-picker_config.md》、《ai-gateway-epp/server-data-conf修改方案-EPPAddr字段语义.md》、《EPP改造方案讨论/EPP主备池化部署方案.md》
+- EPP 侧消费实现参考：`ai-gateway-epp/pkg/poller/assignment.go`、`ai-gateway-epp/pkg/assignment/types.go`

--- a/design-docs/modifications/2026-09-08-epp-scheduling-integration/design-changes.md
+++ b/design-docs/modifications/2026-09-08-epp-scheduling-integration/design-changes.md
@@ -1,0 +1,286 @@
+# EPP 调度对接：ai-gateway-api 控制面设计变更说明
+
+> 本文档只描述 `ai-gateway-api` 控制面为 EPP 调度对接所做的改造。EPP 侧设计见 `document-ai-gateway/EPP分析/ai-gateway-epp/` 系列文档，BFE 侧改造见 `bfe/docs/zh_cn/modifications/2026-09-06-epp-ai-gateway-integration/design-changes.md`。上游改造方案见 `document-ai-gateway/迭代系统设计/v0.6/EPP支持/ai-gateway-api/ai-gateway-api改造方案-EPP调度对接.md`。
+
+## 1. 概述
+
+### 1.1 变更目标
+
+1. cluster 新增显式 `balance_mode` 参数（默认 `WRR`，可选 `EPP`），作为 EPP 模式的 OpenAPI 配置入口。
+2. cluster 新增 `epp_config` 字段（**简化用户形态**：调度档位 + 调优参数 + 流控，导出时编译为完整 `EndpointPickerConfig`），`balance_mode=EPP` 时必填并生效、`WRR` 时可保留休眠（切换模式不丢配置），随 `/clusters` 配置（替代上游方案的独立 CRUD 域与原始结构透出）。
+3. 新增 `epp_data` 统一下发端点：epp_config 与 assignment 全量视图合并导出（单 topic、单 version 快照）。
+4. 新增 OpenAPI `/epp-pool`（单例，`GET` + `PATCH` 全量替换），维护 EPP 实例池（实例组 + 实例列表），替代上游方案中的 InnerAPI 注册/心跳方式。
+5. 新增 EPP 实例组与分配模型，EPPAddr 生成由静态派生改为分配驱动。
+6. 新增 OpenAPI 管理面（epp-assignments 查询与手工覆写）。
+
+### 1.2 可复用基础（代码事实，已核实）
+
+| 能力 | 位置 | 说明 |
+|------|------|------|
+| InnerAPI 框架 | `endpoints/innerapi_v1/endpoints.go:33-57` | 9 个导出端点已就绪，endpoint→xreq.Convert→Manager 模式 |
+| 版本化下发框架 | `model/iversion_control/version_control.go:84-111` | `ExportConfig(ctx, topic, generator)` 事务内生成→MD5 签名→与 `config_versions` 表比对，变了才发新 version；新 topic 零框架改动 |
+| token 认证 | `endpoints/middleware/user_probe.go:26-48` | `Authorization: Token xxx`，逐端点 `Authorizer` 沿用 `FeatureRoute + ActionExport` |
+| 单例池接口模式 | `endpoints/openapi_v1/bfe_pool/update.go:31-36`、`design-docs/api-define/OpenAPI接口定义/alb-pool.md` | `/alb-pool` 单例资源：`GET` 详情 + `PATCH` 全量替换实例列表；`/epp-pool` 直接复用该模式 |
+| EPP 静态建模 | `model/icluster_conf/pool.go:129-143` | `ProductPoolRoleEPP`、`EPPServer{Domain,Port,Endpoints}`、`EPPEndpoint{IP,Port}` |
+| EPPAddr 生成 | `model/icluster_conf/cluster.go:1183-1184,1362-1382` | `buildEPPAddrsFromSubClusters` 从 EPPServer 派生 `GslbBasic.EPPAddr` |
+| cluster_table 导出 | `model/icluster_conf/exporter.go:44-110` | EPP 从中获取 model server 实例列表（本方案不变更） |
+
+### 1.3 缺口
+
+| 缺口 | 现状 |
+|------|------|
+| cluster 无显式 EPP 开关 | `BalanceMode` 由 SubCluster 的 pool `Role` 派生（`cluster.go:295-302`），而设置 `Role=EPP` 的旧 `/instance-pools` 端点已移除（`endpoints/openapi_v1/product_pool/endpoints.go` 注册表为空），无任何 OpenAPI 可达路径；`POST /clusters` 创建的 pool 固定 `Role=COMMON`（`cluster.go:450`） |
+| EPP 实例列表无 OpenAPI 配置入口 | 唯一能写 `pools.epp_server`（`EPPServer{Domain,Port,Endpoints}`）的是旧 `/instance-pools` 端点（`product_pool/create.go:53` 的 `epp_server` 参数），已随上述端点一并移除；现有 `PATCH /alb-pool`（`bfe_pool/update.go:31-36`）只更新内置 BFE pool 的 `Instances`，不触碰 `EPPServer`。EPPAddr 现由 `pools.epp_server` 派生（`cluster.go:1367`），该数据现已无 OpenAPI 可写 |
+| EPP 下发通道 | `epp_config` Go 代码零出现（已核实），assignment 下发不存在 |
+| EPP 实例组/分配模型 | 不存在。EPP 实例当前只是 pool 内的静态配置（EPPServer），无实例组、无角色、无序 |
+| `EPPAddr` 有序主备语义 | 字段已生成但无语义文档、无按序分配 |
+| 失效检测/再平衡 | 无 |
+
+---
+
+## 2. cluster `balance_mode` 与 `epp_config` 字段（P0）
+
+### 2.1 `balance_mode` 设计
+
+cluster 新增显式 `balance_mode` 字段（OpenAPI JSON 字段名 `balance_mode`），替代现状的 SubCluster Role 派生：
+
+| 项 | 设计 |
+|----|------|
+| 存储 | `clusters` 表新增 `balance_mode` varchar 列，默认 `'WRR'`；`model/icluster_conf.Cluster` 结构体新增同名字段 |
+| 枚举 | `WRR`（默认）、`EPP` |
+| OpenAPI | `POST /clusters` 与 cluster 更新接口新增可选参数；GET/List 响应返回该字段（契约见 `api-changes.md` §3.2） |
+| 导出 | `getBalanceMode()`（`cluster.go:295-302`）改为读取显式字段，直接决定 `GslbBasic.BalanceMode`（`cluster.go:1170`） |
+
+`getBalanceMode()` 简化为直接读取显式字段（列默认 `'WRR'`，字段恒有值），删除 Role 派生逻辑——`balance_mode` 是 EPP 模式的唯一判定来源。新列带默认值，存量数据无需迁移。
+
+### 2.2 `epp_config` 设计（简化用户形态）
+
+| 项 | 设计 |
+|----|------|
+| 存储 | `clusters` 表新增 `epp_config` JSON 列（可空），存**用户形态的简化配置**（保留原始字段，未显式设置的 key 不落盘，以区分 `cache_affinity` 缺省"跟随档位"与显式覆盖）；`Cluster` 结构体新增 `EppConfig *EppConfigSimplified` 字段 |
+| 形状 | **简化用户形态**：`scheduling_profile`（档位）+ `cache_affinity` / `kv_cache_utilization_max`（调优）+ `prefix_cache_affinity` / `session_affinity_enabled` + `session_affinity_header`（亲和特性开关）+ `flow_control`（流控），字段定义见 `api-changes.md` §3.2.1；不直接暴露 llm-d `EndpointPickerConfig` 插件声明细节 |
+| OpenAPI | 随 `POST/PUT /clusters` 一并传入、校验、更新；GET/List 响应原样返回用户形态（契约见 `api-changes.md` §3.2） |
+| 校验 | `balance_mode=EPP` ⇒ **必填**并生效；`balance_mode=WRR` ⇒ 可选（传入则保留并做格式校验，不编译、不导出，休眠）；字段级校验（枚举、数值范围、秒数取值范围）全部 api 侧强制 |
+| 编译 | epp_data generator 在导出时把简化配置**确定性编译**为完整 `EndpointPickerConfig`（注入 `cluster-table-discovery`、`utilization-filter`、scorer、`max-score-picker`，按档位/参数展开权重与流控段）；编译规则固化在代码模板中、单测覆盖，正常路径出厂即合法 |
+| 生效 | 仅 `balance_mode=EPP` 时编译下发；`WRR` 时保留休眠，EPP ↔ WRR 切换不丢配置 |
+| 停用 | 将 `balance_mode` 改回 `WRR` 即可（无需清空 `epp_config`） |
+| 高级模式 | **本期不提供**原样透传；如未来出现自定义插件链需求，届时再开放 |
+
+**为什么不直接暴露 `EndpointPickerConfig`**：那是 llm-d 的内部实现抽象（插件实例、pluginRef 引用图、DAG 层序、Quantity 格式），用户侧配置它意味着理解整套插件体系，且 api 只能做 JSON Schema 结构校验，引用错误要到 EPP 编译期才暴露。改为"档位 + 调优参数"后：用户表达成本从"组装插件链"降到"选一个档位、填几个数字"；api 从"做不了引用校验"变成"配置出厂即合法"（模板自生成、引用/DAG 由构造保证）；EPP 侧消费格式不变。档位语义（latency-first / balanced / throughput-first）与 scorer 权重映射见 `api-changes.md` §3.2.1 编译规则表。
+
+**为什么不采用上游方案的独立建表 + 独立 CRUD 域**：epp_config 是 per-cluster 配置且与 `balance_mode` 强耦合——EPP 模式必须有调度配置，非 EPP 模式不应有。挂在 `/clusters` 下可在 cluster 写入时原子强制该校验，杜绝"EPP cluster 无调度配置"的悬空状态与"非 EPP cluster 残留 EPP 配置"的孤儿数据；管理面也收敛到单一资源。变更面分析：epp_config 的变更几乎总是与 cluster 创建/模式变更同步发生，独立 CRUD 带来的灵活性与它引入的跨资源一致性成本不对等。
+
+### 2.3 创建 / 更新流程
+
+- **创建（`POST /clusters`）**：
+  - `balance_mode` 缺省 / `WRR`：`epp_config` 可选（传入则保留休眠）；创建路径与现状一致（`Role=COMMON` 实例池）。
+  - `balance_mode=EPP`：`epp_config` 必填；创建的 pool `Role=EPP`，复用现有 EPP 分支校验（`cluster.go:498` 单 subcluster 约束、`cluster.go:854` EPP 跳过实例池校验）；**池仍同步 provider `instance_pool` 实例**（与更新路径一致；`Role=EPP` 仅标记类型）——这些实例供两处消费：① cluster_table 导出（EPP 的 `cluster-table-discovery` 靠它发现推理后端，§1.2"EPP 从中获取 model server 实例列表（本方案不变更）"）；② EPP 全挂时 BFE 回退本地 WRR 的兜底后端。`BalanceMode=EPP` 下 BFE 不做本地 WRR，实例列表不参与正常均衡；`llm_config` 校验照常。
+- **更新**：
+  - `WRR → EPP`：须同时提供合法 `epp_config`（此前休眠保留的配置可继续用，也可一并更新）；即时 bump server_data_conf version。
+  - `EPP → WRR`：仅改 `balance_mode` 即可，`epp_config` 与分配记录保留休眠，再切回 `EPP` 时继续生效（休眠保留的 `epp_config` 非空仍须保持字段合法——校验与 `balance_mode` 无关）。
+- **变更影响面**：epp_config / assignment 下发范围、EPPAddr 生成路径（§4.3）、server_data_conf 导出校验（EPP 模式 cluster 无分配时拒绝）统一以 `cluster.balance_mode == EPP` 判定。
+- **实现修正（2026-09-08，SC28 五组件集成测试 TC-07 暴露）**：provider 实例池同步钩子 `ProviderInstancePoolSyncer`（`model/icluster_conf/cluster.go`）原实现对 `Role=EPP` 的 subcluster 实例池**跳过同步**，导致 `PATCH /providers` 修改 `instance_pool`（如某实例 `weight=0` 摘流）后，EPP cluster 的池实例不更新、cluster_table 导出仍旧值，EPP `cluster-table-discovery` 与 BFE 兜底 WRR 均感知不到摘流——与本节"池仍同步 provider 实例（与更新路径一致）"的设计意图矛盾（创建路径已对齐，更新路径漏改）。已修复为 EPP 池同样同步，并同步修正单测（`skips EPP sub-clusters` → `syncs EPP sub-clusters`）。
+
+---
+
+## 3. epp_data 统一下发（P0，epp_config + assignment 合并）
+
+- **端点**：`GET /inner-api/v1/configs/epp_data/config?version=...`（接口契约见 `api-changes.md` §2.1）。
+- **topic**：新增 `ConfigTopicEppData`，复用 `ExportConfig` 框架（version 格式 `20060102150405`，未变化返回 `Data: null`，与现有接口行为一致）。
+- **形状**：
+
+```json
+{
+    "Version": "20260906120000",
+    "Config": {
+        "epp_config": { "cluster-a": { "...": "编译后的 EndpointPickerConfig（由简化配置确定性展开）" } },
+        "assignment": {
+            "cluster-a": { "primary": "epp-a", "standby": "epp-b" },
+            "cluster-c": { "primary": "epp-c", "standby": null }
+        }
+    }
+}
+```
+
+- **epp_config 段**：数据源为 `clusters` 表 `balance_mode=EPP` 的 cluster 的 `epp_config` 列（§2.2，用户形态简化配置），generator 在导出时编译为完整 `EndpointPickerConfig`（编译规则见 `api-changes.md` §3.2.1）。OpenAPI 校验保证 EPP 模式 cluster 配置必填，导出结果中 EPP cluster 必然有配置。
+- **assignment 段（全量视图）**：`map[cluster名]{primary, standby}`，**所有 EPP 实例返回完全相同的内容**；范围仅含 `balance_mode=EPP` 的 cluster（`EPP → WRR` 后残留的分配记录休眠保留、不进导出）；`primary`/`standby` 为 `/epp-pool` 实例 id，单实例组时 `standby` 为 `null`；数据源为 `epp_assignments` + `epp_instances` 的读时 join。
+- **EPP 侧消费**：以自身 `-instance-id` 逐 cluster 匹配 `primary`/`standby` 得出角色；未命中跳过；`epp_config` 有而 `assignment` 无条目的 cluster = 未分配异常态（EPP 本地告警）。
+
+**为什么合并单端点、单 topic**（与上游"两个端点 + 两个独立 topic"不同）：
+
+1. **原子快照**：cluster 创建、模式变更、手工覆写往往同时改变两段配置，单 topic 天然保证 EPP 拿到同一 version 的 epp_config 与 assignment，消除跨 topic 版本偏移导致的角色/配置错配窗口。
+2. **代价可忽略**：数据量极小（两段 × 几十个 cluster），任一段变化全量重发的增量成本可忽略，"变更频率不同"不构成拆分理由。
+3. **实现简化**：generator 单事务内生成两段、一次 MD5 签名；EPP 轮询端点减半。
+
+---
+
+## 4. EPP 实例组与分配模型（P0）
+
+### 4.1 数据模型（新增表）
+
+```
+epp_instances:  id, host, port, group_name, 创建/更新时间；id 池内全局唯一；UNIQUE(host, port)（池内地址唯一）
+epp_assignments: cluster(唯一), group_name, primary_instance_id
+```
+
+说明：
+
+- 实例**无** `status` / `last_heartbeat` 字段——存活感知在 BFE 侧（EPPAddr 连接滞回），api 侧不做存活标记（§5）。
+- `clusters` 表仅新增 `balance_mode`、`epp_config` 两列（§2），其余不动；cluster ↔ EPP 实例组的关联全部走 `epp_assignments`。
+- 不复用 `pools` 表存 EPP 实例：pool/SubCluster 机制保留给 BFE 实例池，新实例池独立存储，避免两套语义纠缠。
+- 分配**只存主**：`epp_assignments` 仅记 `primary_instance_id`，standby 为读时展开（同组除 primary 外的实例），避免双写不一致；管理面全量视图（`GET /api/v1/epp-assignments`）即两者的读时 join，不一致时标记 degraded（契约见 `api-changes.md` §3.3.1）。
+
+### 4.2 分配器（第一期简化，与《EPP主备池化部署方案》一致）
+
+- 实例组固定 2 实例（测试环境允许 1 实例组/单实例：所有 cluster 仅有主、无备）。
+- 分配输入：实例组列表（来自 `/epp-pool` 配置的 `epp_instances`）、cluster 列表（`balance_mode=EPP`）；输出写入 `epp_assignments`。
+- 分配变更即时生效——下次 server_data_conf 导出时自然带出。
+- 约束校验：
+  - 生产组必须 2 实例完整；
+  - 主备同地址拒绝；
+  - `balance_mode=EPP` 的 cluster 无有效分配（无记录或记录悬空）时，导出 server_data_conf **降级导出**：该 cluster 的 `BalanceMode` 置为 `WRR`、不生成 `EPPAddr`，同时 ai-gateway-api 输出 **error 级日志**（含 cluster 名与降级原因）。降级后 BFE 以**本地 WRR** 调度该 cluster 池中的 provider 实例（请求仍可服务，仅失去 EPP 智能调度），属显式降级而非静默错误；单 cluster 降级不阻塞整份 server_data_conf 下发。分配恢复后下轮导出自动回到 `EPP`。
+
+#### 4.2.1 分配是自动生成的
+
+`epp_assignments` 由**分配器自动生成**，`PUT /api/v1/epp-assignments/{cluster}` 手工覆写作为运维兜底（故障转移确认、特殊布局）。管理面 `GET /api/v1/epp-assignments` 视图与 epp_data 的 assignment 段的数据来源即分配器输出 + 手工覆写结果。
+
+**触发时机（P0）**：
+
+| 触发点 | 行为 |
+|--------|------|
+| cluster 创建为 `balance_mode=EPP`，或 `WRR → EPP` 变更 | 无分配记录 → 自动分配（算法见 4.2.2） |
+| `/epp-pool` PATCH 后分配悬空（primary 实例已被移出池） | 自动修复：组仍存在 → 同组剩余实例中重选 primary（不换组）；组已不存在（或规模不满足部署形态要求）→ **跨组重分配**（对整个池重跑贪心算法选新组）；池无可分配候选组 → 清除分配（未分配态，导出时降级 `WRR` + error 日志，容量恢复后自动修复路径重新分配） |
+| P2 失效检测信号就绪后 | 叠加失效实例触发的主动翻转（先翻备观察再确认），算法届时扩展 |
+
+#### 4.2.2 自动分配算法（P0：贪心 + 确定性 tie-break）
+
+```
+输入：实例池（组→实例列表，来自 epp_instances）、现有分配（epp_assignments）、目标 cluster
+
+1. 候选组过滤：实例数满足部署形态要求（生产=2，测试≥1）
+2. 选组：组负载 = 组内各实例"作为 primary 承担的 cluster 数"之和
+        → 选负载最小的组；并列取组名字典序最小（组间均衡）
+3. 选主：组内选"作为 primary 承担的 cluster 数最少"的实例
+        → 并列取实例 id 字典序最小（组内均衡）
+4. 写入 epp_assignments（cluster 唯一键 upsert）
+```
+
+设计取舍：
+
+- **确定性**：全程字典序 tie-break，无随机；结果可重放、可单测；同一输入多次执行结果一致。
+- **无新增并发控制**：cluster 创建/更新路径本身串行，`/epp-pool` PATCH 触发的修复量小且幂等；P0 不为分配器引入额外分布式锁（如有并发分配竞争，唯一键约束兜底，失败方重试读取后再分配）。
+- **互为主备是合法输出**：同组两实例在不同 cluster 间互为主备（cluster-a 主=epp-a、cluster-b 主=epp-b）是该算法的自然结果——分配以 cluster 为单位，不做组↔cluster 一对一约束。
+- 反亲和（同 host 不共主备/不共组）为 P2 约束，届时作为选组打分项加入。
+
+### 4.3 EPPAddr 生成逻辑改造
+
+`model/icluster_conf/cluster.go:1362-1382` 的 `buildEPPAddrsFromSubClusters` 被替换为"按 `epp_assignments` 查 cluster 的 `{primary, standby}` 生成有序 `EPPAddr`"（`[0]`=主、`[1]`=备）：`cluster.balance_mode == EPP` 且有有效分配时按分配生成；**无有效分配时降级导出**——该 cluster `BalanceMode` 置为 `WRR`、不生成 `EPPAddr`，同时输出 error 级日志（含 cluster 名与原因），不阻塞整份 server_data_conf 下发。实例地址由 `epp_instances` 的 host/port 经 `net.JoinHostPort` 拼接。
+
+---
+
+## 5. EPP 实例池管理：`/epp-pool`（P0，替代注册/心跳）
+
+上游方案采用 InnerAPI `register` / `heartbeat` 自注册方式；本期**改为 OpenAPI `/epp-pool` 全量配置**，模式对齐 `/alb-pool`（单例资源、`GET` 详情 + `PATCH` 全量替换，接口契约见 `api-changes.md` §3.1）。
+
+### 5.1 设计要点
+
+| 项 | 设计 |
+|----|------|
+| 资源形态 | 单例池，池名由配置项提供（建议 `RunTime.DefaultEPPInstancePoolName`，默认值如 `EPP.pool`），请求不传 `name` |
+| 数据形状 | `{"name": ..., "groups": [{"name": "g1", "instances": [{"id": "epp-a", "host": "10.0.0.1", "port": 9002}]}]}`（host/port 分字段，与项目 Instance 模型风格一致；IPv6 字面量不带括号） |
+| 存储 | 展开写入 `epp_instances` 表（id、host、port、group_name） |
+| 写入方式 | `PATCH` 全量替换：部署流程在实例变更（扩缩容、换机）后调用；不提供增量接口 |
+| 校验 | 组名非空唯一；实例 id 池内全局唯一；`(host, port)` 组合池内全局唯一（host 为 Hostname 或 IP，port 为合法端口）；生产环境每组恰 2 实例（测试环境允许单实例组，校验强度由部署形态配置项控制） |
+| 下发拼接 | 生成 EPPAddr 时以 `net.JoinHostPort(host, strconv.Itoa(port))` 拼为 `host:port`（IPv6 自动加括号），BFE `EPPAddr` 的消费格式不变 |
+
+### 5.2 为什么用静态配置替代自注册
+
+- **与既有管理面一致**：`/alb-pool` 已确立"单例池 + 全量替换"的运维模式，EPP 实例池照此办理，管理面行为可预期，无需新增"实例自发写库"的反向通道及幂等、鉴权、时钟同步等一系列问题。
+- **实例列表是部署事实**：EPP 实例由部署系统拉起/下线，列表权威来源是部署流程而非进程自身；PATCH 全量替换天然幂等，与部署系统的 reconcile 循环契合。
+- **api 侧无存活管理负担**：自注册方案需要心跳续约、失联阈值、Scheduler 分布式锁等一整套机制；改为静态配置后 P0 全部不需要。实例存活与 failover 由 BFE 侧 EPPAddr 连接滞回判断驱动，api 只保证配置与分配视图稳定下发。
+- **保留演进空间**：若 P2 需要 api 侧主动失效检测，可在此基础上叠加心跳或 BFE 健康上报，信号来源届时另定，不与本期耦合。
+
+### 5.3 与上下游的衔接
+
+- **对 EPP**：实例身份即池中实例 id，EPP 以 `-instance-id` 启动参数（默认 hostname）在 epp_data 的 assignment 全量视图中定位自身角色；id 不在池中则未命中任何角色（fail-static，保留本地已知角色）。
+- **对分配器**：分配输入直接读 `epp_instances`（§4.2）；`/api/v1/epp-assignments/{cluster}` PUT 手工覆写时校验 primary 存在于对应组实例列表。
+- **对导出**：实例池变更不 bump `ConfigTopicEppData` topic（cluster→role 映射未变）；EPPAddr 由 `epp_assignments` 驱动，实例池变更仅在导致分配悬空修复时才间接影响导出。
+
+---
+
+## 6. 再平衡与失效检测（P2）
+
+- **P2 主动失效检测**：失效实例触发的自动分配翻转（先翻备观察健康再确认）+ 加组扩容与组间再平衡（再平衡不设独立端点，随失效检测/扩容流程内触发或经 `PUT /api/v1/epp-assignments/{cluster}` 手工覆写）+ 反亲和分配约束。
+- **前提**：失效检测/就绪信号来源届时在"EPP 上报通道 / 心跳 / BFE 健康回调"中统一设计——`/epp-pool` 静态配置模式下 api 侧无存活数据，P2 需先补信号通道。原 P1 的"就绪感知翻转""双活跃观测"依赖该信号通道，一并顺延至信号通道确定后评估。
+
+---
+
+## 7. 数据库变更
+
+| 表 | 变更 | 文件 |
+|----|------|------|
+| `clusters` | 新增 `balance_mode` 列（varchar，默认 `'WRR'`，取值 `WRR`/`EPP`）；新增 `epp_config` 列（JSON text，可空） | `db_ddl.sql`、`db_ddl_sqlite.sql` |
+| `epp_instances` | 新增（id，host，port，group_name，创建/更新时间；`UNIQUE(host, port)` 池内地址唯一） | 同上 |
+| `epp_assignments` | 新增（cluster 唯一键，group_name，primary_instance_id） | 同上 |
+
+`pools.epp_server` 列保留（本期无消费方，后续版本清理）。无 migration 框架，全量 DDL 手工同步；新列带默认值/可空，存量数据无需迁移。
+
+---
+
+## 8. 涉及文件清单
+
+| 文件 | 改造点 |
+|------|--------|
+| `endpoints/innerapi_v1/endpoints.go` | 注册 `epp_data/config` 端点 |
+| `endpoints/innerapi_v1/epp_data/`（新增） | epp_data 导出 handler（epp_config + assignment 两段生成） |
+| `endpoints/openapi_v1/epp_pool/`（新增） | `/epp-pool` GET/PATCH（模式照 `bfe_pool/`） |
+| `endpoints/openapi_v1/epp_assignments/`（新增） | OpenAPI assignments 查询与手工覆写 |
+| `endpoints/openapi_v1/product_cluster/create.go`、`update_basic.go` | `/clusters` 请求体新增 `balance_mode`、`epp_config` 参数与校验 |
+| `model/iversion_control/version_control.go` | 复用，新增 `ConfigTopicEppData` topic |
+| `model/icluster_conf/cluster.go:295-302` | `getBalanceMode()` 简化为直读 `balance_mode` 字段（默认 `WRR`），删除 Role 派生逻辑 |
+| `model/icluster_conf/cluster.go:450` | 创建流程按 `balance_mode` 生成 `Role=COMMON`/`Role=EPP` 的 pool |
+| `model/icluster_conf/cluster.go:1362-1382` | EPPAddr 生成改为分配驱动（旧 EPPServer 派生逻辑删除） |
+| `model/iroute_conf/exporter.go:67-166` | server_data_conf 导出接入分配处理（EPP 模式 cluster 无有效分配时降级为该 cluster `BalanceMode=WRR` + error 日志，不阻塞整份下发） |
+| `model/epp_pool/`（新增）+ `storage/rdb/epp_pool/`（新增） | 实例池读写、分配器、epp_data generator（含简化 epp_config → EndpointPickerConfig 编译模板） |
+| `lib/validate/validate.go` | `balance_mode` 枚举、`epp_config` 简化字段校验（枚举/范围/duration，随 balance_mode 条件必填规则） |
+| `db_ddl.sql` / `db_ddl_sqlite.sql` | `clusters` 新增两列 + 两张新表 |
+
+---
+
+## 9. 测试计划
+
+### 9.1 验收标准（checkable）
+
+1. EPP 实例以其 `-instance-id`（与 `/epp-pool` 配置一致）经 InnerAPI 拉取到 epp_data（epp_config + assignment 全量视图）与 cluster_table，version 增量生效（重复拉取返回 `Data: null`）；所有实例拿到的 assignment 内容一致。
+2. `POST /clusters` 携带 `balance_mode=EPP` + 合法 `epp_config` 创建的 cluster：server_data_conf 中 `BalanceMode=EPP`、`EPPAddr = [主, 备]`（分配器自动分配）；epp_data 导出包含该 cluster 的 epp_config（编译后形态，与档位/参数预期一致）与 assignment 条目；缺 `epp_config` 时创建返回 422。
+3. epp_config 变更（`PUT /clusters`）后，EPP 在下一同步周期拿到新配置并热加载生效（EPP 侧责任，本方案提供下发）。
+4. `EPP → WRR` 变更：仅改 `balance_mode` 即成功；导出 `BalanceMode=WRR`、EPPAddr 为空；`epp_config` 与分配记录保留（GET 回读不变、不进 epp_data 导出，非空配置仍须字段校验通过）；再 `WRR → EPP` 时原配置与原分配继续生效。
+
+### 9.2 单元测试
+
+- `getBalanceMode()`：直读 `balance_mode` 字段；缺省/空值为 `WRR`；Role 派生逻辑已删除、无引用。
+- cluster 创建/更新校验：`balance_mode=EPP` 缺 `epp_config` 拒绝；`epp_config` 非空即做简化字段校验（枚举、范围、秒数取值范围），**与 `balance_mode` 无关**（含 WRR 休眠保留与 `EPP → WRR` 随带场景）；休眠语义（EPP→WRR 保留、切回继续生效、不进导出）。
+- cluster 创建：`balance_mode=EPP` 生成 `Role=EPP` pool 且**池同步 provider 实例**（cluster_table 导出与兜底 WRR 依赖；BFE 在 EPP 模式下不做本地 WRR）；缺省与显式 `WRR` 走现状路径。
+- `/epp-pool` PATCH：全量替换语义、id 唯一性校验、`(host, port)` 组合唯一性校验、host/port 格式校验、组规模校验（生产 2 实例 / 测试允许单实例）、空组拒绝；PATCH 后 GET 回读一致；PATCH 触发分配悬空自动修复。
+- epp_data generator：epp_config 段数据源为 `clusters` 表、EPP cluster 必有配置；简化配置 → EndpointPickerConfig 编译正确性（档位权重映射、cache_affinity 覆盖、prefix/session 亲和 scorer 条件注入与固定权重、flow_control 展开、featureGates 追加、固定插件注入）；assignment 段 cluster→{primary, standby} 读时 join 正确、单实例组 `standby=null`；version 不变返回 `Data: null`。
+- 分配器：生产组 2 实例完整性校验、主备同地址拒绝、贪心选组选主的确定性（同输入同输出、负载均衡断言）、EPP 模式 cluster 无有效分配时导出降级（`BalanceMode=WRR` + error 日志，不阻塞整份下发）。
+- EPPAddr 生成：分配驱动有序输出 `[主, 备]`、host/port 经 `net.JoinHostPort` 拼接；EPP 模式 cluster 无有效分配时导出降级不报错。
+
+### 9.3 集成测试
+
+- OpenAPI：`PATCH /epp-pool`（配置实例组）→ `POST /clusters`（`balance_mode=EPP` + `epp_config`）→ `GET /epp-assignments`（验证自动分配）→ server_data_conf 导出有序 EPPAddr、epp_data 导出包含两段配置。
+- InnerAPI：epp_data 增量拉取（重复拉取返回 `Data: null`）；assignment 全量视图对所有实例一致。
+
+---
+
+## 10. 风险与注意事项
+
+| 风险 | 说明 | 缓解措施 |
+|------|------|----------|
+| /epp-pool 配置与部署事实漂移 | 静态配置模式下，实例实际下线但未更新 /epp-pool 时，api 侧无感知 | 部署流程负责 reconcile（变更后 PATCH）；BFE 侧 EPPAddr 滞回容错；P2 补失效检测信号通道 |
+| cluster 更新面变大 | `balance_mode`/`epp_config` 并入 `/clusters` 后，cluster 写入的校验与冲突面增大 | 两字段校验内聚在 cluster 写入路径；epp_config 校验为简化字段（枚举/范围/duration），错误信息指明字段路径 |
+| epp_config 与 balance_mode 不一致 | 独立 CRUD 模式下可能出现的悬空/孤儿配置 | 本期已消除：单一写入口 + 条件必填校验（EPP⇒必填、WRR⇒可选休眠保留；非空一律做字段校验），写入时原子强制 |
+| 双 EPP 判定来源 | `balance_mode` 字段与 pool `Role` 并存，可能不一致（如手工改库） | `balance_mode` 是唯一判定来源（`getBalanceMode()` 直读字段，Role 派生已删除）；OpenAPI 是唯一写入口，创建/更新时保持两者一致（`balance_mode=EPP` ⇔ pool `Role=EPP`） |
+| 分配变更与 EPP 实际角色的时序 | 分配即时变更但 EPP 下一同步周期才应用 | P0 由 BFE 侧滞回吸收短暂不一致；若 P2 引入 api 主动翻转，届时结合信号通道设计"先同步后翻转"约束 |
+| 合并 topic 的全量重发 | 任一段变化会 bump version，另一段随之重发 | 数据量极小，代价可忽略；换来的是两段配置的原子快照 |
+| server_data_conf 降级导出 | EPP 模式 cluster 无有效分配时导出行为需明确定义 | 降级导出：该 cluster `BalanceMode=WRR`、不生成 EPPAddr，同时输出 error 级日志（含 cluster 名与原因）；不阻塞整份下发，分配恢复后自动回到 `EPP`；降级期间该 cluster 无后端可调度，需靠 error 日志 + `unassigned_clusters` 监控告警发现 |

--- a/design-docs/sys-design/details/EPP调度对接.md
+++ b/design-docs/sys-design/details/EPP调度对接.md
@@ -1,0 +1,151 @@
+# EPP 调度对接
+
+## 1. 概述
+
+EPP（Endpoint Picker，基于 llm-d 的 LLM 推理调度器）接入后，ai-gateway-api 需要承担其**控制面**职责：集群级调度配置管理、EPP 实例池管理、cluster→EPP 实例组分配，以及向 BFE 与 EPP 两侧的配置下发。
+
+本组件覆盖四块能力：
+
+- **cluster 均衡模式与调度配置**（`/clusters` 新增 `balance_mode` + `epp_config`）；
+- **EPP 实例池管理**（`/epp-pool`，对齐 `/alb-pool` 的单例池 + 全量替换模式）；
+- **cluster→实例组分配**（分配器自动生成 + `/epp-assignments` 查询视图与手工覆写）；
+- **双向下发**：server_data_conf 向 BFE 导出 `BalanceMode`/`EPPAddr`；epp_data（新 topic）向 EPP 实例统一下发编译后的调度配置 + assignment 全量视图。
+
+> 完整变更说明见 `design-docs/modifications/2026-09-08-epp-scheduling-integration/`（change-summary / api-changes / design-changes）；接口契约见 `design-docs/api-define/` 下 `OpenAPI接口定义/epp-pool.md`、`epp-assignments.md`、`clusters.md` 与 `InnerAPI接口定义/epp-data.md`、`server-data-conf.md`。自动分配各场景的详细分析见《EPP实例自动分配-场景分析与方案》（document-ai-gateway 仓库）。
+
+---
+
+## 2. 数据模型
+
+### 2.1 `clusters` 表新增列
+
+| 列 | 类型 | 说明 |
+|----|------|------|
+| `balance_mode` | varchar，默认 `'WRR'` | 集群均衡模式：`WRR`（BFE 本地加权轮询，默认）/ `EPP`（EPP 调度器接管后端选择）。**唯一判定来源**（`getBalanceMode()` 直读该字段；pool `Role` 派生逻辑已删除） |
+| `epp_config` | JSON text，可空 | EPP 调度配置，**简化用户形态**（见 §3）；仅 `balance_mode=EPP` 时生效，WRR 时保留不生效（休眠语义，见 §5） |
+
+两列均可空/带默认值，存量数据无需迁移。`pools.epp_server` 列保留但已无消费方，后续版本清理。
+
+> **EPP 模式 cluster 的实例池语义**：创建/更新时池**照常同步 provider `instance_pool` 实例**（`Role=EPP` 仅作类型标记）。这些实例服务于：① cluster_table 导出——EPP 的 `cluster-table-discovery` 经它发现推理后端（"EPP 从中获取 model server 实例列表，本方案不变更"）；② EPP 全挂时 BFE 回退本地 WRR 的兜底后端。`BalanceMode=EPP` 下 BFE 不做本地 WRR，实例不参与正常均衡。
+
+### 2.2 `epp_instances` 表（新增）
+
+EPP 实例池存储，一行一个实例：
+
+```
+id, host, port, group_name, 创建/更新时间
+```
+
+- `id`：实例 id，池内全局唯一；EPP 进程以 `-instance-id` 启动参数对应此值（StatefulSet 部署时缺省为 Pod hostname，同组副本共享相同启动参数）。
+- `(host, port)`：`UNIQUE(host, port)` 池内地址唯一；host 为 Hostname 或 IP（IPv6 字面量不带括号），导出拼接 `host:port` 时经 `net.JoinHostPort` 自动加括号。
+- **无 `status`/`last_heartbeat`**：存活感知在 BFE 侧（EPPAddr 连接滞回），api 侧不做存活标记。
+
+### 2.3 `epp_assignments` 表（新增）
+
+cluster→实例组分配，**只存主**：
+
+```
+cluster（唯一键）, group_name, primary_instance_id
+```
+
+- standby 不存储：读时展开为同组除 primary 外的实例，避免双写不一致。
+- 分配由**分配器自动生成**（§4），`PUT /api/v1/epp-assignments/{cluster}` 手工覆写作为运维兜底。
+- `EPP → WRR` 后分配记录**休眠保留**（不进导出），切回 EPP 继续生效。
+
+---
+
+## 3. `epp_config`：简化用户形态与确定性编译
+
+`epp_config` 不直接暴露 llm-d `EndpointPickerConfig` 的插件声明细节，用户以"调度档位 + 少量一等公民调优参数"表达意图：
+
+| 字段 | 默认 | 说明 |
+|------|------|------|
+| `scheduling_profile` | `balanced` | 调度档位：`latency-first` / `balanced` / `throughput-first`，映射 (kv, queue) scorer 权重 |
+| `cache_affinity` | 缺省（跟随档位） | 显式 `low`/`medium`/`high` 时覆盖档位权重；存储保留原始 JSON 以区分"缺省"与"显式 medium" |
+| `prefix_cache_affinity` | `true` | 前缀缓存亲和 scorer 开关（软亲和，权重固定 1.0；本地内存 LRU，无外部存储） |
+| `session_affinity_enabled` / `session_affinity_header` | `false` / - | 会话亲和开关 + session id 来源请求头（enabled=true 时 header 必填；false 时 header 可休眠保留） |
+| `kv_cache_utilization_max` | `0.9` | utilization-filter 阈值 `(0,1]` |
+| `flow_control` | - | `max_requests`（缺省/-1 不限）、`queue_ttl`/`no_endpoint_queue_ttl`（int 秒，≥0，0=禁用驱逐；缺省由 EPP 默认 60s）、`enable_eviction` |
+
+api 导出时把简化配置**确定性编译**为完整 `EndpointPickerConfig`（档位权重映射、亲和 scorer 条件注入、flowControl 段展开、featureGates 追加、固定插件注入），规则固化并单测覆盖；本期不提供原样透传的高级模式。秒数在编译时转为 Go duration 下发（`30` → `30s`）。
+
+**休眠语义**：`epp_config` 非空即须通过字段校验（**与 `balance_mode` 无关**）；仅 `balance_mode=EPP` 时编译下发，WRR 时保留不导出；停用 EPP = 改回 WRR，无需清空。
+
+---
+
+## 4. EPP 实例池（`/epp-pool`）与分配器
+
+### 4.1 实例池：静态配置替代自注册
+
+- **单例池**，池名由配置项 `RunTime.DefaultEPPInstancePoolName` 提供（默认 `EPP.pool`）；`GET` 详情 + `PATCH` 全量替换（对齐 `/alb-pool`）。
+- 实例列表是**部署事实**：部署流程在扩缩容/换机后 reconcile PATCH，天然幂等；api 侧无心跳续约、失联阈值等存活管理负担。
+- 组规模校验：生产每组恰 2 实例（主备），测试允许单实例组；校验强度由部署形态配置项控制。
+
+### 4.2 分配器：贪心 + 确定性 tie-break
+
+```
+输入：实例池（组→实例列表）、现有分配（epp_assignments）、目标 cluster
+1. 候选组过滤：实例数满足部署形态要求（生产=2，测试≥1）
+2. 选组：组负载 = 组内各实例"作为 primary 承担的 cluster 数"之和
+        → 最小者优先，并列取组名字典序最小
+3. 选主：组内"作为 primary 承担的 cluster 数最少"的实例
+        → 并列取实例 id 字典序最小
+4. upsert epp_assignments
+```
+
+全程确定性、可重放、可单测。互为主备是合法输出（同组两实例在不同 cluster 间互为主备）；不做组↔cluster 一对一约束。
+
+### 4.3 触发时机
+
+| 触发点 | 行为 |
+|--------|------|
+| cluster 创建为 EPP / `WRR → EPP` 变更 | 无分配记录 → 同步自动分配（创建请求内完成） |
+| `/epp-pool` PATCH 后悬空修复 | ① primary 被移出、组仍在 → 同组剩余实例重选 primary（不换组）；② 组已不存在（或规模不满足要求）→ **跨组重分配**（对整个池重跑算法）；③ 池无可分配候选组 → 清除分配，进入未分配态 |
+| 手工覆写指向的组被移除 | 同悬空修复② |
+| 周期对账 reconciler（30s，可配） | 扫描全部 EPP cluster，无有效分配即自动补分配（漂移兜底；幂等，大部分轮次零写入） |
+
+### 4.4 查询与手工覆写
+
+- `GET /api/v1/epp-assignments`：分配全量视图——`epp_assignments` 与 `epp_instances` 的**读时 join**（不引入冗余存储），per-cluster 展开 `{group, primary, standby}`；不一致标记 `degraded`；汇总 `unassigned_clusters` 与 `idle_groups` 便于巡检。
+- `PUT /api/v1/epp-assignments/{cluster}`：手工覆写 `{group_name, primary_instance_id}`（运维干预入口），触发 server_data_conf version bump。
+
+---
+
+## 5. 双向下发
+
+### 5.1 server_data_conf → BFE（`BalanceMode` / `EPPAddr`）
+
+- `balance_mode=EPP` 且有有效分配：`GslbBasic.BalanceMode=EPP`，`EPPAddr` 为**有序列表 `[主, 备]`**（主 `[0]`、备 `[1]`，单实例组仅主；host/port 经 `net.JoinHostPort` 拼接）。
+- **无有效分配时降级导出**：该 cluster `BalanceMode` 置为 `WRR`、不生成 `EPPAddr`，同时输出 **error 级日志**（含 cluster 名与原因）。单 cluster 降级不阻塞整份下发；分配恢复后下轮导出自动回到 `EPP`。降级期间 BFE 以本地 WRR 调度该 cluster 池中的 provider 实例（请求仍可服务，仅失去 EPP 智能调度），靠 error 日志 + `unassigned_clusters` 告警发现。
+
+### 5.2 epp_data → EPP（新 topic，两段合并单端点）
+
+- **端点**：`GET /inner-api/v1/configs/epp_data/config?version=...`；topic `ConfigTopicEppData`，复用 `ExportConfig` 框架（MD5 签名、version 单调递增、未变化返回 `Data: null`）。
+- **形状**：`{ "epp_config": { cluster → 编译后 EndpointPickerConfig }, "assignment": { cluster → {primary, standby} } }`。
+- assignment 为**全量视图**：所有 EPP 实例返回完全相同内容，EPP 以自身 `-instance-id` 逐 cluster 匹配得出角色；未命中跳过。单 topic 保证两段配置同一 version 原子快照，消除角色/配置错配窗口。
+- 实例池变更不直接 bump 该 topic（cluster→role 映射未变），仅分配变化时经 server_data_conf 导出间接体现。
+
+---
+
+## 6. 关键设计取舍
+
+| 取舍 | 决策 | 理由 |
+|------|------|------|
+| 兼容性 | **不考虑兼容路径**：旧 EPPServer 派生逻辑直接删除 | 同版本发布，控制面与数据面一起升级 |
+| 实例存活管理 | api 侧无心跳/存活标记 | 存活与 failover 由 BFE 侧 EPPAddr 连接滞回驱动；实例列表权威来源是部署流程 |
+| 高级逃生门 | 本期不提供（epp_config 只暴露简化形态） | 自定义插件链需求出现时再开放 |
+| 导出失败策略 | 无分配 → 单 cluster 降级 WRR + error 日志，而非整份拒绝 | 避免单 cluster 配置阻塞全局下发；显式降级可监控 |
+| 均衡算法 | 贪心 + 字典序 tie-break，无随机 | 确定性可重放、可单测；组间再平衡/反亲和/失效翻转属 P2 |
+| 亲和实现 | prefix/session 亲和均为 EPP 本地内存（LRU/binding），指标为周期抓取后端 `/metrics` | EPP 全链路对外依赖仅两类无状态拉取：控制面配置 + 数据面指标 |
+
+---
+
+## 7. 涉及代码位置
+
+| 位置 | 职责 |
+|------|------|
+| `endpoints/openapi_v1/epp_pool/`、`endpoints/openapi_v1/epp_assignments/`（新增） | `/epp-pool`、`/epp-assignments` OpenAPI |
+| `endpoints/innerapi_v1/epp_data/`（新增） | epp_data 导出 handler |
+| `model/epp_pool/` + `storage/rdb/epp_pool/`（新增） | 实例池读写、分配器（含 reconciler）、epp_data generator、epp_config 编译模板 |
+| `model/icluster_conf/cluster.go` | `balance_mode`/`epp_config` 字段、创建流程、EPPAddr 分配驱动生成 |
+| `model/iversion_control/version_control.go` | 复用，新增 `ConfigTopicEppData` topic |

--- a/design-docs/sys-design/summary.md
+++ b/design-docs/sys-design/summary.md
@@ -11,8 +11,8 @@
 | 总体设计文档 | [总体设计文档.md](./总体设计文档.md) | 描述 `ai-gateway-api` 在 AI 网关中的定位、功能范围、三层架构（接口层/模型层/存储层）、组件交互关系、核心数据流以及 OpenAPI 与 InnerAPI 的职责划分。 |
 | 接口层设计文档 | [接口层设计文档.md](./接口层设计文档.md) | 描述管理面 OpenAPI（`/open-api/v1`）与数据面 InnerAPI（`/inner-api/v1`）的路由组织、统一的 `xreq.Endpoint` 抽象、全局与业务中间件链、子包划分以及典型接口实现模式。 |
 | 模型层设计文档 | [模型层设计文档.md](./模型层设计文档.md) | 描述 `model/` 层的子包职责、Manager + Storager 接口的分层模式、Param/Filter 设计、事务管理、典型业务流程以及各业务模型（API-Key、Entity、Provider、Cluster、Quota、RateLimit、Route 等）的交互方式。 |
-| 存储层设计文档 | [存储层设计文档.md](./存储层设计文档.md) | 描述 `storage/rdb` 层的 DAO + Storage 两层结构、通用 DAO 设计模式、事务与连接管理、29 张表的 DAO 映射关系以及 Storage 实现如何向上暴露接口供模型层调用。 |
-| 数据库设计文档 | [数据库设计文档.md](./数据库设计文档.md) | 描述 `ai-gateway-api` 当前实现中全部 29 张持久化表的字段、约束、索引、JSON 字段结构以及表间逻辑关系，覆盖基础配置、集群、路由、证书、API-Key、Entity、配额、限流、模型定价、操作日志等模块。 |
+| 存储层设计文档 | [存储层设计文档.md](./存储层设计文档.md) | 描述 `storage/rdb` 层的 DAO + Storage 两层结构、通用 DAO 设计模式、事务与连接管理、31 张表的 DAO 映射关系以及 Storage 实现如何向上暴露接口供模型层调用。 |
+| 数据库设计文档 | [数据库设计文档.md](./数据库设计文档.md) | 描述 `ai-gateway-api` 当前实现中全部 31 张持久化表的字段、约束、索引、JSON 字段结构以及表间逻辑关系，覆盖基础配置、集群、路由、证书、API-Key、Entity、配额、限流、模型定价、操作日志等模块。 |
 
 ---
 
@@ -32,6 +32,7 @@
 | Redis Key 清理机制 | [details/Redis Key 清理机制.md](./details/Redis%20Key%20清理机制.md) | 描述 API-Key / Entity 删除及 rate-limit 规则变更时的 Redis Key 清理逻辑，包括 Quota Key 与 Rate-Limit Key 格式、触发场景、对 BFE 的影响以及控制面立即清理实现方案。 |
 | 模型定价管理 | [api-define/OpenAPI接口定义/model-prices.md](../api-define/OpenAPI接口定义/model-prices.md) | 描述 `/model-prices` 管理接口、`model-list.yaml` 导入格式、`ModelPrice` 数据模型与校验规则，是 InnerAPI `AIConf.ModelTable` 的数据源。 |
 | RMB 配额分时段定价 | [details/RMB配额分时段定价.md](./details/RMB配额分时段定价.md) | 描述 RMB 配额按 provider 时段模板与 model-prices 分时段价格进行计费的设计，包括 `time_zone` / `tiers` / `tier_prices` 数据模型、控制面导出逻辑、BFE 数据面时段匹配与成本计算。 |
+| EPP 调度对接 | [details/EPP调度对接.md](./details/EPP调度对接.md) | 描述 EPP（llm-d 调度器）接入后控制面的四块能力：cluster `balance_mode`/`epp_config`（简化用户形态 + 确定性编译）、`/epp-pool` 静态实例池、分配器（贪心确定性算法、悬空修复、周期对账）、双向下发（server_data_conf 的 `BalanceMode`/`EPPAddr` 含降级语义、epp_data 单 topic 两段合并）。 |
 
 ---
 

--- a/design-docs/sys-design/存储层设计文档.md
+++ b/design-docs/sys-design/存储层设计文档.md
@@ -28,6 +28,8 @@ storage/rdb/internal/dao/
 ├── table_domains.go # domains 表（域名）
 ├── table_entities.go # entities 表（Entity）
 ├── table_entity_types.go # entity_types 表（Entity 类型）
+├── table_epp_assignments.go # epp_assignments 表（cluster→EPP 实例组分配）
+├── table_epp_instances.go # epp_instances 表（EPP 实例池）
 ├── table_extra_files.go # extra_files 表（附加文件）
 ├── table_lb_matrix.go # lb_matrices 表（负载均衡矩阵）
 ├── table_model_prices.go # model_prices 表（模型定价）
@@ -186,6 +188,9 @@ storage/rdb/
 │ ├── model_price.go # ModelPrice 存储读取（供 AIConf.ModelTable 使用）
 │ ├── pool.go # 实例池存储；数据来自 Provider，按 cluster 生成 BFE 配置
 │ └── sub_cluster.go # 子集群存储
+├── epp_pool/
+│ ├── epp_instance.go # EPP 实例池存储（epp_instances 表）
+│ └── epp_assignment.go # EPP 分配存储（epp_assignments 表，cluster 唯一键 upsert）
 ├── provider/
 │ └── provider.go # Provider 存储
 ├── entity/
@@ -432,6 +437,17 @@ type TxnStorager interface {
 - 查询时先 `dao.TOperationLogCount` 取总数，再 `dao.TOperationLogList` 分页读取；
 - `change_summary` 在写入前由模型层完成 JSON 序列化，读取时反序列化回 `map[string]interface{}`。
 
+#### 3.3.12 epp_pool 域
+
+实现文件位于 `storage/rdb/epp_pool/`，对应接口定义在 `model/epp_pool`。
+
+| 文件 | Storage 结构 | 构造函数 | 实现接口 | 主要方法 |
+|------|--------------|----------|----------|----------|
+| `epp_instance.go` | `RDBEppInstanceStorager` | `NewRDBEppInstanceStorager` | `epp_pool.EppInstanceStorager` | 实例池读写：按组查询/全量替换写入 `epp_instances`（`id` 池内全局唯一、`(host, port)` 联合唯一） |
+| `epp_assignment.go` | `RDBEppAssignmentStorager` | `NewRDBEppAssignmentStorager` | `epp_pool.EppAssignmentStorager` | 分配读写：`epp_assignments` 按 `cluster` 唯一键 upsert/删除/查询（只存主，`primary_instance_id` 引用池内实例） |
+
+`epp_instances` 一行一个实例，`group_name` 标识所属实例组；`epp_assignments` 一行一条 cluster 分配（`cluster` 唯一键），standby 不存储、由模型层读时展开为同组除 primary 外的实例。实例池写入为**全量替换**语义（对齐 `/alb-pool`），由模型层在事务内完成删除重建。
+
 ### 3.4 特殊 Storage 实现
 
 #### 3.4.1 RouteRules 列表分页
@@ -534,6 +550,7 @@ Provider 与 Cluster 概念分离及模型定价改造引入了以下 schema 变
 | `providers` | `instance_pool` | 后端实例池 |
 | `providers` | `model_protocols` | 支持的模型访问协议 |
 | `clusters` | `llm_config` | LLM 转发策略（含 Key 引用 `keys`、`key_policy`、`provider`） |
+| `clusters` | `epp_config` | EPP 调度配置（简化用户形态，导出时编译为 EndpointPickerConfig） |
 | `lb_matrices` | `lb_matrix` | 负载均衡矩阵 |
 | `model_prices` | `capabilities` | 能力列表 |
 | `model_prices` | `supported_parameters` | 支持的请求参数列表 |

--- a/design-docs/sys-design/总体设计文档.md
+++ b/design-docs/sys-design/总体设计文档.md
@@ -22,6 +22,7 @@ AI 网关整体由以下核心组件构成：
 | **AI Gateway API** | 控制面 | 即本项目，负责配置管理和配置下发 |
 | **Dashboard** | 管理控制台 | Web UI，调用 OpenAPI 完成可视化操作 |
 | **BFE** | 数据面 | 流量转发与访问控制 |
+| **EPP** | 数据面 | LLM 推理调度器（基于 llm-d），消费 epp_data 配置接管 EPP 模式 cluster 的后端选择 |
 | **Conf Agent** | 配置代理 | 从 InnerAPI 拉取最新配置并触发 BFE 热加载 |
 | **Service Controller** | 服务发现 | 发现并同步 Kubernetes 后端服务 |
 
@@ -41,9 +42,10 @@ AI 网关整体由以下核心组件构成：
 - **Provider 管理（`/providers`）**：创建、查询、更新、删除 Provider；支持 `model_endpoint`、`models`、`keys`、`instance_pool`、`model_protocols` 等字段，集中管理下游模型提供方的接入能力；提供 `/providers/tools/discover-models` 无状态工具接口触发模型发现，返回模型名列表。
 - **集群管理（`/clusters`）**：集群一键创建、查询、更新、删除；`llm_config` 只保留转发策略（含 `models`、`model_mappings`、`keys` Key 引用与权重、`key_policy`、`key_affinity`、`provider`、`match_prefix`/`strip_prefix` 等），后端实例池、Key 明文、模型端点等能力通过 `llm_config.provider` 引用 Provider 获取；集群就绪状态、子集群、调度矩阵等内部概念不再对外暴露；`llm_config.provider` 用于 InnerAPI 自动填充 `AIConf.ModelTable`。
 - **模型定价管理（`/model-prices`）**：导入 `model-list.yaml`、单条 CRUD、分页查询、查询所有 Provider 名称列表（`GET /model-prices/actions/get-providers`）；`provider` 字段仅作为价格归集标识，不强制引用 `/providers` 中已存在的 Provider，为 RMB 配额与 BFE 成本核算提供统一模型定价数据源。
+- **EPP 调度管理（`/epp-pool`、`/epp-assignments`、`/clusters`）**：cluster 均衡模式与调度配置（`balance_mode`/`epp_config`）、EPP 实例池单例管理（`/epp-pool` 全量替换）、cluster→EPP 实例组自动分配（贪心 + 字典序 tie-break，含 30s 周期对账 reconciler）与分配查询/手工覆写（`/epp-assignments`）、epp_data 统一下发（`ConfigTopicEppData`：epp_config 编译产物 + assignment 全量视图，单 topic 两段合并）。
 - **操作日志管理（`/operation-logs`）**：记录控制面配置变更操作，覆盖 cluster、route、domain、certificate、quota_plan、rate_limit_policy、model_price、user、token、entity、api_key、provider 等域；支持按操作人、资源类型、动作、时间范围分页查询；对 api-key token、密码、私钥、证书等敏感字段统一脱敏；采用异步批量写入降低主请求延迟，失败操作同样记录。
 
-- **配置导出（InnerAPI）**：向 BFE/Conf Agent 导出 TLS/Server/路由、GSLB、证书、附加文件、API-Key、请求体处理、限流策略、AI 路由等配置；`server_data_conf` 中 `ClusterConf.Config.<cluster_name>.AIConf` 新增 `Provider`、`ModelTable`、`MatchPrefix`、`StripPrefix` 与 `ModelProtocols`。
+- **配置导出（InnerAPI）**：向 BFE/Conf Agent 导出 TLS/Server/路由、GSLB、证书、附加文件、API-Key、请求体处理、限流策略、AI 路由等配置；`server_data_conf` 中 `ClusterConf.Config.<cluster_name>.AIConf` 新增 `Provider`、`ModelTable`、`MatchPrefix`、`StripPrefix` 与 `ModelProtocols`；EPP 模式 cluster 导出 `GslbBasic.BalanceMode=EPP` 与有序 `EPPAddr [主, 备]`（无有效分配时降级为该 cluster `BalanceMode=WRR` + error 日志，不阻塞整份下发）；向 EPP 实例导出 `epp_data`（`/configs/epp_data/config`）。
 
 ---
 
@@ -199,13 +201,13 @@ ai-gateway-api/
 
 ## 4. 数据库设计（概要）
 
-`ai-gateway-api` 当前代码实现中共使用 29 张关系型数据表，按业务模块划分如下：
+`ai-gateway-api` 当前代码实现中共使用 31 张关系型数据表，按业务模块划分如下：
 
 | 模块 | 表名 |
 |------|------|
 | 基础配置 | `bfe_clusters`、`products`、`domains`、`users`、`user_products`、`config_versions` |
 | Provider | `providers` |
-| 集群与实例池 | `clusters`、`sub_clusters`、`pools`、`lb_matrices` |
+| 集群与实例池 | `clusters`、`sub_clusters`、`pools`、`lb_matrices`、`epp_instances`、`epp_assignments` |
 | 路由规则 | `route_basic_rules`、`route_advance_rules`、`route_default_rules`、`route_cases`、`ai_route_rules`、`route_rules` |
 | 证书与附加文件 | `certificates`、`extra_files` |
 | API Key / Entity / 配额 / 限流 | `api_keys`、`api_key_id_seq`、`api_key_tokens`、`entity_types`、`entities`、`entity_id_seq`、`quota_plans`、`rate_limit_policies` |
@@ -235,6 +237,9 @@ ai-gateway-api/
 | `ai_route_rules` | 历史 AI 路由规则明细表，OpenAPI 不再通过 `/ai-route-rules` 暴露 |
 | `certificates` | TLS 证书表 |
 | `extra_files` | 附加文件表，用于 InnerAPI 导出 |
+| `clusters` | AI 集群配置表；除转发策略（`llm_config`）外，新增 `balance_mode`（均衡模式，唯一判定来源）与 `epp_config`（EPP 调度配置简化用户形态）两列 |
+| `epp_instances` | EPP 实例池表，一行一个 EPP 实例（id、host、port、group_name），`(host, port)` 池内唯一，无 status/heartbeat |
+| `epp_assignments` | cluster→EPP 实例组分配表（cluster 唯一键），只存主（`primary_instance_id`），standby 读时展开 |
 
 更多表结构、字段含义、索引设计和 DDL 详见《数据库设计文档.md》。
 
@@ -269,6 +274,7 @@ ai-gateway-api/
 | `storage/rdb/basic` | `model/ibasic` | `bfe_clusters`、`products`、`extra_files` |
 | `storage/rdb/api_key` | `model/api_key` | `api_keys`、`api_key_tokens` |
 | `storage/rdb/cluster_conf` | `model/icluster_conf` | `clusters`、`sub_clusters`、`pools`、`lb_matrices` |
+| `storage/rdb/epp_pool` | `model/epp_pool` | `epp_instances`、`epp_assignments` |
 | `storage/rdb/entity` | `model/entity` | `entity_types`、`entities` |
 | `storage/rdb/protocol` | `model/iprotocol` | `certificates` |
 | `storage/rdb/quota` | `model/quota` | `quota_plans` |
@@ -303,7 +309,8 @@ ai-gateway-api/
 | `model/entity` | Entity / Entity-Type 业务逻辑、层级校验、级联删除、Entity 相关导出数据源 |
 | `model/iauth` | 用户/Token 认证、产品线授权、Feature-Action 权限定义 |
 | `model/ibasic` | Product、BFECluster、ExtraFile 业务逻辑 |
-| `model/icluster_conf` | Cluster、SubCluster、Pool 业务逻辑；`LLMConfig` 只保留转发策略，通过 `provider` 引用 Provider 获取后端能力；导出 `AIConf` 时按 name join Provider 的 key 明文与 Cluster 的 key 权重，填充 `Provider`、`ModelTable`、`MatchPrefix`、`StripPrefix` 与 `ModelProtocols` |
+| `model/icluster_conf` | Cluster、SubCluster、Pool 业务逻辑；`LLMConfig` 只保留转发策略，通过 `provider` 引用 Provider 获取后端能力；导出 `AIConf` 时按 name join Provider 的 key 明文与 Cluster 的 key 权重，填充 `Provider`、`ModelTable`、`MatchPrefix`、`StripPrefix` 与 `ModelProtocols`；`balance_mode`/`epp_config` 字段处理与 EPPAddr 分配驱动生成 |
+| `model/epp_pool` | EPP 实例池读写（`/epp-pool` 单例池全量替换）、分配器（贪心 + 字典序 tie-break，含 30s 周期 reconciler）、epp_data generator（`ConfigTopicEppData`：epp_config 编译产物 + assignment 全量视图）、`epp_config` 简化用户形态 → `EndpointPickerConfig` 确定性编译 |
 | `model/iprovider` | Provider 业务逻辑：CRUD、模型发现、被 cluster 引用检查 |
 | `model/imodel_price` | `ModelPrice` 模型定价管理：`model-list.yaml` 导入、单条 CRUD、分页查询、按 provider 查询、查询所有 price provider 名称；`provider` 不强制引用已存在的 Provider |
 | `model/iroute_conf` | 基础/高级路由规则、Domain 业务逻辑 |
@@ -379,6 +386,8 @@ type Endpoint struct {
 | `model_price` | `/model-prices` | 模型定价管理 |
 | `certificate` | `/certificates` | 证书管理 |
 | `bfe_pool` | `/alb-pool` | 默认 AI 实例池 |
+| `epp_pool` | `/epp-pool` | EPP 实例池（单例池，GET 详情 + PATCH 全量替换） |
+| `epp_assignments` | `/epp-assignments` | EPP 分配全量视图查询与手工覆写 |
 | `auth` | `/auth`、`/meta` | 用户、Session Key、Token（Scope 收敛为 System/Support） |
 | `operation_log` | `/operation-logs` | 操作日志查询（需 `FeatureOperationLog + ActionReadAll`） |
 | `route` | `/expression/verify` | BFE 表达式校验（需 `FeatureRoute + ActionRead`） |
@@ -396,6 +405,7 @@ type Endpoint struct {
 | `/configs/mod-body-process` | 导出请求体处理配置 |
 | `/configs/rate-limit-policy` | 导出限流策略配置 |
 | `/configs/ai-route` | 导出 AI 路由配置 |
+| `/configs/epp_data/config` | 导出 EPP 配置（`ConfigTopicEppData`：epp_config 编译产物 + assignment 全量视图，单 topic 两段合并） |
 
 更多接口清单、中间件执行顺序、参数绑定方式、鉴权机制和典型代码示例详见《接口层设计文档.md》。
 

--- a/design-docs/sys-design/接口层设计文档.md
+++ b/design-docs/sys-design/接口层设计文档.md
@@ -39,6 +39,8 @@ ai-gateway-api/endpoints/
 │ ├── bfe_pool/ # ALB 池（/alb-pool）
 │ ├── certificate/ # 证书（/certificates）
 │ ├── domain/ # 域名（当前未注册）
+│ ├── epp_assignments/ # EPP 分配查询与手工覆写（/epp-assignments）
+│ ├── epp_pool/ # EPP 实例池（/epp-pool，单例池）
 │ ├── entity/ # Entity 管理（/entities）
 │ ├── entity_type/ # Entity-Type 管理（/entity-types）
 │ ├── global_route_rules/ # Global 路由表（/global-route-rules）
@@ -53,6 +55,7 @@ ai-gateway-api/endpoints/
 └── innerapi_v1/ # 数据面 Inner-API（BFE 配置拉取）
     ├── endpoints.go # 统一注册 Inner-API 导出接口
     ├── ai_route/
+    ├── epp_data/ # epp_data 导出（/configs/epp_data/config）
     ├── extra_file/
     ├── gslb_data/
     ├── mod_api_key/
@@ -131,6 +134,8 @@ func endpoints() []*xreq.Endpoint {
         model_price.Endpoints, // 新增：模型定价管理
         operation_log.Endpoints, // 新增：操作日志查询
         provider.Endpoints, // 新增：Provider 管理
+        epp_pool.Endpoints, // 新增：EPP 实例池（/epp-pool）
+        epp_assignments.Endpoints, // 新增：EPP 分配查询与手工覆写（/epp-assignments）
     )
 }
 ```
@@ -237,7 +242,7 @@ func endpoints() []*xreq.Endpoint {
 
 代码位置：`endpoints/openapi_v1/provider/`、`endpoints/openapi_v1/product_cluster/`、`endpoints/openapi_v1/model_price/`
 
-> 说明：Provider 与 Cluster 概念分离后，`/providers` 集中管理接入能力（`model_endpoint`、`models`、`keys`、`instance_pool`、`model_protocols`），并通过 `time_zone` / `tiers` 描述高峰/闲时时段规则；`/clusters` 只保留转发策略。`llm_config.provider` 必填，且必须引用 `/providers` 中已存在的 Provider；`llm_config.models` 须为 Provider `models` 的子集；`llm_config.keys` 元素结构变为 `{name, weight}`，通过 `name` 引用 Provider 中的 key，不再返回 key 明文。`llm_config.model_endpoint`、`llm_config.provider_type` 已删除。`llm_config.model_mappings` 字段仍使用 `source_model`/`target_model` 描述模型映射；`llm_config.key_policy` 用于声明选择策略、请求内重试与退避参数；`llm_config.key_affinity` 用于声明基于 Redis + `ClientKeyId` 的会话级 Key 亲和性（含开关、空闲超时、Redis 前缀、Key 惩罚）。InnerAPI 据此自动填充 `AIConf.ModelTable`：从 Provider 取 `time_zone` / `tiers`，从 `model-prices` 取 `prices` / `tier_prices`，并将 Provider 的 `model_protocols` 透传为 `AIConf.ModelProtocols`；`llm_config.model_table` 不在 OpenAPI `/clusters` 中展示。集群实例 `weight=0` 表示不接收流量，不会被后端强制改为默认值。
+> 说明：Provider 与 Cluster 概念分离后，`/providers` 集中管理接入能力（`model_endpoint`、`models`、`keys`、`instance_pool`、`model_protocols`），并通过 `time_zone` / `tiers` 描述高峰/闲时时段规则；`/clusters` 只保留转发策略。`llm_config.provider` 必填，且必须引用 `/providers` 中已存在的 Provider；`llm_config.models` 须为 Provider `models` 的子集；`llm_config.keys` 元素结构变为 `{name, weight}`，通过 `name` 引用 Provider 中的 key，不再返回 key 明文。`llm_config.model_endpoint`、`llm_config.provider_type` 已删除。`llm_config.model_mappings` 字段仍使用 `source_model`/`target_model` 描述模型映射；`llm_config.key_policy` 用于声明选择策略、请求内重试与退避参数；`llm_config.key_affinity` 用于声明基于 Redis + `ClientKeyId` 的会话级 Key 亲和性（含开关、空闲超时、Redis 前缀、Key 惩罚）。InnerAPI 据此自动填充 `AIConf.ModelTable`：从 Provider 取 `time_zone` / `tiers`，从 `model-prices` 取 `prices` / `tier_prices`，并将 Provider 的 `model_protocols` 透传为 `AIConf.ModelProtocols`；`llm_config.model_table` 不在 OpenAPI `/clusters` 中展示。集群实例 `weight=0` 表示不接收流量，不会被后端强制改为默认值。`/clusters` 另新增 `balance_mode`（默认 `WRR`，可选 `EPP`）与 `epp_config`（简化用户形态的 EPP 调度配置，EPP 模式必填、WRR 时休眠保留）两个字段，EPP 模式 cluster 的 EPPAddr 由分配驱动生成（详见 `epp_pool` / `epp_assignments` 域）。
 >
 > **更新与删除约束**：
 > - `PATCH /providers/{provider_name}` 的请求体**不能包含 `name`**；名称由 URI 路径参数唯一指定，若请求体携带 `name` 返回 422。
@@ -303,6 +308,28 @@ func endpoints() []*xreq.Endpoint {
 | Method | Path | 用途 | Authorizer |
 |--------|------|------|------------|
 | GET | `/operation-logs` | 分页查询操作日志 | `FeatureOperationLog + ActionReadAll` |
+
+#### 4.2.10 EPP 实例池（epp_pool）
+
+代码位置：`endpoints/openapi_v1/epp_pool/`
+
+> 说明：单例池（池名由配置项 `RunTime.DefaultEPPInstancePoolName` 提供，默认 `EPP.pool`），模式对齐 `/alb-pool`；实例列表是部署事实，由部署流程在扩缩容/换机后 reconcile `PATCH`（全量替换，天然幂等）。校验组名非空唯一、实例 id 池内全局唯一、`(host, port)` 组合唯一、组规模满足部署形态要求（生产每组恰 2 实例，测试允许单实例组）。`PATCH` 后触发分配悬空自动修复（同组重选 primary 或跨组重分配），由 `model/epp_pool` 分配器完成。
+
+| Method | Path | 用途 | Authorizer |
+|--------|------|------|------------|
+| GET | `/epp-pool` | 查询 EPP 实例池详情（实例组 + 实例列表） | `FeatureBFEPool + ActionReadAll` |
+| PATCH | `/epp-pool` | 全量替换 EPP 实例池（组 + 实例两级） | `FeatureBFEPool + ActionUpdate` |
+
+#### 4.2.11 EPP 分配（epp_assignments）
+
+代码位置：`endpoints/openapi_v1/epp_assignments/`
+
+> 说明：分配由分配器自动生成（cluster 进入 EPP 模式、`/epp-pool` 变更后悬空修复、30s 周期对账 reconciler），本域提供查询视图与手工覆写（运维兜底）。视图是 `epp_assignments` 与 `epp_instances` 的读时 join，per-cluster 展开 `{group, primary, standby}`，不一致标记 `degraded`，并汇总 `unassigned_clusters` 与 `idle_groups`；手工覆写校验 `primary_instance_id` 存在于目标组实例列表，成功后触发 server_data_conf version bump。
+
+| Method | Path | 用途 | Authorizer |
+|--------|------|------|------------|
+| GET | `/epp-assignments` | 分配全量视图（可按 `cluster` 过滤） | `FeatureBFEPool + ActionReadAll` |
+| PUT | `/epp-assignments/{cluster}` | 手工覆写单个 cluster 的分配 `{group_name, primary_instance_id}` | `FeatureBFEPool + ActionUpdate` |
 
 ### 4.3 典型接口实现
 
@@ -567,6 +594,7 @@ func endpoints() []*xreq.Endpoint {
         mod_body_process.ExportRoute,
         rate_limit_policy.ExportRoute,
         ai_route.ExportRoute,
+        epp_data.ExportRoute,
     }
 }
 ```
@@ -584,6 +612,7 @@ func endpoints() []*xreq.Endpoint {
 | GET | `/configs/mod-body-process` | 导出请求体处理配置 | `FeatureAPIKey + ActionExport` |
 | GET | `/configs/rate-limit-policy` | 导出限流策略配置 | `FeatureRateLimitPolicy + ActionExport` |
 | GET | `/configs/ai-route` | 导出 AI 路由配置 | `FeatureRoute + ActionExport` |
+| GET | `/configs/epp_data/config` | 导出 EPP 配置（`ConfigTopicEppData`：epp_config 编译产物 + assignment 全量视图，单 topic 两段合并） | `FeatureRoute + ActionExport` |
 
 所有 Inner-API 导出接口均支持 `version` 查询参数，通过 `export_util.NewExportFromReq` 解析，并交给对应 Manager 的 `ConfigExport` 方法处理。当配置未变化时返回 `Data: nil`。
 

--- a/design-docs/sys-design/数据库设计文档.md
+++ b/design-docs/sys-design/数据库设计文档.md
@@ -24,13 +24,13 @@
 
 ### 1.3 表清单
 
-按业务模块划分，共 29 张表：
+按业务模块划分，共 31 张表：
 
 | 模块 | 表名 |
 |------|------|
 | 基础配置 | `bfe_clusters`、`products`、`domains`、`users`、`user_products`、`config_versions` |
 | Provider | `providers` |
-| 集群与实例池 | `clusters`、`sub_clusters`、`pools`、`lb_matrices` |
+| 集群与实例池 | `clusters`、`sub_clusters`、`pools`、`lb_matrices`、`epp_instances`、`epp_assignments` |
 | 路由规则 | `route_basic_rules`、`route_advance_rules`、`route_default_rules`、`route_cases`、`ai_route_rules`、`route_rules` |
 | 证书与附加文件 | `certificates`、`extra_files` |
 | API Key / Entity / 配额 / 限流 | `api_keys`、`api_key_id_seq`、`api_key_tokens`、`entity_types`、`entities`、`entity_id_seq`、`quota_plans`、`rate_limit_policies` |
@@ -303,6 +303,8 @@ CREATE TABLE `clusters` (
   `failure_status` tinyint(1) NOT NULL DEFAULT 0,
   `max_conns_per_host` int(11) NOT NULL DEFAULT 0,
   `llm_config` text,
+  `balance_mode` varchar(16) NOT NULL DEFAULT 'WRR',
+  `epp_config` text,
   `created_at` datetime NOT NULL,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
@@ -345,6 +347,8 @@ CREATE TABLE `clusters` (
 | `failure_status` | tinyint(1) | NOT NULL DEFAULT 0 | 失败状态 |
 | `max_conns_per_host` | int(11) | NOT NULL DEFAULT 0 | 每主机最大连接 |
 | `llm_config` | text | NULL | LLM 转发策略 JSON；当前包含 `models`、`model_mappings`、`keys`（Key 引用与权重数组，元素为 `{name, weight}`）、`key_policy`、`key_affinity`（会话级 Key 亲和性配置，包含 `enabled`、`ttl`、`redis_prefix`、`penalty_enable`）、`provider`（必填，引用 `providers.name`）、`match_prefix`、`strip_prefix` 等字段；`model_endpoint`、`provider_type` 已移除，key 明文下沉到 Provider |
+| `balance_mode` | varchar(16) | NOT NULL DEFAULT 'WRR' | 集群均衡模式：`WRR`（BFE 本地加权轮询，默认）/ `EPP`（EPP 调度器接管后端选择）；**唯一判定来源**（`getBalanceMode()` 直读该字段，pool `Role` 派生逻辑已删除） |
+| `epp_config` | text | NULL | EPP 调度配置 JSON，**简化用户形态**（调度档位 + 一等公民调优参数，导出时确定性编译为完整 `EndpointPickerConfig`）；非空即须通过字段校验（与 `balance_mode` 无关），仅 `balance_mode=EPP` 时编译下发，`WRR` 时保留休眠（切换模式不丢配置） |
 | `created_at` | datetime | NOT NULL | 创建时间 |
 | `updated_at` | timestamp | 自动更新 | 更新时间 |
 
@@ -440,9 +444,65 @@ CREATE TABLE `pools` (
 | `type` | tinyint(4) | NOT NULL DEFAULT 1 | 类型 |
 | `tag` | tinyint(4) | NOT NULL DEFAULT 0 | 标签 |
 | `role` | varchar(32) | NOT NULL DEFAULT 'COMMON' | 角色 |
-| `epp_server` | mediumtext | NULL | EPP 配置 JSON |
+| `epp_server` | mediumtext | NULL | EPP 配置 JSON；本期已无消费方（EPP 实例池独立存储于 `epp_instances`），保留待后续版本清理 |
 | `created_at` | datetime | NOT NULL | 创建时间 |
 | `updated_at` | timestamp | 自动更新 | 更新时间 |
+
+### 3.6 `epp_instances`
+
+EPP 实例池存储表，一行一个 EPP 实例（llm-d Endpoint Picker）。实例列表是**部署事实**：由 `/epp-pool` 全量替换写入，api 侧不做心跳续约与存活标记。
+
+```sql
+CREATE TABLE `epp_instances` (
+  `id` varchar(255) NOT NULL,
+  `host` varchar(255) NOT NULL,
+  `port` int(11) NOT NULL,
+  `group_name` varchar(255) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `host_port_uni` (`host`, `port`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+```
+
+| 字段 | 类型 | 约束 | 说明 |
+|------|------|------|------|
+| `id` | varchar(255) | 主键 | 实例 id，池内全局唯一；EPP 进程以 `-instance-id` 启动参数对应此值（StatefulSet 部署时缺省为 Pod hostname，同组副本共享相同启动参数） |
+| `host` | varchar(255) | NOT NULL、联合唯一 | 实例地址，Hostname 或 IP（IPv6 字面量不带括号）；导出拼接 `host:port` 时经 `net.JoinHostPort` 自动加括号 |
+| `port` | int(11) | NOT NULL、联合唯一 | 实例端口；`(host, port)` 组合池内地址唯一 |
+| `group_name` | varchar(255) | NOT NULL | 所属实例组名（对应 `/epp-pool` 的 `groups[].name`） |
+| `created_at` | datetime | NOT NULL | 创建时间 |
+| `updated_at` | timestamp | 自动更新 | 更新时间 |
+
+> 说明：实例**无 `status` / `last_heartbeat` 字段**——存活感知在 BFE 侧（EPPAddr 连接滞回），api 侧不做存活标记。组规模校验在 `/epp-pool` 写入时完成（生产每组恰 2 实例主备，测试允许单实例组）。
+
+### 3.7 `epp_assignments`
+
+cluster → EPP 实例组分配表，**只存主**（standby 读时展开为同组除 primary 外的实例，避免双写不一致）。
+
+```sql
+CREATE TABLE `epp_assignments` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `cluster` varchar(255) NOT NULL,
+  `group_name` varchar(255) NOT NULL,
+  `primary_instance_id` varchar(255) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `cluster_uni` (`cluster`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+```
+
+| 字段 | 类型 | 约束 | 说明 |
+|------|------|------|------|
+| `id` | bigint(20) | 主键、自增 | 主键 ID |
+| `cluster` | varchar(255) | NOT NULL、唯一 | 集群名（引用 `clusters.name`），每个 cluster 至多一条分配记录 |
+| `group_name` | varchar(255) | NOT NULL | 分配的 EPP 实例组名（引用 `epp_instances.group_name`） |
+| `primary_instance_id` | varchar(255) | NOT NULL | 主实例 id（引用 `epp_instances.id`） |
+| `created_at` | datetime | NOT NULL | 创建时间 |
+| `updated_at` | timestamp | 自动更新 | 更新时间 |
+
+> 说明：分配由**分配器自动生成**（cluster 进入 EPP 模式、`/epp-pool` 变更后悬空修复、30s 周期对账 reconciler），`PUT /api/v1/epp-assignments/{cluster}` 手工覆写作为运维兜底。`EPP → WRR` 后分配记录**休眠保留**（不进 epp_data 导出），切回 EPP 继续生效。
 
 ---
 
@@ -1204,6 +1264,15 @@ CREATE TABLE `operation_logs` (
 | `entities` | `entity_id` | `api_keys.entity_id` |
 | `entity_types` | `type_name` | `entities.type` |
 
+### 7.6 集群与 EPP 实例池 / 分配
+
+| 主表 | 从表 | 字段 | 说明 |
+|------|------|------|------|
+| `clusters` | `epp_assignments` | `epp_assignments.cluster` | cluster → EPP 实例组分配（cluster 唯一键，逻辑引用 `clusters.name`）；仅 `balance_mode=EPP` 的 cluster 参与分配与导出 |
+| `epp_instances` | `epp_assignments` | `epp_assignments.group_name` / `primary_instance_id` | 分配引用实例组与主实例（逻辑引用 `epp_instances.group_name` / `epp_instances.id`）；standby 读时展开为同组除 primary 外的实例，不冗余存储 |
+
+`epp_instances`、`epp_assignments` 两表独立成池，不复用 `pools`/`sub_clusters` 机制（后者保留给 BFE 实例池）。cluster ↔ EPP 实例组的关联全部经 `epp_assignments`，`clusters` 表仅新增 `balance_mode`、`epp_config` 两列。
+
 ---
 
 ## 8. 初始数据
@@ -1223,4 +1292,4 @@ CREATE TABLE `operation_logs` (
 2. **`users` 表复用**：普通用户与 API Token 共用 `users` 表，通过 `type` 字段区分：0=普通用户，1=Token。
 3. **`route_cases` 表**：仅在 DDL 中定义，当前代码中无对应 DAO 与业务代码引用。
 4. **MySQL 与 SQLite**：字段类型等价；SQLite 通过 trigger 模拟 `updated_at` 自动更新。
-5. **JSON 字段**：`providers.model_endpoint`、`providers.models`、`providers.keys`、`providers.instance_pool`、`providers.model_protocols`、`providers.tiers`、`instance_detail`、`lb_matrix`、`llm_config`、`allowed_models`、`subnet`、`tpm_configs`、`rpm_configs`、`rules`、`basic`、`params`、`route_action`、`host_names`、`paths`、`model_prices.capabilities`、`model_prices.supported_parameters`、`model_prices.limits`、`model_prices.prices`、`model_prices.tier_prices`、`model_prices.metadata` 等字段均为 JSON 或文本序列化存储。
+5. **JSON 字段**：`providers.model_endpoint`、`providers.models`、`providers.keys`、`providers.instance_pool`、`providers.model_protocols`、`providers.tiers`、`instance_detail`、`lb_matrix`、`llm_config`、`clusters.epp_config`、`allowed_models`、`subnet`、`tpm_configs`、`rpm_configs`、`rules`、`basic`、`params`、`route_action`、`host_names`、`paths`、`model_prices.capabilities`、`model_prices.supported_parameters`、`model_prices.limits`、`model_prices.prices`、`model_prices.tier_prices`、`model_prices.metadata` 等字段均为 JSON 或文本序列化存储。

--- a/design-docs/sys-design/模型层设计文档.md
+++ b/design-docs/sys-design/模型层设计文档.md
@@ -39,6 +39,10 @@ model/
 │ ├── pool.go # Pool 模型；实例池数据来自 Provider，按 cluster 生成 BFE 配置
 │ ├── model_price.go # ModelPrice 模型（按 provider 查询，供 AIConf.ModelTable 使用）
 │ └── exporter.go # 集群配置导出
+├── epp_pool/
+│ ├── epp_pool.go # EPP 实例池模型与 Manager（/epp-pool 单例池读写）
+│ ├── assignment.go # 分配器（贪心 + 字典序 tie-break）与 reconciler
+│ └── epp_data.go # epp_data generator：epp_config 编译 + assignment 全量视图
 ├── iprovider/
 │ ├── provider.go # Provider 实体与 CRUD
 │ └── discover.go # 模型发现逻辑
@@ -848,6 +852,14 @@ type AIConf struct {
    - 若 `Provider` 为空或该 provider 无记录，`ModelTable.Models` 为空列表。
 
 `model_prices` 变更不会同步触发 InnerAPI 推送，由 BFE/Conf Agent 按自身周期拉取配置。
+
+#### Cluster EPP 调度相关改造
+
+EPP（llm-d 调度器）接入后，`model/icluster_conf/cluster.go` 承担以下改造点：
+
+- `Cluster` 结构体新增 `balance_mode`（varchar，默认 `WRR`，取值 `WRR`/`EPP`）与 `epp_config`（JSON text，简化用户形态）两字段。`balance_mode` 是 EPP 模式的**唯一判定来源**：`getBalanceMode()` 直读该字段，原 pool `Role` 派生逻辑已删除；创建流程按 `balance_mode` 生成 `Role=COMMON`/`Role=EPP` 的 pool。
+- `epp_config` 非空即须通过字段校验（与 `balance_mode` 无关）；`balance_mode=EPP` 时必填并生效，`WRR` 时保留休眠（不编译、不导出，切换模式不丢配置）。校验规则内聚在 cluster 创建/更新路径（`balance_mode=EPP` 缺 `epp_config` 返回 422）。
+- EPPAddr 生成由静态派生（旧 `pools.epp_server`）改为**分配驱动**：`balance_mode=EPP` 且有有效分配时，按 `epp_assignments` 生成有序 `GslbBasic.EPPAddr [主, 备]`（host/port 经 `net.JoinHostPort` 拼接）；无有效分配时**降级导出**——该 cluster `BalanceMode` 置为 `WRR`、不生成 `EPPAddr`，同时输出 error 级日志（含 cluster 名与原因），不阻塞整份 server_data_conf 下发。降级与 EPPAddr 生成逻辑位于 `model/iroute_conf/exporter.go` 的 server_data_conf 导出路径。
 
 #### 4.3.2 Provider 模型
 
@@ -2217,6 +2229,17 @@ Provider 管理不影响 InnerAPI 导出配置的结构，仅改变 `AIConf` 内
 
 ---
 
+### 4.15 `model/epp_pool`
+
+EPP 调度对接模型，承担 EPP（llm-d 调度器）控制面职责：实例池读写、cluster→实例组分配、epp_data 导出。
+
+- **实例池管理**：`/epp-pool` 单例池（池名由配置项 `RunTime.DefaultEPPInstancePoolName` 提供，默认 `EPP.pool`）的读写字段模型；`PATCH` 全量替换（组 + 实例两级）展开写入 `epp_instances`，校验组名唯一、实例 id 池内全局唯一、`(host, port)` 组合唯一、组规模满足部署形态要求（生产恰 2 实例，测试允许单实例组）。
+- **分配器**：贪心 + 字典序 tie-break（组负载最小优先、并列取组名字典序最小；组内 primary 负载最少优先、并列取实例 id 字典序最小），全程确定性、可重放。触发点：cluster 创建/`WRR → EPP` 变更时同步自动分配；`/epp-pool` PATCH 后悬空修复（同组重选 primary 或跨组重分配）；30s 周期对账 reconciler（可配，幂等）。`PUT /epp-assignments/{cluster}` 手工覆写作为运维兜底。
+- **epp_data generator**：生成 `ConfigTopicEppData` topic 的两段配置——`epp_config` 段（`balance_mode=EPP` 的 cluster → 编译后 `EndpointPickerConfig`）与 `assignment` 段（cluster → `{primary, standby}` 全量视图，`epp_assignments` 与 `epp_instances` 读时 join，只存主、standby 读时展开）；单 topic 两段合并保证同一 version 原子快照，复用 `model/iversion_control` 的 `ExportConfig` 框架。
+- **epp_config 编译**：把 `clusters.epp_config` 的简化用户形态（调度档位 + 一等公民调优参数 + 流控）**确定性编译**为完整 `EndpointPickerConfig`（档位权重映射、亲和 scorer 条件注入、flowControl 段展开、featureGates 追加、固定插件注入），编译规则固化并单测覆盖；仅 `balance_mode=EPP` 时编译下发，WRR 时休眠保留。
+
+---
+
 ## 5. 典型业务流程
 
 ### 5.1 API Key 创建流程
@@ -2289,7 +2312,8 @@ ID 生成方式与 API Key 一致：Endpoint 在 `param.EntityID` 为空时，�
 | `entity` | `entity_type.go`、`entity_type_manager.go`、`entity.go`、`entity_manager.go`、`id_generator.go` | Entity / Entity-Type 模型与业务逻辑；`EntityIDGenerator` ID 生成器接口（`entity-{seq}`，基于 `entity_id_seq` 原子分配） |
 | `ibasic` | `product.go`、`bfe_cluster.go`、`extra_file.go` | 基础资源模型 |
 | `iauth` | `authentication.go`、`authorization.go`、`features.go` | 认证授权模型 |
-| `icluster_conf` | `cluster.go`、`sub_cluster.go`、`pool.go`、`model_price.go`、`exporter.go` | 集群/子集群/实例池模型；Cluster 只保留转发策略，后端能力通过 provider 引用获取 |
+| `icluster_conf` | `cluster.go`、`sub_cluster.go`、`pool.go`、`model_price.go`、`exporter.go` | 集群/子集群/实例池模型；Cluster 只保留转发策略，后端能力通过 provider 引用获取；`balance_mode`/`epp_config` 字段处理与 EPPAddr 分配驱动生成 |
+| `epp_pool` | `epp_pool.go`、`assignment.go`、`epp_data.go` | EPP 实例池读写、分配器（贪心 + 字典序 tie-break，含 30s 周期 reconciler）、epp_data generator、epp_config 简化形态 → EndpointPickerConfig 确定性编译 |
 | `iprovider` | `provider.go`、`discover.go` | Provider 模型与模型发现 |
 | `imodel_price` | `model_price.go`、`import.go` | 模型定价管理；`provider` 须引用已存在的 Provider |
 | `iroute_conf` | `route_rule.go`、`domain.go` | 路由与域名模型 |
@@ -2311,6 +2335,7 @@ ID 生成方式与 API Key 一致：Endpoint 在 `param.EntityID` 为空时，�
 | `auth` | `authentication.go`、`authorization.go` | 认证授权存储 |
 | `api_key` | `api_key.go`、`id_generator.go` | API-Key 存储；`RDBAPIKeyIDGenerator` 基于 `api_key_id_seq` 表原子分配 ID |
 | `cluster_conf` | `cluster.go`、`sub_cluster.go`、`pool.go`、`model_price.go` | 集群/子集群/实例池存储；实例池数据来自 Provider |
+| `epp_pool` | `epp_instance.go`、`epp_assignment.go` | EPP 实例池与分配存储（`epp_instances`、`epp_assignments`，cluster 唯一键 upsert，全量替换语义） |
 | `provider` | `provider.go` | Provider 存储 |
 | `entity` | `entity.go`、`entity_type.go`、`id_generator.go` | Entity / Entity-Type 存储；`RDBEntityIDGenerator` 基于 `entity_id_seq` 表原子分配 ID |
 | `route_conf` | `route_rule.go`、`domain.go` | 路由与域名存储 |

--- a/endpoints/innerapi_v1/endpoints.go
+++ b/endpoints/innerapi_v1/endpoints.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/innerapi_v1/ai_route"
+	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/innerapi_v1/epp_data"
 	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/innerapi_v1/extra_file"
 	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/innerapi_v1/gslb_data"
 	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/innerapi_v1/mod_api_key"
@@ -42,6 +43,7 @@ func endpoints() []*xreq.Endpoint {
 		quota_reset.TriggerResetRoute,
 		rate_limit_policy.ExportRoute,
 		ai_route.ExportRoute,
+		epp_data.ExportRoute,
 	}
 }
 

--- a/endpoints/innerapi_v1/endpoints_test.go
+++ b/endpoints/innerapi_v1/endpoints_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestEndpoints(t *testing.T) {
 	eps := endpoints()
-	require.Len(t, eps, 10)
+	require.Len(t, eps, 11)
 
 	paths := make([]string, 0, len(eps))
 	for _, ep := range eps {
@@ -47,6 +47,7 @@ func TestEndpoints(t *testing.T) {
 		"/quota/trigger-reset",
 		"/configs/rate-limit-policy",
 		"/configs/ai-route",
+		"/configs/epp_data/config",
 	}, paths)
 }
 
@@ -76,4 +77,5 @@ func TestRegisterRouter(t *testing.T) {
 	assert.Contains(t, matchedPaths, "/inner-api/v1/quota/trigger-reset")
 	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/rate-limit-policy")
 	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/ai-route")
+	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/epp_data/config")
 }

--- a/endpoints/innerapi_v1/epp_data/export.go
+++ b/endpoints/innerapi_v1/epp_data/export.go
@@ -1,0 +1,49 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+// Package epp_data exposes the InnerAPI export endpoint of the merged EPP
+// data config (epp_config + assignment, see design-docs/api-define/
+// InnerAPI接口定义/epp-data.md).
+package epp_data
+
+import (
+	"net/http"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/innerapi_v1/export_util"
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xreq"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iauth"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful/container"
+)
+
+// ExportRoute route
+var ExportRoute = &xreq.Endpoint{
+	Path:       "/configs/epp_data/config",
+	Method:     http.MethodGet,
+	Handler:    xreq.Convert(ExportAction),
+	Authorizer: iauth.FA(iauth.FeatureRoute, iauth.ActionExport),
+}
+
+var _ xreq.Handler = ExportAction
+
+// ExportAction exports the epp_data config. When the version carried by the
+// request is still the latest one, a nil payload is returned (Data: null
+// semantics, see epp-data.md §4).
+func ExportAction(req *http.Request) (interface{}, error) {
+	param, err := export_util.NewExportFromReq(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return container.EppPoolManager.ExportEppData(req.Context(), param.Version)
+}

--- a/endpoints/innerapi_v1/epp_data/export_test.go
+++ b/endpoints/innerapi_v1/epp_data/export_test.go
@@ -1,0 +1,209 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_data
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/innerapi_v1/internal/testutil"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeEppPoolStorager is a hand-written in-memory EppPoolStorager for
+// handler tests.
+type fakeEppPoolStorager struct {
+	mu          sync.Mutex
+	instances   map[string]*epp_pool.InstanceParam
+	assignments map[string]*epp_pool.AssignmentParam
+}
+
+func newFakeEppPoolStorager() *fakeEppPoolStorager {
+	return &fakeEppPoolStorager{
+		instances:   map[string]*epp_pool.InstanceParam{},
+		assignments: map[string]*epp_pool.AssignmentParam{},
+	}
+}
+
+func (s *fakeEppPoolStorager) FetchInstanceList(ctx context.Context, filter *epp_pool.InstanceFilter) ([]*epp_pool.InstanceParam, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rst := []*epp_pool.InstanceParam{}
+	for _, inst := range s.instances {
+		rst = append(rst, inst)
+	}
+	sort.Slice(rst, func(i, j int) bool { return rst[i].ID < rst[j].ID })
+	return rst, nil
+}
+
+func (s *fakeEppPoolStorager) CreateInstances(ctx context.Context, params []*epp_pool.InstanceParam) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, param := range params {
+		s.instances[param.ID] = param
+	}
+	return int64(len(params)), nil
+}
+
+func (s *fakeEppPoolStorager) DeleteInstances(ctx context.Context, filter *epp_pool.InstanceFilter) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var affected int64
+	for id := range s.instances {
+		delete(s.instances, id)
+		affected++
+	}
+	return affected, nil
+}
+
+func (s *fakeEppPoolStorager) FetchAssignment(ctx context.Context, cluster string) (*epp_pool.AssignmentParam, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.assignments[cluster], nil
+}
+
+func (s *fakeEppPoolStorager) FetchAssignmentList(ctx context.Context) ([]*epp_pool.AssignmentParam, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rst := []*epp_pool.AssignmentParam{}
+	for _, assignment := range s.assignments {
+		rst = append(rst, assignment)
+	}
+	sort.Slice(rst, func(i, j int) bool { return rst[i].Cluster < rst[j].Cluster })
+	return rst, nil
+}
+
+func (s *fakeEppPoolStorager) UpsertAssignment(ctx context.Context, param *epp_pool.AssignmentParam) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.assignments[param.Cluster] = param
+	return nil
+}
+
+func (s *fakeEppPoolStorager) DeleteAssignment(ctx context.Context, cluster string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.assignments, cluster)
+	return nil
+}
+
+type fakeClusterSource struct {
+	clusters []*epp_pool.EPPClusterInfo
+}
+
+func (f *fakeClusterSource) FetchEPPClusters(ctx context.Context) ([]*epp_pool.EPPClusterInfo, error) {
+	return f.clusters, nil
+}
+
+const testExportedVersion = "20260906120000"
+
+// setupManager swaps container.EppPoolManager with one backed by in-memory
+// fakes plus a fake version-control manager pinned to testExportedVersion.
+func setupManager(t *testing.T) func() {
+	old := container.EppPoolManager
+	storager := newFakeEppPoolStorager()
+
+	instances := []*epp_pool.InstanceParam{
+		{ID: "epp-a", Host: "10.0.0.1", Port: 9002, GroupName: "g1"},
+		{ID: "epp-b", Host: "10.0.0.2", Port: 9002, GroupName: "g1"},
+		{ID: "epp-c", Host: "10.0.0.3", Port: 9002, GroupName: "g2"},
+	}
+	if _, err := storager.CreateInstances(context.Background(), instances); err != nil {
+		t.Fatalf("seed instances: %v", err)
+	}
+	if err := storager.UpsertAssignment(context.Background(), &epp_pool.AssignmentParam{
+		Cluster:           "cluster-a",
+		GroupName:         "g1",
+		PrimaryInstanceID: "epp-a",
+	}); err != nil {
+		t.Fatalf("seed assignment: %v", err)
+	}
+	if err := storager.UpsertAssignment(context.Background(), &epp_pool.AssignmentParam{
+		Cluster:           "cluster-b",
+		GroupName:         "g2",
+		PrimaryInstanceID: "epp-c",
+	}); err != nil {
+		t.Fatalf("seed assignment: %v", err)
+	}
+
+	clusterSource := &fakeClusterSource{clusters: []*epp_pool.EPPClusterInfo{
+		{Name: "cluster-a", EppConfigJSON: `{"scheduling_profile":"balanced","kv_cache_utilization_max":0.9}`},
+		{Name: "cluster-b", EppConfigJSON: `{"scheduling_profile":"latency-first"}`},
+	}}
+
+	container.EppPoolManager = epp_pool.NewEppPoolManager(
+		&testutil.FakeTxn{},
+		storager,
+		clusterSource,
+		testutil.NewVersionControlManager(testExportedVersion),
+		&epp_pool.ManagerOptions{ValidationMode: epp_pool.ValidationModeTest},
+	)
+	return func() { container.EppPoolManager = old }
+}
+
+func TestExportAction(t *testing.T) {
+	defer setupManager(t)()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/epp_data/config?version=", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	conf, ok := data.(*epp_pool.ExportEppDataConfig)
+	require.True(t, ok)
+	assert.Equal(t, testExportedVersion, conf.Version)
+	require.NotNil(t, conf.Config)
+
+	// epp_config section: one compiled entry per EPP-mode cluster.
+	require.Len(t, conf.Config.EppConfig, 2)
+	assert.Contains(t, conf.Config.EppConfig, "cluster-a")
+	assert.Contains(t, conf.Config.EppConfig, "cluster-b")
+
+	// assignment section: standby is expanded at read time; a single
+	// instance group exports a null standby.
+	require.Len(t, conf.Config.Assignment, 2)
+	entryA := conf.Config.Assignment["cluster-a"]
+	require.NotNil(t, entryA)
+	assert.Equal(t, "epp-a", entryA.Primary)
+	require.NotNil(t, entryA.Standby)
+	assert.Equal(t, "epp-b", *entryA.Standby)
+
+	entryB := conf.Config.Assignment["cluster-b"]
+	require.NotNil(t, entryB)
+	assert.Equal(t, "epp-c", entryB.Primary)
+	assert.Nil(t, entryB.Standby)
+}
+
+func TestExportAction_VersionNotChanged(t *testing.T) {
+	defer setupManager(t)()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/epp_data/config?version="+testExportedVersion, nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}

--- a/endpoints/openapi_v1/endpoints.go
+++ b/endpoints/openapi_v1/endpoints.go
@@ -26,6 +26,8 @@ import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/openapi_v1/domain"
 	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/openapi_v1/entity"
 	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/openapi_v1/entity_type"
+	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/openapi_v1/epp_assignments"
+	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/openapi_v1/epp_pool"
 	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/openapi_v1/global_route_rules"
 	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/openapi_v1/model_price"
 	"github.com/rainway-ai-gateway/ai-gateway-api/endpoints/openapi_v1/operation_log"
@@ -57,6 +59,8 @@ func endpoints() []*xreq.Endpoint {
 		product_pool.Endpoints,
 		subcluster.Endpoints,
 		bfe_pool.Endpoints,
+		epp_pool.Endpoints,
+		epp_assignments.Endpoints,
 		auth.Endpoints,
 		traffic.Endpoints,
 		bfe_cluster.Endpoints,

--- a/endpoints/openapi_v1/endpoints_test.go
+++ b/endpoints/openapi_v1/endpoints_test.go
@@ -37,6 +37,9 @@ func TestEndpoints(t *testing.T) {
 	// Sanity check that some well-known paths are registered.
 	assert.Contains(t, paths, "/auth/users")
 	assert.Contains(t, paths, "/clusters")
+	assert.Contains(t, paths, "/epp-pool")
+	assert.Contains(t, paths, "/epp-assignments")
+	assert.Contains(t, paths, "/epp-assignments/{cluster}")
 	assert.Contains(t, paths, "/model-prices")
 	assert.Contains(t, paths, "/model-prices/{id}")
 	assert.Contains(t, paths, "/model-prices/import")

--- a/endpoints/openapi_v1/epp_assignments/data.go
+++ b/endpoints/openapi_v1/epp_assignments/data.go
@@ -1,0 +1,97 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_assignments
+
+import (
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
+)
+
+// InstanceData is one EPP instance as exposed by the OpenAPI
+// (same shape as the /epp-pool instance: id/host/port only).
+type InstanceData struct {
+	ID   string `json:"id"`
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+// ClusterAssignmentData is the per-cluster expanded assignment view
+// (epp-assignments.md §2.1 clusters[] element).
+type ClusterAssignmentData struct {
+	Cluster  string        `json:"cluster"`
+	Group    *string       `json:"group"`
+	Primary  *InstanceData `json:"primary"`
+	Standby  *InstanceData `json:"standby"`
+	Degraded bool          `json:"degraded"`
+}
+
+// AssignmentsData is the full assignment view: per-cluster expansion plus
+// the unassigned cluster list and the idle group list.
+type AssignmentsData struct {
+	Clusters           []*ClusterAssignmentData `json:"clusters"`
+	UnassignedClusters []string                 `json:"unassigned_clusters"`
+	IdleGroups         []string                 `json:"idle_groups"`
+}
+
+// ClusterAssignmentOverrideData is the response of the manual override
+// (epp-assignments.md §2.2): the cluster assignment view without the
+// degraded marker.
+type ClusterAssignmentOverrideData struct {
+	Cluster string        `json:"cluster"`
+	Group   *string       `json:"group"`
+	Primary *InstanceData `json:"primary"`
+	Standby *InstanceData `json:"standby"`
+}
+
+func newInstanceData(inst *epp_pool.InstanceParam) *InstanceData {
+	if inst == nil {
+		return nil
+	}
+	return &InstanceData{
+		ID:   inst.ID,
+		Host: inst.Host,
+		Port: inst.Port,
+	}
+}
+
+func newClusterAssignmentData(view *epp_pool.ClusterAssignmentView) *ClusterAssignmentData {
+	return &ClusterAssignmentData{
+		Cluster:  view.Cluster,
+		Group:    view.Group,
+		Primary:  newInstanceData(view.Primary),
+		Standby:  newInstanceData(view.Standby),
+		Degraded: view.Degraded,
+	}
+}
+
+func newAssignmentsData(view *epp_pool.AssignmentsView) *AssignmentsData {
+	rst := &AssignmentsData{
+		Clusters:           []*ClusterAssignmentData{},
+		UnassignedClusters: view.UnassignedClusters,
+		IdleGroups:         view.IdleGroups,
+	}
+	for _, entry := range view.Clusters {
+		rst.Clusters = append(rst.Clusters, newClusterAssignmentData(entry))
+	}
+	return rst
+}
+
+func newClusterAssignmentOverrideData(view *epp_pool.ClusterAssignmentView) *ClusterAssignmentOverrideData {
+	return &ClusterAssignmentOverrideData{
+		Cluster: view.Cluster,
+		Group:   view.Group,
+		Primary: newInstanceData(view.Primary),
+		Standby: newInstanceData(view.Standby),
+	}
+}

--- a/endpoints/openapi_v1/epp_assignments/endpoints.go
+++ b/endpoints/openapi_v1/epp_assignments/endpoints.go
@@ -1,0 +1,25 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+// Package epp_assignments exposes the OpenAPI endpoints of the EPP cluster
+// to instance-group assignment view and its manual override
+// (design-docs/api-define/OpenAPI接口定义/epp-assignments.md).
+package epp_assignments
+
+import "github.com/rainway-ai-gateway/ai-gateway-api/lib/xreq"
+
+var Endpoints = []*xreq.Endpoint{
+	GetEndpoint,
+	OverrideEndpoint,
+}

--- a/endpoints/openapi_v1/epp_assignments/endpoints_test.go
+++ b/endpoints/openapi_v1/epp_assignments/endpoints_test.go
@@ -1,0 +1,364 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_assignments
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/itxn"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTxn struct{}
+
+func (f *fakeTxn) AtomExecute(ctx context.Context, do func(context.Context) error) error {
+	return do(ctx)
+}
+
+var _ itxn.TxnStorager = (*fakeTxn)(nil)
+
+// fakeEppPoolStorager is a hand-written in-memory EppPoolStorager for
+// handler tests.
+type fakeEppPoolStorager struct {
+	mu          sync.Mutex
+	instances   map[string]*epp_pool.InstanceParam
+	assignments map[string]*epp_pool.AssignmentParam
+}
+
+func newFakeEppPoolStorager() *fakeEppPoolStorager {
+	return &fakeEppPoolStorager{
+		instances:   map[string]*epp_pool.InstanceParam{},
+		assignments: map[string]*epp_pool.AssignmentParam{},
+	}
+}
+
+func (s *fakeEppPoolStorager) seedInstances(instances ...*epp_pool.InstanceParam) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, inst := range instances {
+		s.instances[inst.ID] = inst
+	}
+}
+
+func (s *fakeEppPoolStorager) seedAssignments(assignments ...*epp_pool.AssignmentParam) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, assignment := range assignments {
+		s.assignments[assignment.Cluster] = assignment
+	}
+}
+
+func (s *fakeEppPoolStorager) fetchAssignment(cluster string) *epp_pool.AssignmentParam {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.assignments[cluster]
+}
+
+func (s *fakeEppPoolStorager) FetchInstanceList(ctx context.Context, filter *epp_pool.InstanceFilter) ([]*epp_pool.InstanceParam, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rst := []*epp_pool.InstanceParam{}
+	for _, inst := range s.instances {
+		if filter != nil {
+			if filter.ID != nil && *filter.ID != inst.ID {
+				continue
+			}
+			if filter.GroupName != nil && *filter.GroupName != inst.GroupName {
+				continue
+			}
+		}
+		rst = append(rst, inst)
+	}
+	sort.Slice(rst, func(i, j int) bool { return rst[i].ID < rst[j].ID })
+	return rst, nil
+}
+
+func (s *fakeEppPoolStorager) CreateInstances(ctx context.Context, params []*epp_pool.InstanceParam) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, param := range params {
+		s.instances[param.ID] = param
+	}
+	return int64(len(params)), nil
+}
+
+func (s *fakeEppPoolStorager) DeleteInstances(ctx context.Context, filter *epp_pool.InstanceFilter) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var affected int64
+	for id, inst := range s.instances {
+		if filter != nil {
+			if filter.ID != nil && *filter.ID != inst.ID {
+				continue
+			}
+			if filter.GroupName != nil && *filter.GroupName != inst.GroupName {
+				continue
+			}
+		}
+		delete(s.instances, id)
+		affected++
+	}
+	return affected, nil
+}
+
+func (s *fakeEppPoolStorager) FetchAssignment(ctx context.Context, cluster string) (*epp_pool.AssignmentParam, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.assignments[cluster], nil
+}
+
+func (s *fakeEppPoolStorager) FetchAssignmentList(ctx context.Context) ([]*epp_pool.AssignmentParam, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rst := []*epp_pool.AssignmentParam{}
+	for _, assignment := range s.assignments {
+		rst = append(rst, assignment)
+	}
+	sort.Slice(rst, func(i, j int) bool { return rst[i].Cluster < rst[j].Cluster })
+	return rst, nil
+}
+
+func (s *fakeEppPoolStorager) UpsertAssignment(ctx context.Context, param *epp_pool.AssignmentParam) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.assignments[param.Cluster] = param
+	return nil
+}
+
+func (s *fakeEppPoolStorager) DeleteAssignment(ctx context.Context, cluster string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.assignments, cluster)
+	return nil
+}
+
+type fakeClusterSource struct {
+	clusters []*epp_pool.EPPClusterInfo
+}
+
+func (f *fakeClusterSource) FetchEPPClusters(ctx context.Context) ([]*epp_pool.EPPClusterInfo, error) {
+	return f.clusters, nil
+}
+
+// setupManager swaps container.EppPoolManager with one backed by in-memory
+// fakes and returns the storager plus a restore function.
+func setupManager(t *testing.T) (*fakeEppPoolStorager, func()) {
+	old := container.EppPoolManager
+	storager := newFakeEppPoolStorager()
+	storager.seedInstances(
+		&epp_pool.InstanceParam{ID: "epp-a", Host: "10.0.0.1", Port: 9002, GroupName: "g1"},
+		&epp_pool.InstanceParam{ID: "epp-b", Host: "10.0.0.2", Port: 9002, GroupName: "g1"},
+		&epp_pool.InstanceParam{ID: "epp-c", Host: "10.0.0.3", Port: 9002, GroupName: "g2"},
+	)
+	storager.seedAssignments(&epp_pool.AssignmentParam{
+		Cluster:           "cluster-a",
+		GroupName:         "g1",
+		PrimaryInstanceID: "epp-a",
+	})
+	clusterSource := &fakeClusterSource{clusters: []*epp_pool.EPPClusterInfo{
+		{Name: "cluster-a", EppConfigJSON: `{"scheduling_profile":"balanced"}`},
+		{Name: "cluster-b", EppConfigJSON: `{"scheduling_profile":"balanced"}`},
+	}}
+	container.EppPoolManager = epp_pool.NewEppPoolManager(
+		&fakeTxn{},
+		storager,
+		clusterSource,
+		nil,
+		&epp_pool.ManagerOptions{ValidationMode: epp_pool.ValidationModeTest},
+	)
+	return storager, func() { container.EppPoolManager = old }
+}
+
+func newGetRequest(target string) *http.Request {
+	return httptest.NewRequest(http.MethodGet, target, nil)
+}
+
+func newPutRequest(cluster, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPut, "/epp-assignments/"+cluster, strings.NewReader(body))
+	return mux.SetURLVars(req, map[string]string{"cluster": cluster})
+}
+
+func TestEndpoints(t *testing.T) {
+	require.Len(t, Endpoints, 2)
+	for _, ep := range Endpoints {
+		require.NotNil(t, ep)
+		assert.NotEmpty(t, ep.Path)
+		assert.NotEmpty(t, ep.Method)
+	}
+	assert.Equal(t, "/epp-assignments", Endpoints[0].Path)
+	assert.Equal(t, http.MethodGet, Endpoints[0].Method)
+	assert.Equal(t, "/epp-assignments/{cluster}", Endpoints[1].Path)
+	assert.Equal(t, http.MethodPut, Endpoints[1].Method)
+}
+
+func TestGetAction(t *testing.T) {
+	_, teardown := setupManager(t)
+	defer teardown()
+
+	data, err := GetAction(newGetRequest("/epp-assignments"))
+	require.NoError(t, err)
+
+	view, ok := data.(*AssignmentsData)
+	require.True(t, ok)
+	require.Len(t, view.Clusters, 2)
+
+	assert.Equal(t, "cluster-a", view.Clusters[0].Cluster)
+	require.NotNil(t, view.Clusters[0].Group)
+	assert.Equal(t, "g1", *view.Clusters[0].Group)
+	require.NotNil(t, view.Clusters[0].Primary)
+	assert.Equal(t, "epp-a", view.Clusters[0].Primary.ID)
+	require.NotNil(t, view.Clusters[0].Standby)
+	assert.Equal(t, "epp-b", view.Clusters[0].Standby.ID)
+	assert.False(t, view.Clusters[0].Degraded)
+
+	// cluster-b is in EPP mode but has no assignment.
+	assert.Equal(t, "cluster-b", view.Clusters[1].Cluster)
+	assert.Nil(t, view.Clusters[1].Group)
+	assert.Nil(t, view.Clusters[1].Primary)
+	assert.Contains(t, view.UnassignedClusters, "cluster-b")
+
+	// g2 has no primary occupation (standby roles do not occupy).
+	assert.Equal(t, []string{"g2"}, view.IdleGroups)
+}
+
+func TestGetAction_ByCluster(t *testing.T) {
+	_, teardown := setupManager(t)
+	defer teardown()
+
+	data, err := GetAction(newGetRequest("/epp-assignments?cluster=cluster-a"))
+	require.NoError(t, err)
+
+	view, ok := data.(*AssignmentsData)
+	require.True(t, ok)
+	require.Len(t, view.Clusters, 1)
+	assert.Equal(t, "cluster-a", view.Clusters[0].Cluster)
+	assert.Empty(t, view.UnassignedClusters)
+}
+
+func TestGetAction_ByClusterUnassigned(t *testing.T) {
+	_, teardown := setupManager(t)
+	defer teardown()
+
+	data, err := GetAction(newGetRequest("/epp-assignments?cluster=cluster-b"))
+	require.NoError(t, err)
+
+	view, ok := data.(*AssignmentsData)
+	require.True(t, ok)
+	require.Len(t, view.Clusters, 1)
+	assert.Equal(t, "cluster-b", view.Clusters[0].Cluster)
+	assert.Contains(t, view.UnassignedClusters, "cluster-b")
+}
+
+func TestGetAction_ClusterNotEPP(t *testing.T) {
+	_, teardown := setupManager(t)
+	defer teardown()
+
+	// Unknown cluster and non-EPP cluster both resolve to the 404 semantic error.
+	for _, cluster := range []string{"cluster-x", "cluster-wrr"} {
+		_, err := GetAction(newGetRequest("/epp-assignments?cluster=" + cluster))
+		require.Error(t, err, cluster)
+		assert.Equal(t, 404, xerror.Resolve(err).ErrNo, cluster)
+	}
+}
+
+func TestOverrideAction(t *testing.T) {
+	storager, teardown := setupManager(t)
+	defer teardown()
+
+	data, err := OverrideAction(newPutRequest("cluster-a", `{"group_name":"g1","primary_instance_id":"epp-b"}`))
+	require.NoError(t, err)
+
+	view, ok := data.(*ClusterAssignmentOverrideData)
+	require.True(t, ok)
+	assert.Equal(t, "cluster-a", view.Cluster)
+	require.NotNil(t, view.Group)
+	assert.Equal(t, "g1", *view.Group)
+	require.NotNil(t, view.Primary)
+	assert.Equal(t, "epp-b", view.Primary.ID)
+	require.NotNil(t, view.Standby)
+	assert.Equal(t, "epp-a", view.Standby.ID)
+
+	stored := storager.fetchAssignment("cluster-a")
+	require.NotNil(t, stored)
+	assert.Equal(t, "g1", stored.GroupName)
+	assert.Equal(t, "epp-b", stored.PrimaryInstanceID)
+}
+
+func TestOverrideAction_ClusterNotEPP(t *testing.T) {
+	_, teardown := setupManager(t)
+	defer teardown()
+
+	_, err := OverrideAction(newPutRequest("cluster-x", `{"group_name":"g1","primary_instance_id":"epp-a"}`))
+	require.Error(t, err)
+	assert.Equal(t, 404, xerror.Resolve(err).ErrNo)
+}
+
+func TestOverrideAction_ValidationErrors(t *testing.T) {
+	_, teardown := setupManager(t)
+	defer teardown()
+
+	cases := []struct {
+		name  string
+		body  string
+		errNo int
+	}{
+		{"group not exist", `{"group_name":"gx","primary_instance_id":"epp-a"}`, 422},
+		{"primary not in group", `{"group_name":"g1","primary_instance_id":"epp-c"}`, 422},
+		{"group name empty", `{"group_name":"","primary_instance_id":"epp-a"}`, 422},
+		{"primary empty", `{"group_name":"g1","primary_instance_id":""}`, 422},
+		{"body empty", `{}`, 422},
+		{"body not json", `{`, 422},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := OverrideAction(newPutRequest("cluster-a", tc.body))
+			require.Error(t, err)
+			assert.Equal(t, tc.errNo, xerror.Resolve(err).ErrNo)
+		})
+	}
+}
+
+func TestOverrideAction_SingleInstanceGroup(t *testing.T) {
+	_, teardown := setupManager(t)
+	defer teardown()
+
+	// cluster-b is assigned to g2 whose only instance is epp-c: no standby.
+	data, err := OverrideAction(newPutRequest("cluster-b", `{"group_name":"g2","primary_instance_id":"epp-c"}`))
+	require.NoError(t, err)
+
+	view, ok := data.(*ClusterAssignmentOverrideData)
+	require.True(t, ok)
+	assert.Equal(t, "cluster-b", view.Cluster)
+	require.NotNil(t, view.Primary)
+	assert.Equal(t, "epp-c", view.Primary.ID)
+	assert.Nil(t, view.Standby)
+}

--- a/endpoints/openapi_v1/epp_assignments/get.go
+++ b/endpoints/openapi_v1/epp_assignments/get.go
@@ -1,0 +1,79 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_assignments
+
+import (
+	"net/http"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xreq"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iauth"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful/container"
+)
+
+// ListParam carries the optional cluster filter of GET /epp-assignments.
+type ListParam struct {
+	Cluster string `form:"cluster"`
+}
+
+// GetRoute route
+var GetEndpoint = &xreq.Endpoint{
+	Path:       "/epp-assignments",
+	Method:     http.MethodGet,
+	Handler:    xreq.Convert(GetAction),
+	Authorizer: iauth.FA(iauth.FeatureBFEPool, iauth.ActionReadAll),
+}
+
+var _ xreq.Handler = GetAction
+
+// GetAction returns the full assignment view, optionally filtered to one
+// cluster, see epp-assignments.md §2.1. Filtering by a cluster that does not
+// exist or is not in EPP mode resolves to a 404 semantic error.
+func GetAction(req *http.Request) (interface{}, error) {
+	param := &ListParam{}
+	if err := xreq.BindForm(req, param); err != nil {
+		return nil, err
+	}
+
+	view, err := container.EppPoolManager.GetAssignmentsView(req.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	data := newAssignmentsData(view)
+	if param.Cluster == "" {
+		return data, nil
+	}
+
+	filtered := &AssignmentsData{
+		Clusters:           []*ClusterAssignmentData{},
+		UnassignedClusters: []string{},
+		IdleGroups:         data.IdleGroups,
+	}
+	for _, entry := range data.Clusters {
+		if entry.Cluster != param.Cluster {
+			continue
+		}
+		filtered.Clusters = append(filtered.Clusters, entry)
+		for _, unassigned := range data.UnassignedClusters {
+			if unassigned == param.Cluster {
+				filtered.UnassignedClusters = append(filtered.UnassignedClusters, unassigned)
+			}
+		}
+		return filtered, nil
+	}
+
+	return nil, xerror.WrapRecordNotExist("epp assignment", param.Cluster)
+}

--- a/endpoints/openapi_v1/epp_assignments/put.go
+++ b/endpoints/openapi_v1/epp_assignments/put.go
@@ -1,0 +1,61 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_assignments
+
+import (
+	"net/http"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xreq"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iauth"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful/container"
+)
+
+// OverrideParam is the body of PUT /epp-assignments/{cluster}
+// (epp-assignments.md §2.2). The cluster must reference an existing
+// balance_mode=EPP cluster; the group and the primary instance must exist
+// in the current EPP instance pool.
+type OverrideParam struct {
+	Cluster           string `uri:"cluster"`
+	GroupName         string `json:"group_name"`
+	PrimaryInstanceID string `json:"primary_instance_id"`
+}
+
+// OverrideRoute route
+var OverrideEndpoint = &xreq.Endpoint{
+	Path:       "/epp-assignments/{cluster}",
+	Method:     http.MethodPut,
+	Handler:    xreq.Convert(OverrideAction),
+	Authorizer: iauth.FA(iauth.FeatureBFEPool, iauth.ActionUpdate),
+}
+
+var _ xreq.Handler = OverrideAction
+
+// OverrideAction manually overwrites the assignment of one cluster and
+// returns the updated per-cluster assignment view, see epp-assignments.md §2.2.
+// A cluster that does not exist or is not in EPP mode surfaces the 404
+// semantic error from the model layer.
+func OverrideAction(req *http.Request) (interface{}, error) {
+	param := &OverrideParam{}
+	if err := xreq.Bind(req, param); err != nil {
+		return nil, err
+	}
+
+	view, err := container.EppPoolManager.OverrideAssignment(req.Context(), param.Cluster, param.GroupName, param.PrimaryInstanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	return newClusterAssignmentOverrideData(view), nil
+}

--- a/endpoints/openapi_v1/epp_pool/data.go
+++ b/endpoints/openapi_v1/epp_pool/data.go
@@ -1,0 +1,68 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
+)
+
+// InstanceData is one EPP instance of the pool as exposed by the OpenAPI
+// (epp-pool.md data model: only id/host/port).
+type InstanceData struct {
+	ID   string `json:"id"`
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+// GroupData is one named instance group of the pool.
+type GroupData struct {
+	Name      string          `json:"name"`
+	Instances []*InstanceData `json:"instances"`
+}
+
+// PoolData is the singleton EPP instance pool detail.
+type PoolData struct {
+	Name   string       `json:"name"`
+	Groups []*GroupData `json:"groups"`
+}
+
+func newInstanceData(inst *epp_pool.InstanceParam) *InstanceData {
+	if inst == nil {
+		return nil
+	}
+	return &InstanceData{
+		ID:   inst.ID,
+		Host: inst.Host,
+		Port: inst.Port,
+	}
+}
+
+func newPoolData(pool *epp_pool.EppPool) *PoolData {
+	rst := &PoolData{
+		Name:   pool.Name,
+		Groups: []*GroupData{},
+	}
+	for _, group := range pool.Groups {
+		g := &GroupData{
+			Name:      group.Name,
+			Instances: []*InstanceData{},
+		}
+		for _, inst := range group.Instances {
+			g.Instances = append(g.Instances, newInstanceData(inst))
+		}
+		rst.Groups = append(rst.Groups, g)
+	}
+	return rst
+}

--- a/endpoints/openapi_v1/epp_pool/endpoints.go
+++ b/endpoints/openapi_v1/epp_pool/endpoints.go
@@ -1,0 +1,24 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+// Package epp_pool exposes the OpenAPI endpoints of the singleton EPP
+// instance pool (design-docs/api-define/OpenAPI接口定义/epp-pool.md).
+package epp_pool
+
+import "github.com/rainway-ai-gateway/ai-gateway-api/lib/xreq"
+
+var Endpoints = []*xreq.Endpoint{
+	GetEndpoint,
+	PatchEndpoint,
+}

--- a/endpoints/openapi_v1/epp_pool/endpoints_test.go
+++ b/endpoints/openapi_v1/epp_pool/endpoints_test.go
@@ -1,0 +1,294 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/itxn"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful/container"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTxn struct{}
+
+func (f *fakeTxn) AtomExecute(ctx context.Context, do func(context.Context) error) error {
+	return do(ctx)
+}
+
+var _ itxn.TxnStorager = (*fakeTxn)(nil)
+
+// fakeEppPoolStorager is a hand-written in-memory EppPoolStorager for
+// handler tests.
+type fakeEppPoolStorager struct {
+	mu        sync.Mutex
+	instances map[string]*epp_pool.InstanceParam
+}
+
+func newFakeEppPoolStorager() *fakeEppPoolStorager {
+	return &fakeEppPoolStorager{instances: map[string]*epp_pool.InstanceParam{}}
+}
+
+func (s *fakeEppPoolStorager) seedInstances(instances ...*epp_pool.InstanceParam) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, inst := range instances {
+		s.instances[inst.ID] = inst
+	}
+}
+
+func (s *fakeEppPoolStorager) FetchInstanceList(ctx context.Context, filter *epp_pool.InstanceFilter) ([]*epp_pool.InstanceParam, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rst := []*epp_pool.InstanceParam{}
+	for _, inst := range s.instances {
+		if filter != nil {
+			if filter.ID != nil && *filter.ID != inst.ID {
+				continue
+			}
+			if filter.GroupName != nil && *filter.GroupName != inst.GroupName {
+				continue
+			}
+		}
+		rst = append(rst, inst)
+	}
+	sort.Slice(rst, func(i, j int) bool { return rst[i].ID < rst[j].ID })
+	return rst, nil
+}
+
+func (s *fakeEppPoolStorager) CreateInstances(ctx context.Context, params []*epp_pool.InstanceParam) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, param := range params {
+		s.instances[param.ID] = param
+	}
+	return int64(len(params)), nil
+}
+
+func (s *fakeEppPoolStorager) DeleteInstances(ctx context.Context, filter *epp_pool.InstanceFilter) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var affected int64
+	for id, inst := range s.instances {
+		if filter != nil {
+			if filter.ID != nil && *filter.ID != inst.ID {
+				continue
+			}
+			if filter.GroupName != nil && *filter.GroupName != inst.GroupName {
+				continue
+			}
+		}
+		delete(s.instances, id)
+		affected++
+	}
+	return affected, nil
+}
+
+func (s *fakeEppPoolStorager) FetchAssignment(ctx context.Context, cluster string) (*epp_pool.AssignmentParam, error) {
+	return nil, nil
+}
+
+func (s *fakeEppPoolStorager) FetchAssignmentList(ctx context.Context) ([]*epp_pool.AssignmentParam, error) {
+	return []*epp_pool.AssignmentParam{}, nil
+}
+
+func (s *fakeEppPoolStorager) UpsertAssignment(ctx context.Context, param *epp_pool.AssignmentParam) error {
+	return nil
+}
+
+func (s *fakeEppPoolStorager) DeleteAssignment(ctx context.Context, cluster string) error {
+	return nil
+}
+
+type fakeClusterSource struct{}
+
+func (f *fakeClusterSource) FetchEPPClusters(ctx context.Context) ([]*epp_pool.EPPClusterInfo, error) {
+	return []*epp_pool.EPPClusterInfo{}, nil
+}
+
+// setupManager swaps container.EppPoolManager with one backed by in-memory
+// fakes and returns the storager plus a restore function.
+func setupManager(t *testing.T, validationMode string) (*fakeEppPoolStorager, func()) {
+	old := container.EppPoolManager
+	storager := newFakeEppPoolStorager()
+	container.EppPoolManager = epp_pool.NewEppPoolManager(
+		&fakeTxn{},
+		storager,
+		&fakeClusterSource{},
+		nil,
+		&epp_pool.ManagerOptions{ValidationMode: validationMode},
+	)
+	return storager, func() { container.EppPoolManager = old }
+}
+
+func newJSONRequest(method, target, body string) *http.Request {
+	return httptest.NewRequest(method, target, strings.NewReader(body))
+}
+
+func TestEndpoints(t *testing.T) {
+	require.Len(t, Endpoints, 2)
+	for _, ep := range Endpoints {
+		require.NotNil(t, ep)
+		assert.NotEmpty(t, ep.Path)
+		assert.NotEmpty(t, ep.Method)
+	}
+	assert.Equal(t, "/epp-pool", Endpoints[0].Path)
+	assert.Equal(t, "/epp-pool", Endpoints[1].Path)
+	assert.Equal(t, http.MethodGet, Endpoints[0].Method)
+	assert.Equal(t, http.MethodPatch, Endpoints[1].Method)
+}
+
+func TestGetAction(t *testing.T) {
+	storager, teardown := setupManager(t, epp_pool.ValidationModeTest)
+	defer teardown()
+
+	storager.seedInstances(
+		&epp_pool.InstanceParam{ID: "epp-b", Host: "10.0.0.2", Port: 9002, GroupName: "g1"},
+		&epp_pool.InstanceParam{ID: "epp-a", Host: "10.0.0.1", Port: 9002, GroupName: "g1"},
+		&epp_pool.InstanceParam{ID: "epp-c", Host: "10.0.0.3", Port: 9002, GroupName: "g2"},
+	)
+
+	data, err := GetAction(newJSONRequest(http.MethodGet, "/epp-pool", ""))
+	require.NoError(t, err)
+
+	pool, ok := data.(*PoolData)
+	require.True(t, ok)
+	assert.Equal(t, epp_pool.DefaultEPPInstancePoolName, pool.Name)
+	require.Len(t, pool.Groups, 2)
+	assert.Equal(t, "g1", pool.Groups[0].Name)
+	require.Len(t, pool.Groups[0].Instances, 2)
+	assert.Equal(t, "epp-a", pool.Groups[0].Instances[0].ID)
+	assert.Equal(t, "10.0.0.1", pool.Groups[0].Instances[0].Host)
+	assert.Equal(t, 9002, pool.Groups[0].Instances[0].Port)
+
+	// The exposed instance shape carries id/host/port only (no group_name).
+	raw, err := json.Marshal(pool)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "group_name")
+}
+
+func TestGetAction_PoolNotExist(t *testing.T) {
+	_, teardown := setupManager(t, epp_pool.ValidationModeTest)
+	defer teardown()
+
+	// Per epp-pool.md §2.1 the pool does not exist until the first PATCH:
+	// GET must surface the record-not-exist error instead of an empty pool.
+	_, err := GetAction(newJSONRequest(http.MethodGet, "/epp-pool", ""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Record Not Exist")
+}
+
+func TestPatchAction(t *testing.T) {
+	storager, teardown := setupManager(t, epp_pool.ValidationModeTest)
+	defer teardown()
+
+	storager.seedInstances(
+		&epp_pool.InstanceParam{ID: "old-a", Host: "10.0.0.9", Port: 9002, GroupName: "old"},
+	)
+
+	body := `{"groups":[
+		{"name":"g1","instances":[
+			{"id":"epp-a","host":"10.0.0.1","port":9002},
+			{"id":"epp-b","host":"10.0.0.2","port":9002}]},
+		{"name":"g2","instances":[
+			{"id":"epp-c","host":"10.0.0.3","port":9002}]}]}`
+
+	data, err := PatchAction(newJSONRequest(http.MethodPatch, "/epp-pool", body))
+	require.NoError(t, err)
+
+	pool, ok := data.(*PoolData)
+	require.True(t, ok)
+	require.Len(t, pool.Groups, 2)
+	assert.Equal(t, "g1", pool.Groups[0].Name)
+	assert.Equal(t, "g2", pool.Groups[1].Name)
+
+	// Full replacement semantics: the previous instance is gone.
+	instances, err := storager.FetchInstanceList(context.Background(), &epp_pool.InstanceFilter{})
+	require.NoError(t, err)
+	assert.Len(t, instances, 3)
+}
+
+func TestPatchAction_ValidationErrors(t *testing.T) {
+	_, teardown := setupManager(t, epp_pool.ValidationModeTest)
+	defer teardown()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"groups missing", `{}`},
+		{"groups empty", `{"groups":[]}`},
+		{"group name empty", `{"groups":[{"name":"","instances":[{"id":"a","host":"10.0.0.1","port":9002}]}]}`},
+		{"group name duplicated", `{"groups":[
+			{"name":"g1","instances":[{"id":"a","host":"10.0.0.1","port":9002}]},
+			{"name":"g1","instances":[{"id":"b","host":"10.0.0.2","port":9002}]}]}`},
+		{"instances empty", `{"groups":[{"name":"g1","instances":[]}]}`},
+		{"instance nil", `{"groups":[{"name":"g1","instances":[null]}]}`},
+		{"instance id empty", `{"groups":[{"name":"g1","instances":[{"id":"","host":"10.0.0.1","port":9002}]}]}`},
+		{"instance id duplicated", `{"groups":[
+			{"name":"g1","instances":[{"id":"a","host":"10.0.0.1","port":9002}]},
+			{"name":"g2","instances":[{"id":"a","host":"10.0.0.2","port":9002}]}]}`},
+		{"host empty", `{"groups":[{"name":"g1","instances":[{"id":"a","host":"","port":9002}]}]}`},
+		{"host invalid", `{"groups":[{"name":"g1","instances":[{"id":"a","host":"-bad-","port":9002}]}]}`},
+		{"port zero", `{"groups":[{"name":"g1","instances":[{"id":"a","host":"10.0.0.1","port":0}]}]}`},
+		{"port out of range", `{"groups":[{"name":"g1","instances":[{"id":"a","host":"10.0.0.1","port":70000}]}]}`},
+		{"address duplicated", `{"groups":[{"name":"g1","instances":[
+			{"id":"a","host":"10.0.0.1","port":9002},
+			{"id":"b","host":"10.0.0.1","port":9002}]}]}`},
+		{"body not json", `{`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := PatchAction(newJSONRequest(http.MethodPatch, "/epp-pool", tc.body))
+			require.Error(t, err)
+			assert.Equal(t, 422, xerror.Resolve(err).ErrNo)
+		})
+	}
+}
+
+func TestPatchAction_GroupSizeProduction(t *testing.T) {
+	_, teardown := setupManager(t, epp_pool.ValidationModeProduction)
+	defer teardown()
+
+	// Test mode allows single instance groups; production requires exactly 2.
+	one := `{"groups":[{"name":"g1","instances":[{"id":"a","host":"10.0.0.1","port":9002}]}]}`
+	_, err := PatchAction(newJSONRequest(http.MethodPatch, "/epp-pool", one))
+	require.Error(t, err)
+	assert.Equal(t, 422, xerror.Resolve(err).ErrNo)
+
+	two := `{"groups":[{"name":"g1","instances":[
+		{"id":"a","host":"10.0.0.1","port":9002},
+		{"id":"b","host":"10.0.0.2","port":9002}]}]}`
+	data, err := PatchAction(newJSONRequest(http.MethodPatch, "/epp-pool", two))
+	require.NoError(t, err)
+	pool, ok := data.(*PoolData)
+	require.True(t, ok)
+	require.Len(t, pool.Groups, 1)
+	assert.Len(t, pool.Groups[0].Instances, 2)
+}

--- a/endpoints/openapi_v1/epp_pool/get.go
+++ b/endpoints/openapi_v1/epp_pool/get.go
@@ -1,0 +1,44 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"net/http"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xreq"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iauth"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful/container"
+)
+
+// GetRoute route
+var GetEndpoint = &xreq.Endpoint{
+	Path:       "/epp-pool",
+	Method:     http.MethodGet,
+	Handler:    xreq.Convert(GetAction),
+	Authorizer: iauth.FA(iauth.FeatureBFEPool, iauth.ActionReadAll),
+}
+
+var _ xreq.Handler = GetAction
+
+// GetAction returns the EPP instance pool detail (groups + instances),
+// see epp-pool.md §2.1.
+func GetAction(req *http.Request) (interface{}, error) {
+	pool, err := container.EppPoolManager.GetPool(req.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	return newPoolData(pool), nil
+}

--- a/endpoints/openapi_v1/epp_pool/patch.go
+++ b/endpoints/openapi_v1/epp_pool/patch.go
@@ -1,0 +1,97 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"net/http"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xreq"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iauth"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful/container"
+)
+
+// PatchParam is the full-replacement body of PATCH /epp-pool
+// (epp-pool.md §2.2). Field-level validation lives in the model layer
+// (EppPoolManager.PatchPool); invalid payloads surface as 422.
+type PatchParam struct {
+	Groups []*GroupParam `json:"groups"`
+}
+
+// GroupParam is one instance group of the replacement body.
+type GroupParam struct {
+	Name      string           `json:"name"`
+	Instances []*InstanceParam `json:"instances"`
+}
+
+// InstanceParam is one instance of the replacement body.
+type InstanceParam struct {
+	ID   string `json:"id"`
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+// PatchRoute route
+var PatchEndpoint = &xreq.Endpoint{
+	Path:       "/epp-pool",
+	Method:     http.MethodPatch,
+	Handler:    xreq.Convert(PatchAction),
+	Authorizer: iauth.FA(iauth.FeatureBFEPool, iauth.ActionUpdate),
+}
+
+var _ xreq.Handler = PatchAction
+
+// PatchAction fully replaces the EPP instance pool and returns the updated
+// pool detail, see epp-pool.md §2.2.
+func PatchAction(req *http.Request) (interface{}, error) {
+	param := &PatchParam{}
+	if err := xreq.BindJSON(req, param); err != nil {
+		return nil, err
+	}
+
+	pool, err := container.EppPoolManager.PatchPool(req.Context(), toModelGroups(param.Groups))
+	if err != nil {
+		return nil, err
+	}
+
+	return newPoolData(pool), nil
+}
+
+func toModelGroups(groups []*GroupParam) []*epp_pool.InstanceGroup {
+	rst := []*epp_pool.InstanceGroup{}
+	for _, group := range groups {
+		if group == nil {
+			rst = append(rst, nil)
+			continue
+		}
+		g := &epp_pool.InstanceGroup{
+			Name:      group.Name,
+			Instances: []*epp_pool.InstanceParam{},
+		}
+		for _, inst := range group.Instances {
+			if inst == nil {
+				g.Instances = append(g.Instances, nil)
+				continue
+			}
+			g.Instances = append(g.Instances, &epp_pool.InstanceParam{
+				ID:   inst.ID,
+				Host: inst.Host,
+				Port: inst.Port,
+			})
+		}
+		rst = append(rst, g)
+	}
+	return rst
+}

--- a/endpoints/openapi_v1/product_cluster/create.go
+++ b/endpoints/openapi_v1/product_cluster/create.go
@@ -29,7 +29,9 @@
 package product_cluster
 
 import (
+	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib/validate"
@@ -57,6 +59,8 @@ type UpsertParam struct {
 	StickySessions     *StickySessionsParam     `json:"sticky_sessions"`
 	PassiveHealthCheck *PassiveHealthCheckParam `json:"passive_health_check"`
 	LLMConfig          *icluster_conf.LLMConfig `json:"llm_config"`
+	BalanceMode        *string                  `json:"balance_mode"`
+	EppConfig          *json.RawMessage         `json:"epp_config"`
 }
 
 // ConnectionParam Request Param
@@ -173,6 +177,8 @@ func clusterParamControlModel(param *UpsertParam) *icluster_conf.ClusterParam {
 		Name:        param.Name,
 		Description: param.Description,
 		LLMConfig:   normalizeLLMConfig(param.LLMConfig),
+		BalanceMode: param.BalanceMode,
+		EppConfig:   normalizeEppConfigRaw(param.EppConfig),
 	}
 
 	basic := normalizeBasic(param.Basic)
@@ -319,6 +325,20 @@ func normalizePassiveHealthCheck(phc *PassiveHealthCheckParam) *PassiveHealthChe
 		phc.Host = &empty
 	}
 	return phc
+}
+
+// normalizeEppConfigRaw converts the raw epp_config JSON body into the raw
+// JSON string pointer expected by the model layer. Absent or explicit null
+// stays nil (field not carried, stored value retained on update).
+func normalizeEppConfigRaw(raw *json.RawMessage) *string {
+	if raw == nil {
+		return nil
+	}
+	s := strings.TrimSpace(string(*raw))
+	if s == "" || s == "null" {
+		return nil
+	}
+	return &s
 }
 
 func normalizeLLMConfig(llm *icluster_conf.LLMConfig) *icluster_conf.LLMConfig {

--- a/endpoints/openapi_v1/product_cluster/one.go
+++ b/endpoints/openapi_v1/product_cluster/one.go
@@ -29,6 +29,7 @@
 package product_cluster
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iauth"
@@ -101,6 +102,13 @@ type ClusterData struct {
 	StickySessions     *StickySessions          `json:"sticky_sessions"`
 	PassiveHealthCheck *PassiveHealthCheck      `json:"passive_health_check"`
 	LLMConfig          *icluster_conf.LLMConfig `json:"llm_config"`
+	// BalanceMode is the explicit cluster balance mode (WRR default, EPP
+	// optional); it is the single source of truth for the export BalanceMode.
+	BalanceMode string `json:"balance_mode"`
+	// EppConfig is the raw stored JSON of the simplified per-cluster EPP
+	// scheduling configuration, returned verbatim (null when never set;
+	// retained verbatim while dormant under WRR).
+	EppConfig json.RawMessage `json:"epp_config"`
 }
 
 type AutoLbMatrix struct {
@@ -147,6 +155,16 @@ func clusterModel2Control(cluster *icluster_conf.Cluster) *ClusterData {
 		PassiveHealthCheck: PassiveHealthCheckM2C(cluster.PassiveHealthCheck),
 
 		LLMConfig: cluster.LLMConfig,
+	}
+
+	// balance_mode defaults to WRR when never written; epp_config is echoed
+	// verbatim as the stored raw JSON (null when never set).
+	rsp.BalanceMode = cluster.BalanceMode
+	if rsp.BalanceMode == "" {
+		rsp.BalanceMode = icluster_conf.BalanceModeWRR
+	}
+	if cluster.EppConfig != "" {
+		rsp.EppConfig = json.RawMessage(cluster.EppConfig)
 	}
 
 	return rsp

--- a/endpoints/openapi_v1/product_cluster/one_test.go
+++ b/endpoints/openapi_v1/product_cluster/one_test.go
@@ -72,6 +72,10 @@ func TestClusterModel2Control(t *testing.T) {
 	assert.Equal(t, "my-cluster", rsp.Name)
 	assert.Equal(t, "openai", *rsp.LLMConfig.Provider)
 
+	// balance_mode defaults to WRR and epp_config is null when never set.
+	assert.Equal(t, icluster_conf.BalanceModeWRR, rsp.BalanceMode)
+	assert.Nil(t, rsp.EppConfig)
+
 	data, err := json.Marshal(rsp)
 	assert.NoError(t, err)
 
@@ -80,4 +84,59 @@ func TestClusterModel2Control(t *testing.T) {
 	assert.False(t, strings.Contains(body, `"hostname"`))
 	assert.False(t, strings.Contains(body, `"ip"`))
 	assert.False(t, strings.Contains(body, `"ports"`))
+	assert.Contains(t, body, `"balance_mode":"WRR"`)
+	assert.Contains(t, body, `"epp_config":null`)
+}
+
+func TestClusterModel2Control_EPPFields(t *testing.T) {
+	// balance_mode=EPP with a stored raw epp_config: both are echoed
+	// verbatim (the dormant WRR retention keeps the stored JSON as-is).
+	cluster := &icluster_conf.Cluster{
+		Name: "epp-cluster",
+		Basic: &icluster_conf.ClusterBasic{
+			Protocol: lib.PString("https"),
+			Connection: &icluster_conf.ClusterBasicConnection{
+				MaxIdleConnPerRs:    0,
+				CancelOnClientClose: false,
+			},
+			Retries: &icluster_conf.ClusterBasicRetries{
+				MaxRetryInSubcluster: 2,
+			},
+			Buffers: &icluster_conf.ClusterBasicBuffers{
+				ReqWriteBufferSize: 512,
+			},
+			Timeouts: &icluster_conf.ClusterBasicTimeouts{
+				TimeoutConnServ:        50000,
+				TimeoutResponseHeader:  50000,
+				TimeoutReadbodyClient:  30000,
+				TimeoutReadClientAgain: 30000,
+				TimeoutWriteClient:     60000,
+			},
+		},
+		StickySessions: &icluster_conf.ClusterStickySessions{
+			SessionSticky: false,
+			HashStrategy:  icluster_conf.ClusterHashStrategyClientIPOnlyI,
+		},
+		BalanceMode: icluster_conf.BalanceModeEPP,
+		EppConfig:   `{"scheduling_profile":"balanced","kv_cache_utilization_max":0.9}`,
+	}
+
+	rsp := clusterModel2Control(cluster)
+	assert.Equal(t, icluster_conf.BalanceModeEPP, rsp.BalanceMode)
+	assert.JSONEq(t,
+		`{"scheduling_profile":"balanced","kv_cache_utilization_max":0.9}`,
+		string(rsp.EppConfig))
+
+	data, err := json.Marshal(rsp)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"balance_mode":"EPP"`)
+	assert.Contains(t, string(data), `"epp_config":{"scheduling_profile":"balanced","kv_cache_utilization_max":0.9}`)
+
+	// WRR dormancy: a stored epp_config is still returned verbatim.
+	cluster.BalanceMode = icluster_conf.BalanceModeWRR
+	rsp = clusterModel2Control(cluster)
+	assert.Equal(t, icluster_conf.BalanceModeWRR, rsp.BalanceMode)
+	assert.JSONEq(t,
+		`{"scheduling_profile":"balanced","kv_cache_utilization_max":0.9}`,
+		string(rsp.EppConfig))
 }

--- a/endpoints/openapi_v1/product_cluster/update_basic.go
+++ b/endpoints/openapi_v1/product_cluster/update_basic.go
@@ -129,6 +129,8 @@ func clusterParamControlModel4Update(param *UpsertParam) *icluster_conf.ClusterP
 	rst := &icluster_conf.ClusterParam{
 		Name:        param.Name,
 		Description: param.Description,
+		BalanceMode: param.BalanceMode,
+		EppConfig:   normalizeEppConfigRaw(param.EppConfig),
 	}
 
 	if param.LLMConfig != nil {

--- a/model/epp_pool/assignment.go
+++ b/model/epp_pool/assignment.go
@@ -1,0 +1,613 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"context"
+	"sort"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+)
+
+// AssignCluster assigns an EPP instance group to the cluster. It is idempotent:
+// if a valid assignment already exists it is a no-op; otherwise the greedy
+// deterministic allocator (design-changes.md §4.2.2) picks a group and a
+// primary and upserts the assignment. It is called when a cluster is created
+// with balance_mode=EPP or switched from WRR to EPP.
+func (m *EppPoolManager) AssignCluster(ctx context.Context, clusterName string) error {
+	if clusterName == "" {
+		return xerror.WrapParamErrorWithMsg("cluster name is empty")
+	}
+
+	instances, err := m.storager.FetchInstanceList(ctx, &InstanceFilter{})
+	if err != nil {
+		return err
+	}
+	pool := buildPool(m.poolName, instances)
+
+	assignments, err := m.storager.FetchAssignmentList(ctx)
+	if err != nil {
+		return err
+	}
+
+	if findValidAssignment(pool, assignments, clusterName, m.validationMode) != nil {
+		return nil
+	}
+
+	return m.allocateAndUpsert(ctx, pool, assignments, clusterName)
+}
+
+// GetAssignmentEndpoints returns the ordered endpoint addresses of the
+// cluster's assignment as [primary, standby] (standby omitted for single
+// instance groups), joined by net.JoinHostPort. found is false when the
+// cluster has no valid assignment (no record or dangling); storager errors
+// are propagated. It is the read path behind the EPPAddr export
+// (design-changes.md §4.3).
+func (m *EppPoolManager) GetAssignmentEndpoints(ctx context.Context, clusterName string) ([]string, bool, error) {
+	if clusterName == "" {
+		return nil, false, xerror.WrapParamErrorWithMsg("cluster name is empty")
+	}
+
+	instances, err := m.storager.FetchInstanceList(ctx, &InstanceFilter{})
+	if err != nil {
+		return nil, false, err
+	}
+	pool := buildPool(m.poolName, instances)
+
+	assignments, err := m.storager.FetchAssignmentList(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	assignment := findValidAssignment(pool, assignments, clusterName, m.validationMode)
+	if assignment == nil {
+		return nil, false, nil
+	}
+
+	group := findGroup(pool, assignment.GroupName)
+	if group == nil {
+		return nil, false, nil
+	}
+
+	primary, standby := expandPrimaryAndStandby(group.Instances, assignment.PrimaryInstanceID)
+	if primary == nil {
+		return nil, false, nil
+	}
+
+	endpoints := []string{instanceAddress(primary.Host, primary.Port)}
+	if standby != nil {
+		endpoints = append(endpoints, instanceAddress(standby.Host, standby.Port))
+	}
+
+	return endpoints, true, nil
+}
+
+// allocateAndUpsert runs the greedy allocator and upserts its result with a
+// unique-key conflict fallback: on conflict the latest assignments are
+// re-read and the allocation is retried once (design-changes.md §4.2.2).
+func (m *EppPoolManager) allocateAndUpsert(ctx context.Context, pool *EppPool, assignments []*AssignmentParam, clusterName string) error {
+	assignment, err := allocateCluster(pool, assignments, clusterName, m.validationMode)
+	if err != nil {
+		// No assignable candidate group: clear the assignment (unassigned state).
+		if errDel := m.storager.DeleteAssignment(ctx, clusterName); errDel != nil {
+			return errDel
+		}
+		return nil
+	}
+
+	err = m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+		return m.storager.UpsertAssignment(ctx, assignment)
+	})
+	if err == nil {
+		return nil
+	}
+
+	// Unique-key conflict fallback: re-read and retry once.
+	assignments, err = m.storager.FetchAssignmentList(ctx)
+	if err != nil {
+		return err
+	}
+	assignment, err = allocateCluster(pool, assignments, clusterName, m.validationMode)
+	if err != nil {
+		if errDel := m.storager.DeleteAssignment(ctx, clusterName); errDel != nil {
+			return errDel
+		}
+		return nil
+	}
+
+	return m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+		return m.storager.UpsertAssignment(ctx, assignment)
+	})
+}
+
+// RepairDangling repairs assignments that became dangling after an
+// /epp-pool change (design-changes.md §4.2.1):
+//   - group still exists and meets the group-size rule -> reselect the
+//     primary within the same group (no group change);
+//   - group gone or undersized -> cross-group reallocation (greedy);
+//   - no candidate group left -> clear the assignment (unassigned state).
+func (m *EppPoolManager) RepairDangling(ctx context.Context) error {
+	instances, err := m.storager.FetchInstanceList(ctx, &InstanceFilter{})
+	if err != nil {
+		return err
+	}
+	pool := buildPool(m.poolName, instances)
+
+	assignments, err := m.storager.FetchAssignmentList(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Deterministic repair order.
+	sort.Slice(assignments, func(i, j int) bool { return assignments[i].Cluster < assignments[j].Cluster })
+
+	changed := false
+	for _, assignment := range assignments {
+		repaired, action := repairOne(pool, assignments, assignment, m.validationMode)
+		switch action {
+		case repairKeep:
+			continue
+		case repairReselectSameGroup, repairReallocate:
+			if err := m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+				return m.storager.UpsertAssignment(ctx, repaired)
+			}); err != nil {
+				return err
+			}
+			changed = true
+		case repairClear:
+			if err := m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+				return m.storager.DeleteAssignment(ctx, assignment.Cluster)
+			}); err != nil {
+				return err
+			}
+			changed = true
+		}
+	}
+
+	if changed {
+		m.triggerEppDataExport(ctx)
+	}
+
+	return nil
+}
+
+// Reconcile idempotently scans all EPP clusters and ensures every one has a
+// valid assignment: dangling repairs first, then greedy allocation for
+// clusters without any assignment. It is the reconciler body and safe to run
+// repeatedly (most passes perform zero writes).
+func (m *EppPoolManager) Reconcile(ctx context.Context) error {
+	if m.clusterSource == nil {
+		return nil
+	}
+
+	if err := m.RepairDangling(ctx); err != nil {
+		return err
+	}
+
+	eppClusters, err := m.clusterSource.FetchEPPClusters(ctx)
+	if err != nil {
+		return err
+	}
+	if len(eppClusters) == 0 {
+		return nil
+	}
+
+	instances, err := m.storager.FetchInstanceList(ctx, &InstanceFilter{})
+	if err != nil {
+		return err
+	}
+	pool := buildPool(m.poolName, instances)
+
+	assignments, err := m.storager.FetchAssignmentList(ctx)
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(eppClusters, func(i, j int) bool { return eppClusters[i].Name < eppClusters[j].Name })
+
+	for _, cluster := range eppClusters {
+		if findValidAssignment(pool, assignments, cluster.Name, m.validationMode) != nil {
+			continue
+		}
+		if err := m.allocateAndUpsert(ctx, pool, assignments, cluster.Name); err != nil {
+			return err
+		}
+		// Re-read so the next allocation sees this new assignment.
+		assignments, err = m.storager.FetchAssignmentList(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// OverrideAssignment manually overrides the assignment of one cluster
+// (operations fallback). The cluster must exist and be in EPP mode, the
+// group must exist in the pool and the primary instance must belong to that
+// group. The epp_data export is triggered after a successful upsert.
+func (m *EppPoolManager) OverrideAssignment(ctx context.Context, clusterName, groupName, primaryInstanceID string) (*ClusterAssignmentView, error) {
+	if clusterName == "" {
+		return nil, xerror.WrapParamErrorWithMsg("cluster name is empty")
+	}
+	if groupName == "" {
+		return nil, xerror.WrapParamErrorWithMsg("group_name is empty")
+	}
+	if primaryInstanceID == "" {
+		return nil, xerror.WrapParamErrorWithMsg("primary_instance_id is empty")
+	}
+
+	if m.clusterSource == nil {
+		return nil, xerror.WrapModelErrorWithMsg("epp pool: cluster source is not configured")
+	}
+	eppClusters, err := m.clusterSource.FetchEPPClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+	clusterFound := false
+	for _, cluster := range eppClusters {
+		if cluster.Name == clusterName {
+			clusterFound = true
+			break
+		}
+	}
+	if !clusterFound {
+		return nil, xerror.WrapRecordNotExist("epp assignment", clusterName)
+	}
+
+	instances, err := m.storager.FetchInstanceList(ctx, &InstanceFilter{GroupName: &groupName})
+	if err != nil {
+		return nil, err
+	}
+	if len(instances) == 0 {
+		return nil, xerror.WrapParamErrorWithMsg("epp pool group %q does not exist", groupName)
+	}
+
+	found := false
+	for _, inst := range instances {
+		if inst.ID == primaryInstanceID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, xerror.WrapParamErrorWithMsg("primary_instance_id %q does not exist in group %q", primaryInstanceID, groupName)
+	}
+
+	err = m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+		return m.storager.UpsertAssignment(ctx, &AssignmentParam{
+			Cluster:           clusterName,
+			GroupName:         groupName,
+			PrimaryInstanceID: primaryInstanceID,
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.triggerEppDataExport(ctx)
+
+	return m.GetAssignmentView(ctx, clusterName)
+}
+
+// ClusterAssignmentView is the per-cluster expanded assignment view
+// (api-changes.md §3.3.1).
+type ClusterAssignmentView struct {
+	Cluster  string         `json:"cluster"`
+	Group    *string        `json:"group"`
+	Primary  *InstanceParam `json:"primary"`
+	Standby  *InstanceParam `json:"standby"`
+	Degraded bool           `json:"degraded"`
+}
+
+// AssignmentsView is the full assignment view: per-cluster expansion plus
+// the unassigned cluster list and the idle group list.
+type AssignmentsView struct {
+	Clusters           []*ClusterAssignmentView `json:"clusters"`
+	UnassignedClusters []string                 `json:"unassigned_clusters"`
+	IdleGroups         []string                 `json:"idle_groups"`
+}
+
+// GetAssignmentsView builds the full assignment view (read-time join of
+// epp_assignments and epp_instances). Only balance_mode=EPP clusters are in
+// scope; EPP clusters without a valid assignment are listed in
+// UnassignedClusters and entries pointing to a removed instance/group are
+// marked Degraded.
+func (m *EppPoolManager) GetAssignmentsView(ctx context.Context) (*AssignmentsView, error) {
+	if m.clusterSource == nil {
+		return nil, xerror.WrapModelErrorWithMsg("epp pool: cluster source is not configured")
+	}
+
+	eppClusters, err := m.clusterSource.FetchEPPClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	instances, err := m.storager.FetchInstanceList(ctx, &InstanceFilter{})
+	if err != nil {
+		return nil, err
+	}
+	pool := buildPool(m.poolName, instances)
+
+	assignments, err := m.storager.FetchAssignmentList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildAssignmentsView(pool, eppClusters, assignments), nil
+}
+
+// GetAssignmentView builds the assignment view of one cluster. The cluster
+// must be in EPP mode; nil is returned when the cluster has no assignment.
+func (m *EppPoolManager) GetAssignmentView(ctx context.Context, clusterName string) (*ClusterAssignmentView, error) {
+	view, err := m.GetAssignmentsView(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range view.Clusters {
+		if entry.Cluster == clusterName {
+			return entry, nil
+		}
+	}
+
+	return nil, xerror.WrapRecordNotExist("epp assignment", clusterName)
+}
+
+// buildAssignmentsView is the pure view builder shared by manager methods and tests.
+func buildAssignmentsView(pool *EppPool, eppClusters []*EPPClusterInfo, assignments []*AssignmentParam) *AssignmentsView {
+	groupMap := map[string][]*InstanceParam{}
+	for _, group := range pool.Groups {
+		groupMap[group.Name] = group.Instances
+	}
+
+	assignmentMap := map[string]*AssignmentParam{}
+	for _, assignment := range assignments {
+		assignmentMap[assignment.Cluster] = assignment
+	}
+
+	view := &AssignmentsView{
+		Clusters:           []*ClusterAssignmentView{},
+		UnassignedClusters: []string{},
+		IdleGroups:         []string{},
+	}
+
+	occupiedGroups := map[string]bool{}
+	validAssignedClusters := map[string]bool{}
+
+	sort.Slice(eppClusters, func(i, j int) bool { return eppClusters[i].Name < eppClusters[j].Name })
+	for _, cluster := range eppClusters {
+		entry := &ClusterAssignmentView{Cluster: cluster.Name}
+
+		assignment := assignmentMap[cluster.Name]
+		if assignment != nil {
+			groupName := assignment.GroupName
+			primary, standby := expandPrimaryAndStandby(groupMap[groupName], assignment.PrimaryInstanceID)
+			if primary != nil {
+				entry.Group = &groupName
+				entry.Primary = primary
+				entry.Standby = standby
+				occupiedGroups[groupName] = true
+				validAssignedClusters[cluster.Name] = true
+			} else {
+				// Assignment dangles: primary removed from the pool.
+				entry.Degraded = true
+			}
+		}
+
+		view.Clusters = append(view.Clusters, entry)
+		if !validAssignedClusters[cluster.Name] {
+			view.UnassignedClusters = append(view.UnassignedClusters, cluster.Name)
+		}
+	}
+
+	for _, group := range pool.Groups {
+		if !occupiedGroups[group.Name] {
+			view.IdleGroups = append(view.IdleGroups, group.Name)
+		}
+	}
+	sort.Strings(view.IdleGroups)
+
+	return view
+}
+
+// expandPrimaryAndStandby resolves the primary instance and the standby
+// (first other instance of the group by id order). Nil primary means the
+// assigned instance is not in the pool anymore.
+func expandPrimaryAndStandby(instances []*InstanceParam, primaryID string) (*InstanceParam, *InstanceParam) {
+	var primary, standby *InstanceParam
+	for _, inst := range instances {
+		if inst.ID == primaryID {
+			primary = inst
+			continue
+		}
+		if standby == nil {
+			standby = inst
+		}
+	}
+	return primary, standby
+}
+
+// findValidAssignment returns the assignment of the cluster if it exists,
+// its group meets the deployment shape requirement, and its primary instance
+// is still present in the assigned group.
+func findValidAssignment(pool *EppPool, assignments []*AssignmentParam, clusterName, validationMode string) *AssignmentParam {
+	groupMap := map[string]*InstanceGroup{}
+	for _, group := range pool.Groups {
+		groupMap[group.Name] = group
+	}
+
+	for _, assignment := range assignments {
+		if assignment.Cluster != clusterName {
+			continue
+		}
+		group := groupMap[assignment.GroupName]
+		if group == nil || !groupMeetsValidationMode(group, validationMode) {
+			return nil
+		}
+		primary, _ := expandPrimaryAndStandby(group.Instances, assignment.PrimaryInstanceID)
+		if primary != nil {
+			return assignment
+		}
+		return nil
+	}
+
+	return nil
+}
+
+type repairAction int
+
+const (
+	repairKeep repairAction = iota
+	repairReselectSameGroup
+	repairReallocate
+	repairClear
+)
+
+// repairOne decides the repair action for one dangling-or-valid assignment.
+// A valid assignment maps to repairKeep.
+func repairOne(pool *EppPool, assignments []*AssignmentParam, assignment *AssignmentParam, validationMode string) (*AssignmentParam, repairAction) {
+	if findValidAssignment(pool, assignments, assignment.Cluster, validationMode) != nil {
+		return assignment, repairKeep
+	}
+
+	group := findGroup(pool, assignment.GroupName)
+	if group != nil && groupMeetsValidationMode(group, validationMode) {
+		// Group still exists: reselect the primary within the same group.
+		primary := selectPrimaryInGroup(group.Instances, assignments)
+		if primary != nil {
+			return &AssignmentParam{
+				Cluster:           assignment.Cluster,
+				GroupName:         group.Name,
+				PrimaryInstanceID: primary.ID,
+			}, repairReselectSameGroup
+		}
+	}
+
+	// Group gone or undersized: cross-group reallocation; clear if impossible.
+	reallocated, err := allocateCluster(pool, assignments, assignment.Cluster, validationMode)
+	if err != nil {
+		return nil, repairClear
+	}
+	return reallocated, repairReallocate
+}
+
+// allocateCluster implements the greedy deterministic allocator
+// (design-changes.md §4.2.2).
+func allocateCluster(pool *EppPool, assignments []*AssignmentParam, clusterName, validationMode string) (*AssignmentParam, error) {
+	candidates := candidateGroups(pool, validationMode)
+	if len(candidates) == 0 {
+		return nil, xerror.WrapModelErrorWithMsg("epp pool has no assignable instance group")
+	}
+
+	primaryCount := countPrimaries(assignments)
+
+	// Select the group with the smallest load; tie-break by group name.
+	selected := candidates[0]
+	selectedLoad := groupLoad(selected, primaryCount)
+	for _, group := range candidates[1:] {
+		load := groupLoad(group, primaryCount)
+		if load < selectedLoad || (load == selectedLoad && group.Name < selected.Name) {
+			selected = group
+			selectedLoad = load
+		}
+	}
+
+	// Select the primary: least loaded instance, tie-break by instance id.
+	primary := selectPrimaryInGroup(selected.Instances, assignments)
+	if primary == nil {
+		return nil, xerror.WrapModelErrorWithMsg("epp pool group %q has no assignable instance", selected.Name)
+	}
+
+	return &AssignmentParam{
+		Cluster:           clusterName,
+		GroupName:         selected.Name,
+		PrimaryInstanceID: primary.ID,
+	}, nil
+}
+
+// candidateGroups filters groups meeting the deployment shape requirement,
+// ordered by group name for determinism.
+func candidateGroups(pool *EppPool, validationMode string) []*InstanceGroup {
+	var candidates []*InstanceGroup
+	for _, group := range pool.Groups {
+		if groupMeetsValidationMode(group, validationMode) {
+			candidates = append(candidates, group)
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Name < candidates[j].Name })
+	return candidates
+}
+
+// groupMeetsValidationMode checks the group size against the deployment shape.
+func groupMeetsValidationMode(group *InstanceGroup, validationMode string) bool {
+	switch validationMode {
+	case ValidationModeTest:
+		return len(group.Instances) >= 1
+	default:
+		return len(group.Instances) == 2
+	}
+}
+
+// countPrimaries counts, per instance id, in how many assignments the
+// instance acts as primary.
+func countPrimaries(assignments []*AssignmentParam) map[string]int {
+	counts := map[string]int{}
+	for _, assignment := range assignments {
+		counts[assignment.PrimaryInstanceID]++
+	}
+	return counts
+}
+
+// groupLoad sums the primary counts of all instances of the group.
+func groupLoad(group *InstanceGroup, primaryCount map[string]int) int {
+	load := 0
+	for _, inst := range group.Instances {
+		load += primaryCount[inst.ID]
+	}
+	return load
+}
+
+// selectPrimaryInGroup picks the instance with the smallest primary count;
+// tie-break by instance id (instances must be id-ordered by the caller via
+// buildPool; sorted here defensively).
+func selectPrimaryInGroup(instances []*InstanceParam, assignments []*AssignmentParam) *InstanceParam {
+	if len(instances) == 0 {
+		return nil
+	}
+
+	ordered := make([]*InstanceParam, len(instances))
+	copy(ordered, instances)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].ID < ordered[j].ID })
+
+	primaryCount := countPrimaries(assignments)
+
+	selected := ordered[0]
+	for _, inst := range ordered[1:] {
+		if primaryCount[inst.ID] < primaryCount[selected.ID] {
+			selected = inst
+		}
+	}
+	return selected
+}
+
+func findGroup(pool *EppPool, groupName string) *InstanceGroup {
+	for _, group := range pool.Groups {
+		if group.Name == groupName {
+			return group
+		}
+	}
+	return nil
+}

--- a/model/epp_pool/assignment_test.go
+++ b/model/epp_pool/assignment_test.go
@@ -1,0 +1,284 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func inst(id, group, host string, port int) *InstanceParam {
+	return &InstanceParam{ID: id, Host: host, Port: port, GroupName: group}
+}
+
+func makePool(groups ...*InstanceGroup) *EppPool {
+	return &EppPool{Name: "EPP.pool", Groups: groups}
+}
+
+func TestAllocateCluster_Deterministic(t *testing.T) {
+	pool := makePool(
+		&InstanceGroup{Name: "g1", Instances: []*InstanceParam{inst("epp-a", "g1", "10.0.0.1", 9002), inst("epp-b", "g1", "10.0.0.2", 9002)}},
+		&InstanceGroup{Name: "g2", Instances: []*InstanceParam{inst("epp-c", "g2", "10.0.0.3", 9002), inst("epp-d", "g2", "10.0.0.4", 9002)}},
+	)
+
+	first, err := allocateCluster(pool, nil, "cluster-a", ValidationModeProduction)
+	require.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		got, err := allocateCluster(pool, nil, "cluster-a", ValidationModeProduction)
+		require.NoError(t, err)
+		assert.Equal(t, first, got)
+	}
+	// Equal load: group name tie-break; instance id tie-break.
+	assert.Equal(t, "g1", first.GroupName)
+	assert.Equal(t, "epp-a", first.PrimaryInstanceID)
+}
+
+func TestAllocateCluster_GroupLoadBalancing(t *testing.T) {
+	pool := makePool(
+		&InstanceGroup{Name: "g1", Instances: []*InstanceParam{inst("epp-a", "g1", "10.0.0.1", 9002), inst("epp-b", "g1", "10.0.0.2", 9002)}},
+		&InstanceGroup{Name: "g2", Instances: []*InstanceParam{inst("epp-c", "g2", "10.0.0.3", 9002), inst("epp-d", "g2", "10.0.0.4", 9002)}},
+	)
+
+	// g1 already carries two primaries -> the next cluster goes to g2.
+	assignments := []*AssignmentParam{
+		{Cluster: "cluster-x", GroupName: "g1", PrimaryInstanceID: "epp-a"},
+		{Cluster: "cluster-y", GroupName: "g1", PrimaryInstanceID: "epp-b"},
+	}
+	got, err := allocateCluster(pool, assignments, "cluster-z", ValidationModeProduction)
+	require.NoError(t, err)
+	assert.Equal(t, "g2", got.GroupName)
+
+	// Equal total load: group name tie-break even when ids would differ.
+	assignments = []*AssignmentParam{
+		{Cluster: "cluster-x", GroupName: "g2", PrimaryInstanceID: "epp-c"},
+	}
+	got, err = allocateCluster(pool, assignments, "cluster-z", ValidationModeProduction)
+	require.NoError(t, err)
+	// g1 load = 0, g2 load = 1 -> g1.
+	assert.Equal(t, "g1", got.GroupName)
+}
+
+func TestAllocateCluster_PrimaryLoadBalancing(t *testing.T) {
+	pool := makePool(
+		&InstanceGroup{Name: "g1", Instances: []*InstanceParam{inst("epp-a", "g1", "10.0.0.1", 9002), inst("epp-b", "g1", "10.0.0.2", 9002)}},
+	)
+
+	// epp-a already primary elsewhere -> epp-b picked within the same group.
+	assignments := []*AssignmentParam{
+		{Cluster: "cluster-x", GroupName: "g2", PrimaryInstanceID: "epp-a"},
+	}
+	got, err := allocateCluster(pool, assignments, "cluster-z", ValidationModeProduction)
+	require.NoError(t, err)
+	assert.Equal(t, "g1", got.GroupName)
+	assert.Equal(t, "epp-b", got.PrimaryInstanceID)
+}
+
+func TestAllocateCluster_CandidateFilter(t *testing.T) {
+	pool := makePool(
+		// Undersized for production mode.
+		&InstanceGroup{Name: "g1", Instances: []*InstanceParam{inst("epp-a", "g1", "10.0.0.1", 9002)}},
+		// Valid production group.
+		&InstanceGroup{Name: "g2", Instances: []*InstanceParam{inst("epp-c", "g2", "10.0.0.3", 9002), inst("epp-d", "g2", "10.0.0.4", 9002)}},
+	)
+
+	got, err := allocateCluster(pool, nil, "cluster-a", ValidationModeProduction)
+	require.NoError(t, err)
+	assert.Equal(t, "g2", got.GroupName)
+
+	// Test mode accepts single instance groups (smallest name first).
+	got, err = allocateCluster(pool, nil, "cluster-a", ValidationModeTest)
+	require.NoError(t, err)
+	assert.Equal(t, "g1", got.GroupName)
+	assert.Equal(t, "epp-a", got.PrimaryInstanceID)
+
+	// No candidates at all.
+	empty := makePool(&InstanceGroup{Name: "g1", Instances: []*InstanceParam{inst("epp-a", "g1", "10.0.0.1", 9002)}})
+	_, err = allocateCluster(empty, nil, "cluster-a", ValidationModeProduction)
+	require.Error(t, err)
+}
+
+func TestRepairOne(t *testing.T) {
+	pool := makePool(
+		&InstanceGroup{Name: "g1", Instances: []*InstanceParam{inst("epp-a", "g1", "10.0.0.1", 9002), inst("epp-b", "g1", "10.0.0.2", 9002)}},
+		&InstanceGroup{Name: "g2", Instances: []*InstanceParam{inst("epp-c", "g2", "10.0.0.3", 9002), inst("epp-d", "g2", "10.0.0.4", 9002)}},
+	)
+
+	t.Run("valid assignment kept", func(t *testing.T) {
+		assignment := &AssignmentParam{Cluster: "c1", GroupName: "g1", PrimaryInstanceID: "epp-a"}
+		_, action := repairOne(pool, []*AssignmentParam{assignment}, assignment, ValidationModeProduction)
+		assert.Equal(t, repairKeep, action)
+	})
+
+	t.Run("same group reselect when primary removed", func(t *testing.T) {
+		assignment := &AssignmentParam{Cluster: "c1", GroupName: "g1", PrimaryInstanceID: "epp-x"}
+		repaired, action := repairOne(pool, []*AssignmentParam{assignment}, assignment, ValidationModeProduction)
+		require.Equal(t, repairReselectSameGroup, action)
+		assert.Equal(t, "g1", repaired.GroupName)
+		assert.Equal(t, "epp-a", repaired.PrimaryInstanceID)
+	})
+
+	t.Run("cross group reallocate when group gone", func(t *testing.T) {
+		assignment := &AssignmentParam{Cluster: "c1", GroupName: "g9", PrimaryInstanceID: "epp-x"}
+		repaired, action := repairOne(pool, []*AssignmentParam{assignment}, assignment, ValidationModeProduction)
+		require.Equal(t, repairReallocate, action)
+		assert.Equal(t, "g1", repaired.GroupName)
+		assert.Equal(t, "epp-a", repaired.PrimaryInstanceID)
+	})
+
+	t.Run("clear when no candidate groups", func(t *testing.T) {
+		empty := makePool(&InstanceGroup{Name: "g1", Instances: []*InstanceParam{inst("epp-a", "g1", "10.0.0.1", 9002)}})
+		assignment := &AssignmentParam{Cluster: "c1", GroupName: "g9", PrimaryInstanceID: "epp-x"}
+		_, action := repairOne(empty, []*AssignmentParam{assignment}, assignment, ValidationModeProduction)
+		assert.Equal(t, repairClear, action)
+	})
+
+	t.Run("cross group when group undersized", func(t *testing.T) {
+		poolUnder := makePool(
+			&InstanceGroup{Name: "g1", Instances: []*InstanceParam{inst("epp-a", "g1", "10.0.0.1", 9002)}},
+			&InstanceGroup{Name: "g2", Instances: []*InstanceParam{inst("epp-c", "g2", "10.0.0.3", 9002), inst("epp-d", "g2", "10.0.0.4", 9002)}},
+		)
+		assignment := &AssignmentParam{Cluster: "c1", GroupName: "g1", PrimaryInstanceID: "epp-a"}
+		repaired, action := repairOne(poolUnder, []*AssignmentParam{assignment}, assignment, ValidationModeProduction)
+		require.Equal(t, repairReallocate, action)
+		assert.Equal(t, "g2", repaired.GroupName)
+	})
+}
+
+func TestBuildAssignmentsView(t *testing.T) {
+	pool := makePool(
+		&InstanceGroup{Name: "g1", Instances: []*InstanceParam{inst("epp-a", "g1", "10.0.0.1", 9002), inst("epp-b", "g1", "10.0.0.2", 9002)}},
+		&InstanceGroup{Name: "g2", Instances: []*InstanceParam{inst("epp-c", "g2", "10.0.0.3", 9002), inst("epp-d", "g2", "10.0.0.4", 9002)}},
+		&InstanceGroup{Name: "g3", Instances: []*InstanceParam{inst("epp-e", "g3", "10.0.0.5", 9002), inst("epp-f", "g3", "10.0.0.6", 9002)}},
+	)
+
+	eppClusters := []*EPPClusterInfo{
+		{Name: "cluster-a"},
+		{Name: "cluster-b"},
+		{Name: "cluster-c"},
+		{Name: "cluster-d"},
+	}
+	assignments := []*AssignmentParam{
+		{Cluster: "cluster-a", GroupName: "g1", PrimaryInstanceID: "epp-a"},
+		{Cluster: "cluster-b", GroupName: "g1", PrimaryInstanceID: "epp-b"},
+		{Cluster: "cluster-c", GroupName: "g9", PrimaryInstanceID: "epp-x"},
+	}
+
+	view := buildAssignmentsView(pool, eppClusters, assignments)
+	require.Len(t, view.Clusters, 4)
+
+	assert.Equal(t, "g1", *view.Clusters[0].Group)
+	assert.Equal(t, "epp-a", view.Clusters[0].Primary.ID)
+	require.NotNil(t, view.Clusters[0].Standby)
+	assert.Equal(t, "epp-b", view.Clusters[0].Standby.ID)
+	assert.False(t, view.Clusters[0].Degraded)
+
+	// Mutual primary/standby across clusters of the same group is legal.
+	assert.Equal(t, "epp-b", view.Clusters[1].Primary.ID)
+	assert.Equal(t, "epp-a", view.Clusters[1].Standby.ID)
+
+	// Dangling assignment: degraded, counted as unassigned.
+	assert.True(t, view.Clusters[2].Degraded)
+	assert.Nil(t, view.Clusters[2].Primary)
+	assert.Nil(t, view.Clusters[2].Group)
+
+	// No assignment at all.
+	assert.Nil(t, view.Clusters[3].Primary)
+	assert.False(t, view.Clusters[3].Degraded)
+
+	assert.Equal(t, []string{"cluster-c", "cluster-d"}, view.UnassignedClusters)
+	// g2 and g3 carry no primary.
+	assert.Equal(t, []string{"g2", "g3"}, view.IdleGroups)
+}
+
+func TestBuildAssignmentsView_SingleInstanceGroup(t *testing.T) {
+	pool := makePool(
+		&InstanceGroup{Name: "g1", Instances: []*InstanceParam{inst("epp-a", "g1", "10.0.0.1", 9002)}},
+	)
+	eppClusters := []*EPPClusterInfo{{Name: "cluster-a"}}
+	assignments := []*AssignmentParam{{Cluster: "cluster-a", GroupName: "g1", PrimaryInstanceID: "epp-a"}}
+
+	view := buildAssignmentsView(pool, eppClusters, assignments)
+	require.Len(t, view.Clusters, 1)
+	assert.Equal(t, "epp-a", view.Clusters[0].Primary.ID)
+	assert.Nil(t, view.Clusters[0].Standby)
+	assert.Empty(t, view.UnassignedClusters)
+}
+
+func TestEppPoolManager_GetAssignmentEndpoints(t *testing.T) {
+	ctx := context.Background()
+
+	newManager := func(store *memoryEppPoolStorager) *EppPoolManager {
+		return NewEppPoolManager(&fakeTxn{}, store, nil, nil, &ManagerOptions{ValidationMode: ValidationModeTest})
+	}
+
+	t.Run("ordered primary standby joined by net.JoinHostPort", func(t *testing.T) {
+		store := newMemoryEppPoolStorager()
+		store.seedInstances(
+			&InstanceParam{ID: "epp-a", Host: "10.0.0.1", Port: 9002, GroupName: "g1"},
+			&InstanceParam{ID: "epp-b", Host: "2001:db8::10", Port: 9002, GroupName: "g1"},
+		)
+		store.seedAssignments(&AssignmentParam{Cluster: "c1", GroupName: "g1", PrimaryInstanceID: "epp-b"})
+
+		endpoints, found, err := newManager(store).GetAssignmentEndpoints(ctx, "c1")
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, []string{"[2001:db8::10]:9002", "10.0.0.1:9002"}, endpoints)
+	})
+
+	t.Run("single instance group yields primary only", func(t *testing.T) {
+		store := newMemoryEppPoolStorager()
+		store.seedInstances(
+			&InstanceParam{ID: "epp-a", Host: "10.0.0.1", Port: 9002, GroupName: "g1"},
+		)
+		store.seedAssignments(&AssignmentParam{Cluster: "c1", GroupName: "g1", PrimaryInstanceID: "epp-a"})
+
+		endpoints, found, err := newManager(store).GetAssignmentEndpoints(ctx, "c1")
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, []string{"10.0.0.1:9002"}, endpoints)
+	})
+
+	t.Run("no assignment record", func(t *testing.T) {
+		store := newMemoryEppPoolStorager()
+		store.seedInstances(
+			&InstanceParam{ID: "epp-a", Host: "10.0.0.1", Port: 9002, GroupName: "g1"},
+		)
+
+		_, found, err := newManager(store).GetAssignmentEndpoints(ctx, "c1")
+		require.NoError(t, err)
+		assert.False(t, found)
+	})
+
+	t.Run("dangling assignment", func(t *testing.T) {
+		store := newMemoryEppPoolStorager()
+		store.seedInstances(
+			&InstanceParam{ID: "epp-a", Host: "10.0.0.1", Port: 9002, GroupName: "g1"},
+		)
+		store.seedAssignments(&AssignmentParam{Cluster: "c1", GroupName: "g1", PrimaryInstanceID: "epp-removed"})
+
+		_, found, err := newManager(store).GetAssignmentEndpoints(ctx, "c1")
+		require.NoError(t, err)
+		assert.False(t, found)
+	})
+
+	t.Run("empty cluster name", func(t *testing.T) {
+		store := newMemoryEppPoolStorager()
+		_, _, err := newManager(store).GetAssignmentEndpoints(ctx, "")
+		require.Error(t, err)
+	})
+}

--- a/model/epp_pool/compiler.go
+++ b/model/epp_pool/compiler.go
@@ -1,0 +1,328 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"strconv"
+	"time"
+)
+
+// Minimal struct set mirroring the llm-d apix v1alpha1 EndpointPickerConfig
+// JSON shape (no llm-d dependency). Field names and json tags follow
+// ai-gateway-epp/docs/zh_cn/configuration/EPP配置定义说明-epp_config.md.
+//
+// The full example:
+//
+//	{
+//	  "featureGates": ["flowControl"],
+//	  "plugins": [
+//	    {"name": "ep-discover", "type": "cluster-table-discovery", "parameters": {"clusterName": "<cluster>"}},
+//	    {"name": "util-filter", "type": "utilization-filter", "parameters": {"conditions": [{"metric": "kv-cache-utilization", "maxValue": 0.9}]}},
+//	    {"name": "kv-scorer", "type": "kv-cache-utilization-scorer", "parameters": {}},
+//	    {"name": "queue-scorer", "type": "queue-scorer", "parameters": {}},
+//	    {"name": "prefix-scorer", "type": "prefix-cache-scorer", "parameters": {}},
+//	    {"name": "session-scorer", "type": "session-affinity-scorer", "parameters": {"sessionIdConfig": {"sources": [{"header": "x-session-id"}]}}},
+//	    {"name": "max-score", "type": "max-score-picker", "parameters": {}},
+//	    {"name": "openai-parser", "type": "openai-parser", "parameters": {}}
+//	  ],
+//	  "schedulingProfiles": [
+//	    {"name": "default", "plugins": [
+//	      {"pluginRef": "util-filter"},
+//	      {"pluginRef": "kv-scorer", "weight": 1.0},
+//	      {"pluginRef": "queue-scorer", "weight": 0.5},
+//	      {"pluginRef": "prefix-scorer", "weight": 1.0},
+//	      {"pluginRef": "session-scorer", "weight": 1.0},
+//	      {"pluginRef": "max-score"}
+//	    ]}
+//	  ],
+//	  "dataLayer": {"discovery": {"endpoints": {"pluginRef": "ep-discover"}}},
+//	  "flowControl": {"maxRequests": "1000", "defaultRequestTTL": "30s", "noEndpointRequestTTL": "10m0s"},
+//	  "requestHandler": {"parsers": [{"pluginRef": "openai-parser"}]}
+//	}
+//
+// JSON tags follow ai-gateway-epp/docs/zh_cn/configuration/EPP配置定义说明-epp_config.md
+// and the llm-d apix v1alpha1 EndpointPickerConfig tags exactly
+// (llm-d-router/apix/config/v1alpha1/endpointpickerconfig_types.go): maxRequests
+// is a Kubernetes resource.Quantity in apix, whose canonical JSON form is the
+// string kept here (e.g. "1000"); enableEviction is omitted when false
+// (omitempty, as in apix); weight carries no omitempty in apix, so an
+// unweighted profile plugin serializes as "weight": null.
+
+// EndpointPickerConfig is the compiled per-cluster EPP scheduling config.
+type EndpointPickerConfig struct {
+	FeatureGates       []string                   `json:"featureGates,omitempty"`
+	Plugins            []*PluginConfig            `json:"plugins"`
+	SchedulingProfiles []*SchedulingProfileConfig `json:"schedulingProfiles"`
+	DataLayer          *DataLayerConfig           `json:"dataLayer"`
+	FlowControl        *FlowControlConfig         `json:"flowControl,omitempty"`
+	RequestHandler     *RequestHandlerConfig      `json:"requestHandler,omitempty"`
+}
+
+// PluginConfig declares one plugin instance.
+type PluginConfig struct {
+	Name       string                 `json:"name"`
+	Type       string                 `json:"type"`
+	Parameters map[string]interface{} `json:"parameters"`
+}
+
+// SchedulingProfileConfig declares one scheduling profile.
+type SchedulingProfileConfig struct {
+	Name    string                 `json:"name"`
+	Plugins []*ProfilePluginConfig `json:"plugins"`
+}
+
+// ProfilePluginConfig references a plugin instance inside a profile.
+// Weight mirrors the apix SchedulingPlugin tag: no omitempty, so an
+// unweighted plugin serializes as "weight": null (accepted by the EPP
+// strict decode).
+type ProfilePluginConfig struct {
+	PluginRef string   `json:"pluginRef"`
+	Weight    *float64 `json:"weight"`
+}
+
+// DataLayerConfig declares the data layer (endpoint discovery).
+type DataLayerConfig struct {
+	Discovery *DiscoveryConfig `json:"discovery,omitempty"`
+}
+
+// DiscoveryConfig declares the endpoint discovery plugin reference.
+type DiscoveryConfig struct {
+	Endpoints *PluginRefConfig `json:"endpoints,omitempty"`
+}
+
+// PluginRefConfig is a bare plugin reference.
+type PluginRefConfig struct {
+	PluginRef string `json:"pluginRef"`
+}
+
+// FlowControlConfig is the compiled flow-control section. MaxRequests is a
+// string because the apix FlowControlConfig types it as resource.Quantity,
+// whose canonical JSON form is a string ("1000").
+type FlowControlConfig struct {
+	MaxRequests          string `json:"maxRequests,omitempty"`
+	DefaultRequestTTL    string `json:"defaultRequestTTL,omitempty"`
+	NoEndpointRequestTTL string `json:"noEndpointRequestTTL,omitempty"`
+	EnableEviction       bool   `json:"enableEviction,omitempty"`
+}
+
+// RequestHandlerConfig declares request parsers.
+type RequestHandlerConfig struct {
+	Parsers []*PluginRefConfig `json:"parsers,omitempty"`
+}
+
+// Fixed plugin instance names of the compile template.
+const (
+	pluginNameDiscovery      = "ep-discover"
+	pluginNameUtilFilter     = "util-filter"
+	pluginNameKVScorer       = "kv-scorer"
+	pluginNameQueueScorer    = "queue-scorer"
+	pluginNamePrefixScorer   = "prefix-scorer"
+	pluginNameSessionScorer  = "session-scorer"
+	pluginNameMaxScorePicker = "max-score"
+	pluginNameOpenAIParser   = "openai-parser"
+)
+
+// Fixed plugin types of the compile template.
+const (
+	pluginTypeDiscovery      = "cluster-table-discovery"
+	pluginTypeUtilFilter     = "utilization-filter"
+	pluginTypeKVScorer       = "kv-cache-utilization-scorer"
+	pluginTypeQueueScorer    = "queue-scorer"
+	pluginTypePrefixScorer   = "prefix-cache-scorer"
+	pluginTypeSessionScorer  = "session-affinity-scorer"
+	pluginTypeMaxScorePicker = "max-score-picker"
+	pluginTypeOpenAIParser   = "openai-parser"
+)
+
+const metricKVCacheUtilization = "kv-cache-utilization"
+
+const featureGateFlowControl = "flowControl"
+
+// scorerWeights maps scheduling profiles / cache affinities to (kv, queue) weights.
+var scorerWeights = map[string][2]float64{
+	SchedulingProfileLatencyFirst:    {0.2, 1.0},
+	SchedulingProfileBalanced:        {1.0, 0.5},
+	SchedulingProfileThroughputFirst: {1.0, 0.2},
+
+	CacheAffinityLow:    {0.2, 1.0},
+	CacheAffinityMedium: {0.6, 0.6},
+	CacheAffinityHigh:   {1.0, 0.2},
+}
+
+// CompileEppConfig deterministically compiles the simplified epp_config of
+// one cluster into the full EndpointPickerConfig (api-changes.md §3.2.1).
+// The result is always structurally valid; defaults are applied for unset fields.
+func CompileEppConfig(clusterName string, conf *EppConfigSimplified) *EndpointPickerConfig {
+	kvWeight, queueWeight := compileScorerWeights(conf)
+
+	plugins := []*PluginConfig{
+		{
+			Name: pluginNameDiscovery,
+			Type: pluginTypeDiscovery,
+			Parameters: map[string]interface{}{
+				"clusterName": clusterName,
+			},
+		},
+		{
+			Name: pluginNameUtilFilter,
+			Type: pluginTypeUtilFilter,
+			Parameters: map[string]interface{}{
+				"conditions": []map[string]interface{}{
+					{
+						"metric":   metricKVCacheUtilization,
+						"maxValue": conf.EffectiveKVCacheUtilizationMax(),
+					},
+				},
+			},
+		},
+		{
+			Name:       pluginNameKVScorer,
+			Type:       pluginTypeKVScorer,
+			Parameters: map[string]interface{}{},
+		},
+		{
+			Name:       pluginNameQueueScorer,
+			Type:       pluginTypeQueueScorer,
+			Parameters: map[string]interface{}{},
+		},
+	}
+
+	profilePlugins := []*ProfilePluginConfig{
+		{PluginRef: pluginNameUtilFilter},
+		{PluginRef: pluginNameKVScorer, Weight: float64Ptr(kvWeight)},
+		{PluginRef: pluginNameQueueScorer, Weight: float64Ptr(queueWeight)},
+	}
+
+	if conf.EffectivePrefixCacheAffinity() {
+		plugins = append(plugins, &PluginConfig{
+			Name:       pluginNamePrefixScorer,
+			Type:       pluginTypePrefixScorer,
+			Parameters: map[string]interface{}{},
+		})
+		profilePlugins = append(profilePlugins, &ProfilePluginConfig{
+			PluginRef: pluginNamePrefixScorer,
+			Weight:    float64Ptr(1.0),
+		})
+	}
+
+	if conf.EffectiveSessionAffinityEnabled() && conf.SessionAffinityHeader != nil {
+		plugins = append(plugins, &PluginConfig{
+			Name: pluginNameSessionScorer,
+			Type: pluginTypeSessionScorer,
+			Parameters: map[string]interface{}{
+				"sessionIdConfig": map[string]interface{}{
+					"sources": []map[string]interface{}{
+						{"header": *conf.SessionAffinityHeader},
+					},
+				},
+			},
+		})
+		profilePlugins = append(profilePlugins, &ProfilePluginConfig{
+			PluginRef: pluginNameSessionScorer,
+			Weight:    float64Ptr(1.0),
+		})
+	}
+
+	plugins = append(plugins,
+		&PluginConfig{
+			Name:       pluginNameMaxScorePicker,
+			Type:       pluginTypeMaxScorePicker,
+			Parameters: map[string]interface{}{},
+		},
+		&PluginConfig{
+			Name:       pluginNameOpenAIParser,
+			Type:       pluginTypeOpenAIParser,
+			Parameters: map[string]interface{}{},
+		},
+	)
+
+	profilePlugins = append(profilePlugins, &ProfilePluginConfig{PluginRef: pluginNameMaxScorePicker})
+
+	compiled := &EndpointPickerConfig{
+		Plugins: plugins,
+		SchedulingProfiles: []*SchedulingProfileConfig{
+			{
+				Name:    "default",
+				Plugins: profilePlugins,
+			},
+		},
+		DataLayer: &DataLayerConfig{
+			Discovery: &DiscoveryConfig{
+				Endpoints: &PluginRefConfig{PluginRef: pluginNameDiscovery},
+			},
+		},
+		RequestHandler: &RequestHandlerConfig{
+			Parsers: []*PluginRefConfig{{PluginRef: pluginNameOpenAIParser}},
+		},
+	}
+
+	if conf.FlowControl != nil {
+		compiled.FeatureGates = []string{featureGateFlowControl}
+		compiled.FlowControl = compileFlowControl(conf.FlowControl)
+	}
+
+	return compiled
+}
+
+// compileScorerWeights resolves the (kv, queue) scorer weights: an explicit
+// cache_affinity overrides the scheduling profile; otherwise the profile
+// weights are used.
+func compileScorerWeights(conf *EppConfigSimplified) (float64, float64) {
+	if conf != nil && conf.CacheAffinity != nil {
+		weights, ok := scorerWeights[*conf.CacheAffinity]
+		if ok {
+			return weights[0], weights[1]
+		}
+	}
+
+	weights, ok := scorerWeights[conf.EffectiveSchedulingProfile()]
+	if !ok {
+		weights = scorerWeights[DefaultSchedulingProfile]
+	}
+	return weights[0], weights[1]
+}
+
+// compileFlowControl expands the simplified flow_control section. Durations
+// are converted from seconds to Go duration strings (30 -> "30s", 600 -> "10m0s").
+func compileFlowControl(fc *FlowControlSimplified) *FlowControlConfig {
+	compiled := &FlowControlConfig{}
+
+	if fc.MaxRequests != nil && *fc.MaxRequests > 0 {
+		compiled.MaxRequests = strconv.Itoa(*fc.MaxRequests)
+	}
+
+	if fc.QueueTTL != nil {
+		compiled.DefaultRequestTTL = secondsToDuration(*fc.QueueTTL)
+	}
+
+	if fc.NoEndpointQueueTTL != nil {
+		compiled.NoEndpointRequestTTL = secondsToDuration(*fc.NoEndpointQueueTTL)
+	}
+
+	if fc.EnableEviction != nil {
+		compiled.EnableEviction = *fc.EnableEviction
+	}
+
+	return compiled
+}
+
+// secondsToDuration converts seconds to a Go duration string ("30s", "10m0s", "0s").
+func secondsToDuration(seconds int) string {
+	return (time.Duration(seconds) * time.Second).String()
+}
+
+func float64Ptr(v float64) *float64 {
+	return &v
+}

--- a/model/epp_pool/compiler_test.go
+++ b/model/epp_pool/compiler_test.go
@@ -1,0 +1,317 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func findProfilePlugin(t *testing.T, conf *EndpointPickerConfig, pluginRef string) *ProfilePluginConfig {
+	t.Helper()
+	require.Len(t, conf.SchedulingProfiles, 1)
+	for _, p := range conf.SchedulingProfiles[0].Plugins {
+		if p.PluginRef == pluginRef {
+			return p
+		}
+	}
+	return nil
+}
+
+func findPlugin(t *testing.T, conf *EndpointPickerConfig, name string) *PluginConfig {
+	t.Helper()
+	for _, p := range conf.Plugins {
+		if p.Name == name {
+			return p
+		}
+	}
+	return nil
+}
+
+func TestCompileEppConfig_Profiles(t *testing.T) {
+	cases := []struct {
+		profile string
+		kv      float64
+		queue   float64
+	}{
+		{SchedulingProfileLatencyFirst, 0.2, 1.0},
+		{SchedulingProfileBalanced, 1.0, 0.5},
+		{SchedulingProfileThroughputFirst, 1.0, 0.2},
+	}
+
+	for _, tc := range cases {
+		conf := CompileEppConfig("cluster-a", &EppConfigSimplified{
+			SchedulingProfile: lib.PString(tc.profile),
+		})
+
+		kv := findProfilePlugin(t, conf, pluginNameKVScorer)
+		require.NotNil(t, kv)
+		require.NotNil(t, kv.Weight)
+		assert.Equal(t, tc.kv, *kv.Weight)
+
+		queue := findProfilePlugin(t, conf, pluginNameQueueScorer)
+		require.NotNil(t, queue)
+		require.NotNil(t, queue.Weight)
+		assert.Equal(t, tc.queue, *queue.Weight)
+	}
+}
+
+func TestCompileEppConfig_CacheAffinityOverride(t *testing.T) {
+	// Explicit cache_affinity overrides the profile weights.
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{
+		SchedulingProfile: lib.PString(SchedulingProfileBalanced),
+		CacheAffinity:     lib.PString(CacheAffinityHigh),
+	})
+	assert.Equal(t, 1.0, *findProfilePlugin(t, conf, pluginNameKVScorer).Weight)
+	assert.Equal(t, 0.2, *findProfilePlugin(t, conf, pluginNameQueueScorer).Weight)
+
+	// Default (no cache_affinity) follows the profile.
+	conf = CompileEppConfig("cluster-a", &EppConfigSimplified{
+		SchedulingProfile: lib.PString(SchedulingProfileLatencyFirst),
+	})
+	assert.Equal(t, 0.2, *findProfilePlugin(t, conf, pluginNameKVScorer).Weight)
+	assert.Equal(t, 1.0, *findProfilePlugin(t, conf, pluginNameQueueScorer).Weight)
+
+	// Explicit medium is an override different from any profile default.
+	conf = CompileEppConfig("cluster-a", &EppConfigSimplified{
+		SchedulingProfile: lib.PString(SchedulingProfileBalanced),
+		CacheAffinity:     lib.PString(CacheAffinityMedium),
+	})
+	assert.Equal(t, 0.6, *findProfilePlugin(t, conf, pluginNameKVScorer).Weight)
+	assert.Equal(t, 0.6, *findProfilePlugin(t, conf, pluginNameQueueScorer).Weight)
+}
+
+func TestCompileEppConfig_PrefixCacheAffinity(t *testing.T) {
+	// Default: prefix scorer injected with weight 1.0.
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{})
+	require.NotNil(t, findPlugin(t, conf, pluginNamePrefixScorer))
+	prefix := findProfilePlugin(t, conf, pluginNamePrefixScorer)
+	require.NotNil(t, prefix)
+	assert.Equal(t, 1.0, *prefix.Weight)
+
+	// Explicit false: not injected.
+	conf = CompileEppConfig("cluster-a", &EppConfigSimplified{
+		PrefixCacheAffinity: lib.PBool(false),
+	})
+	assert.Nil(t, findPlugin(t, conf, pluginNamePrefixScorer))
+	assert.Nil(t, findProfilePlugin(t, conf, pluginNamePrefixScorer))
+}
+
+func TestCompileEppConfig_SessionAffinity(t *testing.T) {
+	// Disabled by default: no session scorer.
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{})
+	assert.Nil(t, findPlugin(t, conf, pluginNameSessionScorer))
+	assert.Nil(t, findProfilePlugin(t, conf, pluginNameSessionScorer))
+
+	// Enabled: injected with header source and weight 1.0.
+	conf = CompileEppConfig("cluster-a", &EppConfigSimplified{
+		SessionAffinityEnabled: lib.PBool(true),
+		SessionAffinityHeader:  lib.PString("x-session-id"),
+	})
+	plugin := findPlugin(t, conf, pluginNameSessionScorer)
+	require.NotNil(t, plugin)
+	assert.Equal(t, pluginTypeSessionScorer, plugin.Type)
+	sessionIDConfig, ok := plugin.Parameters["sessionIdConfig"].(map[string]interface{})
+	require.True(t, ok)
+	sources, ok := sessionIDConfig["sources"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, sources, 1)
+	assert.Equal(t, "x-session-id", sources[0]["header"])
+
+	profilePlugin := findProfilePlugin(t, conf, pluginNameSessionScorer)
+	require.NotNil(t, profilePlugin)
+	assert.Equal(t, 1.0, *profilePlugin.Weight)
+}
+
+func TestCompileEppConfig_FixedPlugins(t *testing.T) {
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{})
+
+	discovery := findPlugin(t, conf, pluginNameDiscovery)
+	require.NotNil(t, discovery)
+	assert.Equal(t, pluginTypeDiscovery, discovery.Type)
+	assert.Equal(t, "cluster-a", discovery.Parameters["clusterName"])
+
+	utilFilter := findPlugin(t, conf, pluginNameUtilFilter)
+	require.NotNil(t, utilFilter)
+	assert.Equal(t, pluginTypeUtilFilter, utilFilter.Type)
+	conditions, ok := utilFilter.Parameters["conditions"].([]map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, conditions, 1)
+	assert.Equal(t, metricKVCacheUtilization, conditions[0]["metric"])
+	assert.Equal(t, DefaultKVCacheUtilizationMax, conditions[0]["maxValue"])
+
+	require.NotNil(t, findPlugin(t, conf, pluginNameKVScorer))
+	require.NotNil(t, findPlugin(t, conf, pluginNameQueueScorer))
+	require.NotNil(t, findPlugin(t, conf, pluginNameMaxScorePicker))
+	require.NotNil(t, findPlugin(t, conf, pluginNameOpenAIParser))
+
+	require.Equal(t, pluginNameDiscovery, conf.DataLayer.Discovery.Endpoints.PluginRef)
+	require.Len(t, conf.RequestHandler.Parsers, 1)
+	assert.Equal(t, pluginNameOpenAIParser, conf.RequestHandler.Parsers[0].PluginRef)
+
+	// No flow_control: no flowControl section, no feature gates.
+	assert.Nil(t, conf.FlowControl)
+	assert.Empty(t, conf.FeatureGates)
+
+	// Filter precedes scorers, picker is last.
+	plugins := conf.SchedulingProfiles[0].Plugins
+	require.Len(t, plugins, 5)
+	assert.Equal(t, pluginNameUtilFilter, plugins[0].PluginRef)
+	assert.Equal(t, pluginNameMaxScorePicker, plugins[len(plugins)-1].PluginRef)
+}
+
+func TestCompileEppConfig_UtilizationMaxOverride(t *testing.T) {
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{
+		KVCacheUtilizationMax: float64Ptr(0.5),
+	})
+	conditions := findPlugin(t, conf, pluginNameUtilFilter).Parameters["conditions"].([]map[string]interface{})
+	assert.Equal(t, 0.5, conditions[0]["maxValue"])
+}
+
+func TestCompileEppConfig_FlowControl(t *testing.T) {
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{
+		FlowControl: &FlowControlSimplified{
+			MaxRequests:        lib.PInt(1000),
+			QueueTTL:           lib.PInt(30),
+			NoEndpointQueueTTL: lib.PInt(600),
+			EnableEviction:     lib.PBool(true),
+		},
+	})
+
+	require.NotNil(t, conf.FlowControl)
+	assert.Equal(t, "1000", conf.FlowControl.MaxRequests)
+	assert.Equal(t, "30s", conf.FlowControl.DefaultRequestTTL)
+	assert.Equal(t, "10m0s", conf.FlowControl.NoEndpointRequestTTL)
+	assert.True(t, conf.FlowControl.EnableEviction)
+	assert.Equal(t, []string{featureGateFlowControl}, conf.FeatureGates)
+}
+
+func TestCompileEppConfig_FlowControlMaxRequestsOmitted(t *testing.T) {
+	// Unset: omitted.
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{
+		FlowControl: &FlowControlSimplified{QueueTTL: lib.PInt(30)},
+	})
+	assert.Empty(t, conf.FlowControl.MaxRequests)
+
+	// Explicit -1 (unlimited): omitted.
+	conf = CompileEppConfig("cluster-a", &EppConfigSimplified{
+		FlowControl: &FlowControlSimplified{MaxRequests: lib.PInt(-1)},
+	})
+	assert.Empty(t, conf.FlowControl.MaxRequests)
+}
+
+func TestCompileEppConfig_FlowControlZeroTTL(t *testing.T) {
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{
+		FlowControl: &FlowControlSimplified{QueueTTL: lib.PInt(0)},
+	})
+	assert.Equal(t, "0s", conf.FlowControl.DefaultRequestTTL)
+}
+
+func TestCompileEppConfig_FlowControlJSONShape(t *testing.T) {
+	// enableEviction carries omitempty (apix parity): false is omitted, true
+	// is emitted; maxRequests stays the string form of the apix
+	// resource.Quantity.
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{
+		FlowControl: &FlowControlSimplified{
+			MaxRequests: lib.PInt(1000),
+			QueueTTL:    lib.PInt(30),
+		},
+	})
+	bs, err := json.Marshal(conf.FlowControl)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"maxRequests":"1000","defaultRequestTTL":"30s"}`, string(bs))
+	assert.NotContains(t, string(bs), "enableEviction")
+	assert.NotContains(t, string(bs), "noEndpointRequestTTL")
+
+	conf = CompileEppConfig("cluster-a", &EppConfigSimplified{
+		FlowControl: &FlowControlSimplified{EnableEviction: lib.PBool(true)},
+	})
+	bs, err = json.Marshal(conf.FlowControl)
+	require.NoError(t, err)
+	assert.Contains(t, string(bs), `"enableEviction":true`)
+}
+
+func TestCompileEppConfig_WeightTagParity(t *testing.T) {
+	// apix SchedulingPlugin.Weight has no omitempty: the unweighted picker
+	// serializes as "weight": null, which the EPP strict decode accepts.
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{})
+	bs, err := json.Marshal(conf.SchedulingProfiles[0])
+	require.NoError(t, err)
+
+	var profile struct {
+		Plugins []struct {
+			PluginRef string   `json:"pluginRef"`
+			Weight    *float64 `json:"weight"`
+		} `json:"plugins"`
+	}
+	require.NoError(t, json.Unmarshal(bs, &profile))
+
+	weighted := map[string]bool{}
+	for _, p := range profile.Plugins {
+		if p.Weight != nil {
+			weighted[p.PluginRef] = true
+		}
+	}
+	assert.True(t, weighted[pluginNameKVScorer])
+	assert.True(t, weighted[pluginNameQueueScorer])
+	assert.False(t, weighted[pluginNameUtilFilter])
+	assert.False(t, weighted[pluginNameMaxScorePicker])
+}
+
+func TestCompileEppConfig_DeterministicJSON(t *testing.T) {
+	conf := CompileEppConfig("cluster-a", &EppConfigSimplified{
+		SchedulingProfile:      lib.PString(SchedulingProfileBalanced),
+		KVCacheUtilizationMax:  float64Ptr(0.9),
+		SessionAffinityEnabled: lib.PBool(true),
+		SessionAffinityHeader:  lib.PString("x-session-id"),
+		FlowControl: &FlowControlSimplified{
+			MaxRequests:        lib.PInt(1000),
+			QueueTTL:           lib.PInt(30),
+			NoEndpointQueueTTL: lib.PInt(600),
+		},
+	})
+
+	bs1, err := json.Marshal(conf)
+	require.NoError(t, err)
+	bs2, err := json.Marshal(CompileEppConfig("cluster-a", &EppConfigSimplified{
+		SchedulingProfile:      lib.PString(SchedulingProfileBalanced),
+		KVCacheUtilizationMax:  float64Ptr(0.9),
+		SessionAffinityEnabled: lib.PBool(true),
+		SessionAffinityHeader:  lib.PString("x-session-id"),
+		FlowControl: &FlowControlSimplified{
+			MaxRequests:        lib.PInt(1000),
+			QueueTTL:           lib.PInt(30),
+			NoEndpointQueueTTL: lib.PInt(600),
+		},
+	}))
+	require.NoError(t, err)
+	assert.JSONEq(t, string(bs1), string(bs2))
+
+	// The compiled JSON must decode back into the minimal struct set.
+	var roundtrip EndpointPickerConfig
+	require.NoError(t, json.Unmarshal(bs1, &roundtrip))
+	require.Len(t, roundtrip.SchedulingProfiles, 1)
+}
+
+func TestSecondsToDuration(t *testing.T) {
+	assert.Equal(t, "0s", secondsToDuration(0))
+	assert.Equal(t, "30s", secondsToDuration(30))
+	assert.Equal(t, "10m0s", secondsToDuration(600))
+	assert.Equal(t, "1h0m0s", secondsToDuration(3600))
+}

--- a/model/epp_pool/epp_config.go
+++ b/model/epp_pool/epp_config.go
@@ -1,0 +1,250 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"regexp"
+	"strings"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+)
+
+// Simplified epp_config field values and defaults (see api-changes.md §3.2.1).
+const (
+	SchedulingProfileLatencyFirst    = "latency-first"
+	SchedulingProfileBalanced        = "balanced"
+	SchedulingProfileThroughputFirst = "throughput-first"
+
+	CacheAffinityLow    = "low"
+	CacheAffinityMedium = "medium"
+	CacheAffinityHigh   = "high"
+
+	DefaultSchedulingProfile      = SchedulingProfileBalanced
+	DefaultPrefixCacheAffinity    = true
+	DefaultKVCacheUtilizationMax  = 0.9
+	DefaultSessionAffinityEnabled = false
+)
+
+// FlowControlUnlimited marks an explicit "no limit" max_requests.
+const FlowControlUnlimited = -1
+
+// EppConfigSimplified is the user-facing simplified shape of the per-cluster
+// EPP scheduling configuration stored in clusters.epp_config. All fields are
+// pointers so that "not set" (follow compiler defaults) is distinguishable
+// from an explicit value; unset fields are not persisted.
+type EppConfigSimplified struct {
+	SchedulingProfile      *string                `json:"scheduling_profile,omitempty"`
+	CacheAffinity          *string                `json:"cache_affinity,omitempty"`
+	PrefixCacheAffinity    *bool                  `json:"prefix_cache_affinity,omitempty"`
+	SessionAffinityEnabled *bool                  `json:"session_affinity_enabled,omitempty"`
+	SessionAffinityHeader  *string                `json:"session_affinity_header,omitempty"`
+	KVCacheUtilizationMax  *float64               `json:"kv_cache_utilization_max,omitempty"`
+	FlowControl            *FlowControlSimplified `json:"flow_control,omitempty"`
+}
+
+// FlowControlSimplified is the simplified flow-control section of epp_config.
+type FlowControlSimplified struct {
+	MaxRequests        *int  `json:"max_requests,omitempty"`
+	QueueTTL           *int  `json:"queue_ttl,omitempty"`
+	NoEndpointQueueTTL *int  `json:"no_endpoint_queue_ttl,omitempty"`
+	EnableEviction     *bool `json:"enable_eviction,omitempty"`
+}
+
+// ParseEppConfig decodes the raw stored JSON of epp_config with strict field
+// checking. Empty input returns nil (no config).
+func ParseEppConfig(raw string) (*EppConfigSimplified, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	decoder.DisallowUnknownFields()
+
+	conf := &EppConfigSimplified{}
+	if err := decoder.Decode(conf); err != nil {
+		return nil, xerror.WrapParamErrorWithMsg("epp_config is invalid: %s", err.Error())
+	}
+
+	return conf, nil
+}
+
+// IsEmpty reports whether no field of the simplified config is set (an empty
+// JSON object {} decodes to an all-nil struct).
+func (c *EppConfigSimplified) IsEmpty() bool {
+	return c == nil ||
+		(c.SchedulingProfile == nil &&
+			c.CacheAffinity == nil &&
+			c.PrefixCacheAffinity == nil &&
+			c.SessionAffinityEnabled == nil &&
+			c.SessionAffinityHeader == nil &&
+			c.KVCacheUtilizationMax == nil &&
+			c.FlowControl == nil)
+}
+
+// Validate checks all field-level rules of the simplified epp_config. It is
+// enforced whenever epp_config is non-empty, regardless of balance_mode.
+func (c *EppConfigSimplified) Validate() error {
+	if c == nil {
+		return nil
+	}
+
+	if c.SchedulingProfile != nil {
+		switch *c.SchedulingProfile {
+		case SchedulingProfileLatencyFirst, SchedulingProfileBalanced, SchedulingProfileThroughputFirst:
+		default:
+			return xerror.WrapParamErrorWithMsg("epp_config.scheduling_profile must be one of %q/%q/%q, got %q",
+				SchedulingProfileLatencyFirst, SchedulingProfileBalanced, SchedulingProfileThroughputFirst, *c.SchedulingProfile)
+		}
+	}
+
+	if c.CacheAffinity != nil {
+		switch *c.CacheAffinity {
+		case CacheAffinityLow, CacheAffinityMedium, CacheAffinityHigh:
+		default:
+			return xerror.WrapParamErrorWithMsg("epp_config.cache_affinity must be one of %q/%q/%q, got %q",
+				CacheAffinityLow, CacheAffinityMedium, CacheAffinityHigh, *c.CacheAffinity)
+		}
+	}
+
+	if c.KVCacheUtilizationMax != nil {
+		if *c.KVCacheUtilizationMax <= 0 || *c.KVCacheUtilizationMax > 1 {
+			return xerror.WrapParamErrorWithMsg("epp_config.kv_cache_utilization_max must be in (0, 1], got %v", *c.KVCacheUtilizationMax)
+		}
+	}
+
+	if c.SessionAffinityEnabled != nil && *c.SessionAffinityEnabled {
+		if c.SessionAffinityHeader == nil || strings.TrimSpace(*c.SessionAffinityHeader) == "" {
+			return xerror.WrapParamErrorWithMsg("epp_config.session_affinity_header is required when session_affinity_enabled is true")
+		}
+	}
+
+	if c.SessionAffinityHeader != nil {
+		if err := validateHeaderName(*c.SessionAffinityHeader); err != nil {
+			return xerror.WrapParamErrorWithMsg("epp_config.session_affinity_header: %s", err.Error())
+		}
+	}
+
+	if c.FlowControl != nil {
+		if err := c.FlowControl.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Validate checks the flow_control section.
+func (f *FlowControlSimplified) Validate() error {
+	if f == nil {
+		return nil
+	}
+
+	if f.MaxRequests != nil && *f.MaxRequests != FlowControlUnlimited && *f.MaxRequests <= 0 {
+		return xerror.WrapParamErrorWithMsg("epp_config.flow_control.max_requests must be > 0 or -1, got %d", *f.MaxRequests)
+	}
+
+	if f.QueueTTL != nil && *f.QueueTTL < 0 {
+		return xerror.WrapParamErrorWithMsg("epp_config.flow_control.queue_ttl must be >= 0, got %d", *f.QueueTTL)
+	}
+
+	if f.NoEndpointQueueTTL != nil && *f.NoEndpointQueueTTL < 0 {
+		return xerror.WrapParamErrorWithMsg("epp_config.flow_control.no_endpoint_queue_ttl must be >= 0, got %d", *f.NoEndpointQueueTTL)
+	}
+
+	return nil
+}
+
+// EffectiveSchedulingProfile returns the profile value with default applied.
+func (c *EppConfigSimplified) EffectiveSchedulingProfile() string {
+	if c == nil || c.SchedulingProfile == nil {
+		return DefaultSchedulingProfile
+	}
+	return *c.SchedulingProfile
+}
+
+// EffectivePrefixCacheAffinity returns the prefix cache affinity switch with default applied.
+func (c *EppConfigSimplified) EffectivePrefixCacheAffinity() bool {
+	if c == nil || c.PrefixCacheAffinity == nil {
+		return DefaultPrefixCacheAffinity
+	}
+	return *c.PrefixCacheAffinity
+}
+
+// EffectiveKVCacheUtilizationMax returns the utilization filter threshold with default applied.
+func (c *EppConfigSimplified) EffectiveKVCacheUtilizationMax() float64 {
+	if c == nil || c.KVCacheUtilizationMax == nil {
+		return DefaultKVCacheUtilizationMax
+	}
+	return *c.KVCacheUtilizationMax
+}
+
+// EffectiveSessionAffinityEnabled returns the session affinity switch with default applied.
+func (c *EppConfigSimplified) EffectiveSessionAffinityEnabled() bool {
+	if c == nil || c.SessionAffinityEnabled == nil {
+		return DefaultSessionAffinityEnabled
+	}
+	return *c.SessionAffinityEnabled
+}
+
+var (
+	// hostnameLabel matches a single DNS label (RFC 1123) with length 1-63.
+	hostnameLabel = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
+	// httpHeaderNameToken matches valid HTTP header name characters (RFC 7230 token).
+	httpHeaderNameToken = regexp.MustCompile(`^[!#$%&'*+\-.^_` + "`" + `|~0-9A-Za-z]+$`)
+)
+
+// validateHost checks that host is a hostname or an IP literal (IPv6 without
+// brackets). Implemented locally (instead of lib/validate) to avoid an
+// import cycle with the cluster model in later wiring.
+func validateHost(host string) error {
+	if host == "" {
+		return xerror.WrapParamErrorWithMsg("host is required")
+	}
+	if len(host) > 255 {
+		return xerror.WrapParamErrorWithMsg("host length must be <= 255")
+	}
+	if net.ParseIP(host) != nil {
+		return nil
+	}
+	labels := strings.Split(host, ".")
+	for _, label := range labels {
+		if !hostnameLabel.MatchString(label) {
+			return xerror.WrapParamErrorWithMsg("host %q contains invalid label %q", host, label)
+		}
+	}
+	return nil
+}
+
+// validatePort checks a TCP port number.
+func validatePort(port int) error {
+	if port < 1 || port > 65535 {
+		return xerror.WrapParamErrorWithMsg("port must be between 1 and 65535, got %d", port)
+	}
+	return nil
+}
+
+// validateHeaderName checks a non-empty HTTP header name.
+func validateHeaderName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return xerror.WrapParamErrorWithMsg("header name is required")
+	}
+	if !httpHeaderNameToken.MatchString(name) {
+		return xerror.WrapParamErrorWithMsg("invalid HTTP header name %q", name)
+	}
+	return nil
+}

--- a/model/epp_pool/epp_config_test.go
+++ b/model/epp_pool/epp_config_test.go
@@ -1,0 +1,191 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEppConfig(t *testing.T) {
+	t.Run("empty returns nil", func(t *testing.T) {
+		conf, err := ParseEppConfig("")
+		require.NoError(t, err)
+		assert.Nil(t, conf)
+	})
+
+	t.Run("full fields", func(t *testing.T) {
+		conf, err := ParseEppConfig(`{
+			"scheduling_profile": "balanced",
+			"cache_affinity": "high",
+			"prefix_cache_affinity": false,
+			"session_affinity_enabled": true,
+			"session_affinity_header": "x-session-id",
+			"kv_cache_utilization_max": 0.8,
+			"flow_control": {"max_requests": 100, "queue_ttl": 30}
+		}`)
+		require.NoError(t, err)
+		require.NotNil(t, conf)
+		assert.Equal(t, SchedulingProfileBalanced, *conf.SchedulingProfile)
+		assert.Equal(t, CacheAffinityHigh, *conf.CacheAffinity)
+		require.NotNil(t, conf.PrefixCacheAffinity)
+		assert.False(t, *conf.PrefixCacheAffinity)
+		require.NotNil(t, conf.SessionAffinityEnabled)
+		assert.True(t, *conf.SessionAffinityEnabled)
+		assert.Equal(t, "x-session-id", *conf.SessionAffinityHeader)
+		require.NotNil(t, conf.KVCacheUtilizationMax)
+		assert.Equal(t, 0.8, *conf.KVCacheUtilizationMax)
+		require.NotNil(t, conf.FlowControl)
+		assert.Equal(t, 100, *conf.FlowControl.MaxRequests)
+		assert.Equal(t, 30, *conf.FlowControl.QueueTTL)
+	})
+
+	t.Run("unknown field rejected", func(t *testing.T) {
+		_, err := ParseEppConfig(`{"unknown_field": true}`)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid json rejected", func(t *testing.T) {
+		_, err := ParseEppConfig(`{`)
+		require.Error(t, err)
+	})
+}
+
+func TestEppConfigSimplified_Validate(t *testing.T) {
+	t.Run("nil is valid", func(t *testing.T) {
+		var conf *EppConfigSimplified
+		require.NoError(t, conf.Validate())
+	})
+
+	t.Run("valid full config", func(t *testing.T) {
+		conf := &EppConfigSimplified{
+			SchedulingProfile:      lib.PString(SchedulingProfileLatencyFirst),
+			CacheAffinity:          lib.PString(CacheAffinityLow),
+			PrefixCacheAffinity:    lib.PBool(true),
+			SessionAffinityEnabled: lib.PBool(true),
+			SessionAffinityHeader:  lib.PString("x-session-id"),
+			KVCacheUtilizationMax:  float64Ptr(0.9),
+			FlowControl: &FlowControlSimplified{
+				MaxRequests:        lib.PInt(100),
+				QueueTTL:           lib.PInt(0),
+				NoEndpointQueueTTL: lib.PInt(600),
+				EnableEviction:     lib.PBool(false),
+			},
+		}
+		require.NoError(t, conf.Validate())
+	})
+
+	t.Run("scheduling_profile enum", func(t *testing.T) {
+		conf := &EppConfigSimplified{SchedulingProfile: lib.PString("bogus")}
+		require.Error(t, conf.Validate())
+	})
+
+	t.Run("cache_affinity enum", func(t *testing.T) {
+		conf := &EppConfigSimplified{CacheAffinity: lib.PString("bogus")}
+		require.Error(t, conf.Validate())
+	})
+
+	t.Run("kv_cache_utilization_max range", func(t *testing.T) {
+		conf := &EppConfigSimplified{KVCacheUtilizationMax: float64Ptr(0)}
+		require.Error(t, conf.Validate())
+
+		conf = &EppConfigSimplified{KVCacheUtilizationMax: float64Ptr(1.01)}
+		require.Error(t, conf.Validate())
+
+		conf = &EppConfigSimplified{KVCacheUtilizationMax: float64Ptr(1)}
+		require.NoError(t, conf.Validate())
+	})
+
+	t.Run("session header required when enabled", func(t *testing.T) {
+		conf := &EppConfigSimplified{SessionAffinityEnabled: lib.PBool(true)}
+		require.Error(t, conf.Validate())
+
+		conf = &EppConfigSimplified{SessionAffinityEnabled: lib.PBool(true), SessionAffinityHeader: lib.PString("")}
+		require.Error(t, conf.Validate())
+
+		conf = &EppConfigSimplified{SessionAffinityEnabled: lib.PBool(true), SessionAffinityHeader: lib.PString("x-session-id")}
+		require.NoError(t, conf.Validate())
+	})
+
+	t.Run("session header format checked when disabled", func(t *testing.T) {
+		conf := &EppConfigSimplified{SessionAffinityHeader: lib.PString("bad header")}
+		require.Error(t, conf.Validate())
+
+		conf = &EppConfigSimplified{SessionAffinityHeader: lib.PString("x-session-id")}
+		require.NoError(t, conf.Validate())
+	})
+
+	t.Run("flow_control max_requests", func(t *testing.T) {
+		conf := &EppConfigSimplified{FlowControl: &FlowControlSimplified{MaxRequests: lib.PInt(0)}}
+		require.Error(t, conf.Validate())
+
+		conf = &EppConfigSimplified{FlowControl: &FlowControlSimplified{MaxRequests: lib.PInt(-1)}}
+		require.NoError(t, conf.Validate())
+
+		conf = &EppConfigSimplified{FlowControl: &FlowControlSimplified{MaxRequests: lib.PInt(1)}}
+		require.NoError(t, conf.Validate())
+	})
+
+	t.Run("flow_control ttl", func(t *testing.T) {
+		conf := &EppConfigSimplified{FlowControl: &FlowControlSimplified{QueueTTL: lib.PInt(-1)}}
+		require.Error(t, conf.Validate())
+
+		conf = &EppConfigSimplified{FlowControl: &FlowControlSimplified{NoEndpointQueueTTL: lib.PInt(-1)}}
+		require.Error(t, conf.Validate())
+
+		conf = &EppConfigSimplified{FlowControl: &FlowControlSimplified{QueueTTL: lib.PInt(0)}}
+		require.NoError(t, conf.Validate())
+	})
+}
+
+func TestValidateHost(t *testing.T) {
+	valid := []string{"10.0.0.1", "epp-0", "epp-0.epp-headless", "2001:db8::1", "a.b-c.d"}
+	for _, host := range valid {
+		require.NoError(t, validateHost(host), host)
+	}
+
+	invalid := []string{"", "-bad", "bad..host", "2001:db8::1]", "a" + string(make([]byte, 300))}
+	for _, host := range invalid {
+		require.Error(t, validateHost(host), host)
+	}
+}
+
+func TestValidatePort(t *testing.T) {
+	require.NoError(t, validatePort(1))
+	require.NoError(t, validatePort(65535))
+	require.Error(t, validatePort(0))
+	require.Error(t, validatePort(65536))
+}
+
+func TestEppConfigSimplified_IsEmpty(t *testing.T) {
+	assert.True(t, (*EppConfigSimplified)(nil).IsEmpty())
+	assert.True(t, (&EppConfigSimplified{}).IsEmpty())
+
+	conf, err := ParseEppConfig(`{}`)
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+	assert.True(t, conf.IsEmpty())
+
+	conf, err = ParseEppConfig(`{"scheduling_profile":"balanced"}`)
+	require.NoError(t, err)
+	assert.False(t, conf.IsEmpty())
+
+	conf, err = ParseEppConfig(`{"flow_control":{"enable_eviction":true}}`)
+	require.NoError(t, err)
+	assert.False(t, conf.IsEmpty())
+}

--- a/model/epp_pool/epp_data.go
+++ b/model/epp_pool/epp_data.go
@@ -1,0 +1,156 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iversion_control"
+)
+
+// ConfigTopicEppData is the version-controlled config topic of the merged
+// epp_data export (epp_config + assignment, see design-changes.md §3).
+const ConfigTopicEppData = "epp_data"
+
+// AssignmentEntry is one cluster entry of the exported assignment section.
+type AssignmentEntry struct {
+	Primary string  `json:"primary"`
+	Standby *string `json:"standby"`
+}
+
+// EppDataConfig is the Config body of the epp_data export.
+type EppDataConfig struct {
+	EppConfig  map[string]*EndpointPickerConfig `json:"epp_config"`
+	Assignment map[string]*AssignmentEntry      `json:"assignment"`
+}
+
+// ExportEppDataConfig is the versioned epp_data export payload.
+type ExportEppDataConfig struct {
+	Version string         `json:"Version"`
+	Config  *EppDataConfig `json:"Config"`
+}
+
+// UpdateVersion implements iversion_control.VersionValuable.
+func (c *ExportEppDataConfig) UpdateVersion(version string) error {
+	c.Version = version
+	return nil
+}
+
+// EppDataGenerator generates the merged epp_data export (design-changes.md §3):
+// the epp_config section compiles every EPP-mode cluster's simplified
+// epp_config into an EndpointPickerConfig, and the assignment section is the
+// full read-time-join view restricted to validly assigned EPP clusters.
+func (m *EppPoolManager) EppDataGenerator(ctx context.Context) (*iversion_control.ExportData, error) {
+	if m.clusterSource == nil {
+		return nil, fmt.Errorf("epp pool: cluster source is not configured")
+	}
+
+	eppClusters, err := m.clusterSource.FetchEPPClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	instances, err := m.storager.FetchInstanceList(ctx, &InstanceFilter{})
+	if err != nil {
+		return nil, err
+	}
+	pool := buildPool(m.poolName, instances)
+
+	assignments, err := m.storager.FetchAssignmentList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	conf := &EppDataConfig{
+		EppConfig:  map[string]*EndpointPickerConfig{},
+		Assignment: map[string]*AssignmentEntry{},
+	}
+
+	for _, cluster := range eppClusters {
+		simplified, err := ParseEppConfig(cluster.EppConfigJSON)
+		if err != nil {
+			return nil, fmt.Errorf("epp pool: parse epp_config of cluster %q error: %s", cluster.Name, err.Error())
+		}
+		if simplified == nil {
+			return nil, fmt.Errorf("epp pool: cluster %q is in EPP mode but has no epp_config", cluster.Name)
+		}
+		conf.EppConfig[cluster.Name] = CompileEppConfig(cluster.Name, simplified)
+	}
+
+	view := buildAssignmentsView(pool, eppClusters, assignments)
+	for _, entry := range view.Clusters {
+		if entry.Primary == nil {
+			// Unassigned or degraded: no assignment entry (EPP side alarms locally).
+			continue
+		}
+
+		assignmentEntry := &AssignmentEntry{Primary: entry.Primary.ID}
+		if entry.Standby != nil {
+			standbyID := entry.Standby.ID
+			assignmentEntry.Standby = &standbyID
+		}
+		conf.Assignment[entry.Cluster] = assignmentEntry
+	}
+
+	rst := &ExportEppDataConfig{Config: conf}
+	rst.UpdateVersion(iversion_control.ZeroVersion)
+
+	return &iversion_control.ExportData{
+		Topic:              ConfigTopicEppData,
+		DataWithoutVersion: rst,
+	}, nil
+}
+
+// ExportEppData exports the epp_data config via the version-control framework:
+// a new version is published only when the content changed, otherwise the last
+// version is returned with a nil payload marker (Data: null semantics).
+func (m *EppPoolManager) ExportEppData(ctx context.Context, lastVersion string) (*ExportEppDataConfig, error) {
+	if m.versionControlManager == nil {
+		return nil, fmt.Errorf("epp pool: version control manager is not configured")
+	}
+
+	rst, err := m.versionControlManager.ExportConfig(ctx, ConfigTopicEppData, m.EppDataGenerator)
+	if err != nil {
+		return nil, err
+	}
+
+	if rst.DataWithoutVersion == nil {
+		return nil, fmt.Errorf("epp pool: EppDataGenerator.DataWithoutVersion is nil")
+	}
+
+	conf, ok := rst.DataWithoutVersion.(*ExportEppDataConfig)
+	if !ok {
+		return nil, fmt.Errorf("epp pool: convert EppDataGenerator.DataWithoutVersion to ExportEppDataConfig is error")
+	}
+
+	if conf.Version == lastVersion {
+		return nil, nil
+	}
+
+	return conf, nil
+}
+
+// triggerEppDataExport eagerly publishes a new epp_data version when the
+// version-control manager is configured. Errors are logged, not propagated.
+func (m *EppPoolManager) triggerEppDataExport(ctx context.Context) {
+	if m.versionControlManager == nil {
+		return
+	}
+
+	if _, err := m.ExportEppData(ctx, ""); err != nil {
+		eppLogError("failed to export epp_data: %v", err)
+	}
+}

--- a/model/epp_pool/epp_data_test.go
+++ b/model/epp_pool/epp_data_test.go
@@ -1,0 +1,225 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iversion_control"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEppDataGenerator(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	store.seedInstances(
+		inst("epp-a", "g1", "10.0.0.1", 9002),
+		inst("epp-b", "g1", "10.0.0.2", 9002),
+	)
+	source := &fakeClusterSource{clusters: []*EPPClusterInfo{
+		{Name: "cluster-a", EppConfigJSON: `{"scheduling_profile":"balanced","kv_cache_utilization_max":0.9}`},
+		{Name: "cluster-b", EppConfigJSON: `{"scheduling_profile":"latency-first"}`},
+		{Name: "cluster-c", EppConfigJSON: `{"prefix_cache_affinity":true}`},
+	}}
+	store.seedAssignments(
+		&AssignmentParam{Cluster: "cluster-a", GroupName: "g1", PrimaryInstanceID: "epp-a"},
+		// Dangling: cluster-b unassigned in the export.
+		&AssignmentParam{Cluster: "cluster-b", GroupName: "g9", PrimaryInstanceID: "epp-x"},
+	)
+
+	m := testManager(store, source)
+
+	exportData, err := m.EppDataGenerator(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, ConfigTopicEppData, exportData.Topic)
+
+	conf, ok := exportData.DataWithoutVersion.(*ExportEppDataConfig)
+	require.True(t, ok)
+
+	// epp_config section: every EPP cluster compiled.
+	require.Len(t, conf.Config.EppConfig, 3)
+	compiledA := conf.Config.EppConfig["cluster-a"]
+	require.NotNil(t, compiledA)
+	assert.Equal(t, "cluster-a", compiledA.Plugins[0].Parameters["clusterName"])
+	compiledB := conf.Config.EppConfig["cluster-b"]
+	require.NotNil(t, compiledB)
+	require.NotNil(t, findProfilePlugin(t, compiledB, pluginNameQueueScorer))
+	assert.Equal(t, 1.0, *findProfilePlugin(t, compiledB, pluginNameQueueScorer).Weight)
+
+	// assignment section: only validly assigned clusters.
+	require.Len(t, conf.Config.Assignment, 1)
+	entry := conf.Config.Assignment["cluster-a"]
+	require.NotNil(t, entry)
+	assert.Equal(t, "epp-a", entry.Primary)
+	require.NotNil(t, entry.Standby)
+	assert.Equal(t, "epp-b", *entry.Standby)
+	_, hasB := conf.Config.Assignment["cluster-b"]
+	assert.False(t, hasB)
+
+	// The whole payload marshals to JSON for the InnerAPI response.
+	_, err = json.Marshal(conf)
+	require.NoError(t, err)
+}
+
+func TestEppDataGenerator_SingleInstanceStandbyNull(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	store.seedInstances(inst("epp-a", "g1", "10.0.0.1", 9002))
+	source := &fakeClusterSource{clusters: []*EPPClusterInfo{
+		{Name: "cluster-a", EppConfigJSON: `{}`},
+	}}
+	store.seedAssignments(&AssignmentParam{Cluster: "cluster-a", GroupName: "g1", PrimaryInstanceID: "epp-a"})
+
+	m := NewEppPoolManager(&fakeTxn{}, store, source, nil, &ManagerOptions{ValidationMode: ValidationModeTest})
+
+	exportData, err := m.EppDataGenerator(ctx)
+	require.NoError(t, err)
+	conf := exportData.DataWithoutVersion.(*ExportEppDataConfig)
+
+	entry := conf.Config.Assignment["cluster-a"]
+	require.NotNil(t, entry)
+	assert.Equal(t, "epp-a", entry.Primary)
+	assert.Nil(t, entry.Standby)
+}
+
+func TestEppDataGenerator_Errors(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil cluster source", func(t *testing.T) {
+		m := testManager(newMemoryEppPoolStorager(), nil)
+		_, err := m.EppDataGenerator(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("cluster without epp_config", func(t *testing.T) {
+		source := &fakeClusterSource{clusters: []*EPPClusterInfo{{Name: "cluster-a"}}}
+		m := testManager(newMemoryEppPoolStorager(), source)
+		_, err := m.EppDataGenerator(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid stored epp_config", func(t *testing.T) {
+		source := &fakeClusterSource{clusters: []*EPPClusterInfo{{Name: "cluster-a", EppConfigJSON: `{"scheduling_profile":"nope"}`}}}
+		m := testManager(newMemoryEppPoolStorager(), source)
+		_, err := m.EppDataGenerator(ctx)
+		require.NoError(t, err) // parse ok; field validation happens at write time
+	})
+}
+
+func TestExportEppData_VersionSemantics(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	store.seedInstances(
+		inst("epp-a", "g1", "10.0.0.1", 9002),
+		inst("epp-b", "g1", "10.0.0.2", 9002),
+	)
+	source := &fakeClusterSource{clusters: []*EPPClusterInfo{
+		{Name: "cluster-a", EppConfigJSON: `{"scheduling_profile":"balanced"}`},
+	}}
+	store.seedAssignments(&AssignmentParam{Cluster: "cluster-a", GroupName: "g1", PrimaryInstanceID: "epp-a"})
+
+	vcStore := &fakeVersionControlStorager{}
+	vc := iversion_control.NewVersionControllerManager(&fakeTxn{}, vcStore)
+	m := NewEppPoolManager(&fakeTxn{}, store, source, vc, &ManagerOptions{})
+
+	t.Run("new version returned", func(t *testing.T) {
+		conf, err := m.ExportEppData(ctx, iversion_control.ZeroVersion)
+		require.NoError(t, err)
+		require.NotNil(t, conf)
+		assert.Equal(t, "20260906120000", conf.Version)
+		require.NotNil(t, conf.Config)
+		assert.Contains(t, conf.Config.EppConfig, "cluster-a")
+	})
+
+	t.Run("unchanged version returns nil", func(t *testing.T) {
+		conf, err := m.ExportEppData(ctx, "20260906120000")
+		require.NoError(t, err)
+		assert.Nil(t, conf)
+	})
+
+	t.Run("nil version control manager", func(t *testing.T) {
+		m := testManager(store, source)
+		_, err := m.ExportEppData(ctx, "")
+		require.Error(t, err)
+	})
+}
+
+func TestOverrideAssignment_TriggersExport(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	store.seedInstances(
+		inst("epp-a", "g1", "10.0.0.1", 9002),
+		inst("epp-b", "g1", "10.0.0.2", 9002),
+	)
+	source := &fakeClusterSource{clusters: []*EPPClusterInfo{
+		{Name: "cluster-a", EppConfigJSON: `{"scheduling_profile":"balanced"}`},
+	}}
+
+	var exported []*iversion_control.ExportData
+	vcStore := &fakeVersionControlStorager{
+		upsertFn: func(ctx context.Context, css *iversion_control.ExportData) (string, error) {
+			exported = append(exported, css)
+			return "20260906120001", nil
+		},
+	}
+	vc := iversion_control.NewVersionControllerManager(&fakeTxn{}, vcStore)
+	m := NewEppPoolManager(&fakeTxn{}, store, source, vc, &ManagerOptions{})
+
+	_, err := m.OverrideAssignment(ctx, "cluster-a", "g1", "epp-b")
+	require.NoError(t, err)
+	require.NotEmpty(t, exported)
+	assert.Equal(t, ConfigTopicEppData, exported[0].Topic)
+}
+
+func TestEppDataGenerator_ClusterSourceError(t *testing.T) {
+	m := testManager(newMemoryEppPoolStorager(), &fakeClusterSource{err: errors.New("boom")})
+	_, err := m.EppDataGenerator(context.Background())
+	require.Error(t, err)
+}
+
+func TestCompileIntegration_FromStoredJSON(t *testing.T) {
+	// End-to-end: stored raw JSON -> parse -> validate -> compile -> marshal.
+	raw := `{
+		"scheduling_profile": "throughput-first",
+		"cache_affinity": "high",
+		"session_affinity_enabled": true,
+		"session_affinity_header": "x-session-id",
+		"kv_cache_utilization_max": 0.85,
+		"flow_control": {"max_requests": -1, "queue_ttl": 45, "no_endpoint_queue_ttl": 0, "enable_eviction": true}
+	}`
+	conf, err := ParseEppConfig(raw)
+	require.NoError(t, err)
+	require.NoError(t, conf.Validate())
+
+	compiled := CompileEppConfig("llm-cluster-a", conf)
+	bs, err := json.Marshal(compiled)
+	require.NoError(t, err)
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(bs, &decoded))
+
+	assert.Equal(t, []interface{}{featureGateFlowControl}, decoded["featureGates"])
+	flowControl := decoded["flowControl"].(map[string]interface{})
+	assert.NotContains(t, flowControl, "maxRequests") // -1 not generated
+	assert.Equal(t, "45s", flowControl["defaultRequestTTL"])
+	assert.Equal(t, "0s", flowControl["noEndpointRequestTTL"])
+	assert.Equal(t, true, flowControl["enableEviction"])
+
+	assert.Equal(t, "llm-cluster-a", decoded["plugins"].([]interface{})[0].(map[string]interface{})["parameters"].(map[string]interface{})["clusterName"])
+}

--- a/model/epp_pool/epp_pool.go
+++ b/model/epp_pool/epp_pool.go
@@ -1,0 +1,371 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+// Package epp_pool implements the EPP instance pool, the cluster to
+// instance-group assignment model and the epp_data export generator.
+// See design-docs/modifications/2026-09-08-epp-scheduling-integration/.
+package epp_pool
+
+import (
+	"context"
+	"net"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/itxn"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iversion_control"
+)
+
+const (
+	// DefaultEPPInstancePoolName is the default singleton pool name used when
+	// the deployment does not configure one (see RunTime.DefaultEPPInstancePoolName).
+	DefaultEPPInstancePoolName = "EPP.pool"
+
+	// DefaultReconcileInterval is the default period of the assignment reconciler.
+	DefaultReconcileInterval = 30 * time.Second
+)
+
+// Validation modes controlling the instance group size check.
+const (
+	// ValidationModeProduction requires every group to hold exactly 2 instances.
+	ValidationModeProduction = "production"
+	// ValidationModeTest allows single instance groups (primary only, no standby).
+	ValidationModeTest = "test"
+)
+
+// InstanceParam describes one EPP instance of the pool.
+type InstanceParam struct {
+	ID   string `json:"id"`
+	Host string `json:"host"`
+	Port int    `json:"port"`
+	// GroupName is an internal storage detail; it never appears in the
+	// serialized API views of /epp-pool and /epp-assignments.
+	GroupName string `json:"-"`
+}
+
+// InstanceFilter filters instance queries.
+type InstanceFilter struct {
+	ID        *string
+	GroupName *string
+}
+
+// InstanceGroup is a named group of EPP instances (primary/standby unit).
+type InstanceGroup struct {
+	Name      string           `json:"name"`
+	Instances []*InstanceParam `json:"instances"`
+}
+
+// EppPool is the singleton EPP instance pool.
+type EppPool struct {
+	Name   string           `json:"name"`
+	Groups []*InstanceGroup `json:"groups"`
+}
+
+// AssignmentParam is one cluster to instance-group assignment (primary only;
+// standby is expanded at read time from the instances of the same group).
+type AssignmentParam struct {
+	Cluster           string `json:"cluster"`
+	GroupName         string `json:"group_name"`
+	PrimaryInstanceID string `json:"primary_instance_id"`
+}
+
+// EPPClusterInfo describes one cluster whose balance_mode is EPP, as seen by
+// the epp_pool domain. EppConfigJSON is the raw simplified epp_config stored
+// in clusters.epp_config (empty string if not set).
+type EPPClusterInfo struct {
+	Name          string
+	EppConfigJSON string
+}
+
+// EPPClusterSource provides the EPP-mode clusters. It is implemented by the
+// cluster model (icluster_conf) and injected at wiring time.
+type EPPClusterSource interface {
+	// FetchEPPClusters returns all clusters with balance_mode=EPP.
+	FetchEPPClusters(ctx context.Context) ([]*EPPClusterInfo, error)
+}
+
+// EppPoolStorager defines the persistence operations of the EPP instance pool
+// and the cluster assignments.
+type EppPoolStorager interface {
+	// FetchInstanceList returns all instances matching the filter.
+	FetchInstanceList(ctx context.Context, filter *InstanceFilter) ([]*InstanceParam, error)
+	// CreateInstances batch creates instances.
+	CreateInstances(ctx context.Context, params []*InstanceParam) (int64, error)
+	// DeleteInstances deletes instances matching the filter.
+	DeleteInstances(ctx context.Context, filter *InstanceFilter) (int64, error)
+
+	// FetchAssignment returns the assignment of one cluster, nil if absent.
+	FetchAssignment(ctx context.Context, cluster string) (*AssignmentParam, error)
+	// FetchAssignmentList returns all assignments.
+	FetchAssignmentList(ctx context.Context) ([]*AssignmentParam, error)
+	// UpsertAssignment inserts or replaces the assignment of one cluster.
+	UpsertAssignment(ctx context.Context, param *AssignmentParam) error
+	// DeleteAssignment deletes the assignment of one cluster.
+	DeleteAssignment(ctx context.Context, cluster string) error
+}
+
+// ManagerOptions carries deployment-shape tunables of EppPoolManager.
+type ManagerOptions struct {
+	// PoolName is the singleton pool name, default DefaultEPPInstancePoolName.
+	PoolName string
+	// ValidationMode is ValidationModeProduction (default) or ValidationModeTest.
+	ValidationMode string
+	// ReconcileInterval is the period of the assignment reconciler,
+	// default DefaultReconcileInterval.
+	ReconcileInterval time.Duration
+}
+
+func (o *ManagerOptions) withDefaults() {
+	if o.PoolName == "" {
+		o.PoolName = DefaultEPPInstancePoolName
+	}
+	if o.ValidationMode == "" {
+		o.ValidationMode = ValidationModeProduction
+	}
+	if o.ReconcileInterval <= 0 {
+		o.ReconcileInterval = DefaultReconcileInterval
+	}
+}
+
+// EppPoolManager manages the EPP instance pool, the cluster assignments and
+// the epp_data export.
+type EppPoolManager struct {
+	txn                   itxn.TxnStorager
+	storager              EppPoolStorager
+	clusterSource         EPPClusterSource
+	versionControlManager *iversion_control.VersionControlManager
+
+	poolName          string
+	validationMode    string
+	reconcileInterval time.Duration
+
+	reconciler *EppReconciler
+}
+
+// NewEppPoolManager creates the manager. clusterSource may be nil: assignment
+// listing/allocation that needs the EPP cluster list is skipped in that case.
+// versionControlManager may be nil: epp_data export triggering is skipped then.
+func NewEppPoolManager(
+	txn itxn.TxnStorager,
+	storager EppPoolStorager,
+	clusterSource EPPClusterSource,
+	versionControlManager *iversion_control.VersionControlManager,
+	options *ManagerOptions,
+) *EppPoolManager {
+	opts := ManagerOptions{}
+	if options != nil {
+		opts = *options
+	}
+	opts.withDefaults()
+
+	m := &EppPoolManager{
+		txn:                   txn,
+		storager:              storager,
+		clusterSource:         clusterSource,
+		versionControlManager: versionControlManager,
+		poolName:              opts.PoolName,
+		validationMode:        opts.ValidationMode,
+		reconcileInterval:     opts.ReconcileInterval,
+	}
+	m.reconciler = NewEppReconciler(m.reconcileInterval, m.Reconcile)
+
+	return m
+}
+
+// PoolName returns the configured singleton pool name.
+func (m *EppPoolManager) PoolName() string {
+	return m.poolName
+}
+
+// StartReconciler starts the periodic assignment reconciler.
+func (m *EppPoolManager) StartReconciler() {
+	m.reconciler.Start()
+}
+
+// StopReconciler stops the periodic assignment reconciler.
+func (m *EppPoolManager) StopReconciler() {
+	m.reconciler.Stop()
+}
+
+// ReconcileInterval returns the configured reconciler period.
+func (m *EppPoolManager) ReconcileInterval() time.Duration {
+	return m.reconcileInterval
+}
+
+// GetPool returns the full instance pool (all groups with their instances).
+// Per epp-pool.md §2.1 the pool is a singleton created by the first PATCH:
+// when no instance has ever been registered the pool does not exist and a
+// record-not-exist error is returned (404 semantics at the API layer).
+func (m *EppPoolManager) GetPool(ctx context.Context) (*EppPool, error) {
+	instances, err := m.storager.FetchInstanceList(ctx, &InstanceFilter{})
+	if err != nil {
+		return nil, err
+	}
+	if len(instances) == 0 {
+		return nil, xerror.WrapRecordNotExist("epp pool")
+	}
+
+	return buildPool(m.poolName, instances), nil
+}
+
+// PatchPool validates and fully replaces the instance pool inside a single
+// transaction, then repairs dangling assignments (see RepairDangling).
+func (m *EppPoolManager) PatchPool(ctx context.Context, groups []*InstanceGroup) (*EppPool, error) {
+	flat, err := m.validateGroups(groups)
+	if err != nil {
+		return nil, err
+	}
+
+	err = m.txn.AtomExecute(ctx, func(ctx context.Context) error {
+		if _, err := m.storager.DeleteInstances(ctx, &InstanceFilter{}); err != nil {
+			return err
+		}
+		if len(flat) > 0 {
+			if _, err := m.storager.CreateInstances(ctx, flat); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := m.RepairDangling(ctx); err != nil {
+		return nil, err
+	}
+
+	return m.GetPool(ctx)
+}
+
+// validateGroups checks the pool shape and returns the flattened instance list.
+func (m *EppPoolManager) validateGroups(groups []*InstanceGroup) ([]*InstanceParam, error) {
+	if len(groups) == 0 {
+		return nil, xerror.WrapParamErrorWithMsg("epp pool requires at least one group")
+	}
+
+	groupNames := map[string]bool{}
+	instanceIDs := map[string]bool{}
+	addresses := map[string]bool{}
+
+	var flat []*InstanceParam
+	for _, group := range groups {
+		if group == nil {
+			return nil, xerror.WrapParamErrorWithMsg("epp pool group is nil")
+		}
+		if group.Name == "" {
+			return nil, xerror.WrapParamErrorWithMsg("epp pool group name is empty")
+		}
+		if groupNames[group.Name] {
+			return nil, xerror.WrapParamErrorWithMsg("epp pool group name %q is duplicated", group.Name)
+		}
+		groupNames[group.Name] = true
+
+		if err := m.validateGroupSize(group); err != nil {
+			return nil, err
+		}
+
+		for _, inst := range group.Instances {
+			if inst == nil {
+				return nil, xerror.WrapParamErrorWithMsg("epp pool instance of group %q is nil", group.Name)
+			}
+			if inst.ID == "" {
+				return nil, xerror.WrapParamErrorWithMsg("epp pool instance id is empty (group %q)", group.Name)
+			}
+			if instanceIDs[inst.ID] {
+				return nil, xerror.WrapParamErrorWithMsg("epp pool instance id %q is duplicated", inst.ID)
+			}
+			instanceIDs[inst.ID] = true
+
+			if err := validateHost(inst.Host); err != nil {
+				return nil, xerror.WrapParamErrorWithMsg("epp pool instance %q host: %s", inst.ID, err.Error())
+			}
+			if err := validatePort(inst.Port); err != nil {
+				return nil, xerror.WrapParamErrorWithMsg("epp pool instance %q port: %s", inst.ID, err.Error())
+			}
+
+			addr := instanceAddress(inst.Host, inst.Port)
+			if addresses[addr] {
+				return nil, xerror.WrapParamErrorWithMsg("epp pool instance address %s is duplicated", addr)
+			}
+			addresses[addr] = true
+
+			flat = append(flat, &InstanceParam{
+				ID:        inst.ID,
+				Host:      inst.Host,
+				Port:      inst.Port,
+				GroupName: group.Name,
+			})
+		}
+	}
+
+	return flat, nil
+}
+
+// validateGroupSize enforces the per-group instance count of the deployment shape.
+func (m *EppPoolManager) validateGroupSize(group *InstanceGroup) error {
+	switch m.validationMode {
+	case ValidationModeTest:
+		if len(group.Instances) < 1 {
+			return xerror.WrapParamErrorWithMsg("epp pool group %q requires at least one instance", group.Name)
+		}
+	case ValidationModeProduction:
+		fallthrough
+	default:
+		if len(group.Instances) != 2 {
+			return xerror.WrapParamErrorWithMsg("epp pool group %q requires exactly 2 instances in %s mode, got %d",
+				group.Name, m.validationMode, len(group.Instances))
+		}
+	}
+	return nil
+}
+
+// buildPool groups flat instances by group name with deterministic order.
+func buildPool(name string, instances []*InstanceParam) *EppPool {
+	groupMap := map[string][]*InstanceParam{}
+	for _, inst := range instances {
+		groupMap[inst.GroupName] = append(groupMap[inst.GroupName], inst)
+	}
+
+	groupNames := make([]string, 0, len(groupMap))
+	for groupName := range groupMap {
+		groupNames = append(groupNames, groupName)
+	}
+	sort.Strings(groupNames)
+
+	pool := &EppPool{Name: name, Groups: []*InstanceGroup{}}
+	for _, groupName := range groupNames {
+		insts := groupMap[groupName]
+		sort.Slice(insts, func(i, j int) bool { return insts[i].ID < insts[j].ID })
+		pool.Groups = append(pool.Groups, &InstanceGroup{
+			Name:      groupName,
+			Instances: insts,
+		})
+	}
+
+	return pool
+}
+
+func instanceAddress(host string, port int) string {
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+func wrapModelError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return xerror.WrapModelErrorWithMsg("epp pool: %s", err.Error())
+}

--- a/model/epp_pool/epp_pool_manager_test.go
+++ b/model/epp_pool/epp_pool_manager_test.go
@@ -1,0 +1,431 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testManager(store *memoryEppPoolStorager, source EPPClusterSource) *EppPoolManager {
+	return NewEppPoolManager(&fakeTxn{}, store, source, nil, &ManagerOptions{
+		PoolName:       "EPP.pool",
+		ValidationMode: ValidationModeProduction,
+	})
+}
+
+func TestGetPool(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	store.seedInstances(
+		inst("epp-b", "g1", "10.0.0.2", 9002),
+		inst("epp-a", "g1", "10.0.0.1", 9002),
+		inst("epp-c", "g2", "10.0.0.3", 9002),
+	)
+
+	m := testManager(store, &fakeClusterSource{})
+
+	pool, err := m.GetPool(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "EPP.pool", pool.Name)
+	require.Len(t, pool.Groups, 2)
+	assert.Equal(t, "g1", pool.Groups[0].Name)
+	require.Len(t, pool.Groups[0].Instances, 2)
+	// Instances id-ordered within a group.
+	assert.Equal(t, "epp-a", pool.Groups[0].Instances[0].ID)
+	assert.Equal(t, "epp-b", pool.Groups[0].Instances[1].ID)
+	assert.Equal(t, "g2", pool.Groups[1].Name)
+}
+
+func TestGetPool_NotExist(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	m := testManager(store, &fakeClusterSource{})
+
+	// Pool never patched: record-not-exist per epp-pool.md §2.1.
+	_, err := m.GetPool(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Record Not Exist")
+}
+
+func TestPatchPool_FullReplace(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	store.seedInstances(inst("epp-old", "g0", "10.0.0.9", 9002))
+
+	m := testManager(store, &fakeClusterSource{})
+
+	pool, err := m.PatchPool(ctx, []*InstanceGroup{
+		{Name: "g1", Instances: []*InstanceParam{
+			{ID: "epp-a", Host: "10.0.0.1", Port: 9002},
+			{ID: "epp-b", Host: "10.0.0.2", Port: 9002},
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, pool.Groups, 1)
+	assert.Equal(t, "g1", pool.Groups[0].Name)
+
+	// Old instances fully replaced.
+	instances, err := store.FetchInstanceList(ctx, &InstanceFilter{})
+	require.NoError(t, err)
+	require.Len(t, instances, 2)
+	for _, one := range instances {
+		assert.NotEqual(t, "epp-old", one.ID)
+		assert.Equal(t, "g1", one.GroupName)
+	}
+}
+
+func TestPatchPool_Validation(t *testing.T) {
+	ctx := context.Background()
+
+	validGroup := func() *InstanceGroup {
+		return &InstanceGroup{Name: "g1", Instances: []*InstanceParam{
+			{ID: "epp-a", Host: "10.0.0.1", Port: 9002},
+			{ID: "epp-b", Host: "10.0.0.2", Port: 9002},
+		}}
+	}
+
+	cases := []struct {
+		name   string
+		groups []*InstanceGroup
+	}{
+		{"empty groups", nil},
+		{"empty group name", []*InstanceGroup{{Name: "", Instances: validGroup().Instances}}},
+		{"duplicated group name", []*InstanceGroup{validGroup(), validGroup()}},
+		{"empty instance id", []*InstanceGroup{{Name: "g1", Instances: []*InstanceParam{{ID: "", Host: "10.0.0.1", Port: 9002}, {ID: "epp-b", Host: "10.0.0.2", Port: 9002}}}}},
+		{"duplicated instance id", []*InstanceGroup{{Name: "g1", Instances: []*InstanceParam{{ID: "epp-a", Host: "10.0.0.1", Port: 9002}, {ID: "epp-a", Host: "10.0.0.2", Port: 9002}}}}},
+		{"duplicated address", []*InstanceGroup{{Name: "g1", Instances: []*InstanceParam{{ID: "epp-a", Host: "10.0.0.1", Port: 9002}, {ID: "epp-b", Host: "10.0.0.1", Port: 9002}}}}},
+		{"bad host", []*InstanceGroup{{Name: "g1", Instances: []*InstanceParam{{ID: "epp-a", Host: "-bad", Port: 9002}, {ID: "epp-b", Host: "10.0.0.2", Port: 9002}}}}},
+		{"bad port", []*InstanceGroup{{Name: "g1", Instances: []*InstanceParam{{ID: "epp-a", Host: "10.0.0.1", Port: 0}, {ID: "epp-b", Host: "10.0.0.2", Port: 9002}}}}},
+		{"production requires exactly 2", []*InstanceGroup{{Name: "g1", Instances: []*InstanceParam{{ID: "epp-a", Host: "10.0.0.1", Port: 9002}}}}},
+		{"nil group", []*InstanceGroup{nil}},
+		{"nil instance", []*InstanceGroup{{Name: "g1", Instances: []*InstanceParam{nil, {ID: "epp-b", Host: "10.0.0.2", Port: 9002}}}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newMemoryEppPoolStorager()
+			m := testManager(store, &fakeClusterSource{})
+			_, err := m.PatchPool(ctx, tc.groups)
+			require.Error(t, err)
+		})
+	}
+
+	t.Run("test mode allows single instance group", func(t *testing.T) {
+		store := newMemoryEppPoolStorager()
+		m := NewEppPoolManager(&fakeTxn{}, store, &fakeClusterSource{}, nil, &ManagerOptions{
+			ValidationMode: ValidationModeTest,
+		})
+		_, err := m.PatchPool(ctx, []*InstanceGroup{
+			{Name: "g1", Instances: []*InstanceParam{{ID: "epp-a", Host: "10.0.0.1", Port: 9002}}},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestAssignCluster(t *testing.T) {
+	ctx := context.Background()
+
+	setup := func() (*EppPoolManager, *memoryEppPoolStorager) {
+		store := newMemoryEppPoolStorager()
+		store.seedInstances(
+			inst("epp-a", "g1", "10.0.0.1", 9002),
+			inst("epp-b", "g1", "10.0.0.2", 9002),
+			inst("epp-c", "g2", "10.0.0.3", 9002),
+			inst("epp-d", "g2", "10.0.0.4", 9002),
+		)
+		return testManager(store, &fakeClusterSource{}), store
+	}
+
+	t.Run("assigns greedily", func(t *testing.T) {
+		m, store := setup()
+		require.NoError(t, m.AssignCluster(ctx, "cluster-a"))
+
+		assignment, err := store.FetchAssignment(ctx, "cluster-a")
+		require.NoError(t, err)
+		require.NotNil(t, assignment)
+		assert.Equal(t, "g1", assignment.GroupName)
+		assert.Equal(t, "epp-a", assignment.PrimaryInstanceID)
+	})
+
+	t.Run("idempotent on valid existing assignment", func(t *testing.T) {
+		m, store := setup()
+		require.NoError(t, m.AssignCluster(ctx, "cluster-a"))
+		store.upsertCalls = 0
+
+		require.NoError(t, m.AssignCluster(ctx, "cluster-a"))
+		assert.Equal(t, 0, store.upsertCalls)
+
+		assignment, err := store.FetchAssignment(ctx, "cluster-a")
+		require.NoError(t, err)
+		assert.Equal(t, "epp-a", assignment.PrimaryInstanceID)
+	})
+
+	t.Run("reassigns dangling assignment", func(t *testing.T) {
+		m, store := setup()
+		store.seedAssignments(&AssignmentParam{Cluster: "cluster-a", GroupName: "g9", PrimaryInstanceID: "epp-x"})
+
+		require.NoError(t, m.AssignCluster(ctx, "cluster-a"))
+
+		assignment, err := store.FetchAssignment(ctx, "cluster-a")
+		require.NoError(t, err)
+		assert.Equal(t, "g1", assignment.GroupName)
+	})
+
+	t.Run("empty cluster name rejected", func(t *testing.T) {
+		m, _ := setup()
+		require.Error(t, m.AssignCluster(ctx, ""))
+	})
+}
+
+func TestAssignCluster_UpsertConflictRetry(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	store.seedInstances(
+		inst("epp-a", "g1", "10.0.0.1", 9002),
+		inst("epp-b", "g1", "10.0.0.2", 9002),
+	)
+	m := testManager(store, &fakeClusterSource{})
+
+	// First upsert conflicts (concurrent writer), retry must succeed.
+	store.upsertConflictAt = 1
+	require.NoError(t, m.AssignCluster(ctx, "cluster-a"))
+
+	assignment, err := store.FetchAssignment(ctx, "cluster-a")
+	require.NoError(t, err)
+	require.NotNil(t, assignment)
+	assert.Equal(t, "epp-a", assignment.PrimaryInstanceID)
+}
+
+func TestRepairDangling(t *testing.T) {
+	ctx := context.Background()
+
+	setup := func() (*EppPoolManager, *memoryEppPoolStorager) {
+		store := newMemoryEppPoolStorager()
+		store.seedInstances(
+			inst("epp-a", "g1", "10.0.0.1", 9002),
+			inst("epp-b", "g1", "10.0.0.2", 9002),
+			inst("epp-c", "g2", "10.0.0.3", 9002),
+			inst("epp-d", "g2", "10.0.0.4", 9002),
+		)
+		return testManager(store, &fakeClusterSource{}), store
+	}
+
+	t.Run("same group reselect", func(t *testing.T) {
+		m, store := setup()
+		store.seedAssignments(&AssignmentParam{Cluster: "cluster-a", GroupName: "g1", PrimaryInstanceID: "epp-x"})
+
+		require.NoError(t, m.RepairDangling(ctx))
+
+		assignment, err := store.FetchAssignment(ctx, "cluster-a")
+		require.NoError(t, err)
+		assert.Equal(t, "g1", assignment.GroupName)
+		assert.Equal(t, "epp-a", assignment.PrimaryInstanceID)
+	})
+
+	t.Run("cross group reallocate", func(t *testing.T) {
+		m, store := setup()
+		// g9 removed from pool entirely.
+		store.seedAssignments(&AssignmentParam{Cluster: "cluster-a", GroupName: "g9", PrimaryInstanceID: "epp-x"})
+
+		require.NoError(t, m.RepairDangling(ctx))
+
+		assignment, err := store.FetchAssignment(ctx, "cluster-a")
+		require.NoError(t, err)
+		assert.Equal(t, "g1", assignment.GroupName)
+	})
+
+	t.Run("clear when pool has no candidate groups", func(t *testing.T) {
+		store := newMemoryEppPoolStorager()
+		store.seedInstances(inst("epp-a", "g1", "10.0.0.1", 9002)) // undersized
+		store.seedAssignments(&AssignmentParam{Cluster: "cluster-a", GroupName: "g1", PrimaryInstanceID: "epp-a"})
+		m := testManager(store, &fakeClusterSource{})
+
+		require.NoError(t, m.RepairDangling(ctx))
+
+		assignment, err := store.FetchAssignment(ctx, "cluster-a")
+		require.NoError(t, err)
+		assert.Nil(t, assignment)
+	})
+
+	t.Run("valid assignments untouched", func(t *testing.T) {
+		m, store := setup()
+		store.seedAssignments(&AssignmentParam{Cluster: "cluster-a", GroupName: "g2", PrimaryInstanceID: "epp-c"})
+
+		require.NoError(t, m.RepairDangling(ctx))
+
+		assignment, err := store.FetchAssignment(ctx, "cluster-a")
+		require.NoError(t, err)
+		assert.Equal(t, "epp-c", assignment.PrimaryInstanceID)
+	})
+}
+
+func TestOverrideAssignment(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	store.seedInstances(
+		inst("epp-a", "g1", "10.0.0.1", 9002),
+		inst("epp-b", "g1", "10.0.0.2", 9002),
+	)
+	source := &fakeClusterSource{clusters: []*EPPClusterInfo{{Name: "cluster-a"}}}
+	m := testManager(store, source)
+
+	t.Run("valid override", func(t *testing.T) {
+		view, err := m.OverrideAssignment(ctx, "cluster-a", "g1", "epp-b")
+		require.NoError(t, err)
+		require.NotNil(t, view)
+		assert.Equal(t, "cluster-a", view.Cluster)
+		assert.Equal(t, "epp-b", view.Primary.ID)
+		require.NotNil(t, view.Standby)
+		assert.Equal(t, "epp-a", view.Standby.ID)
+		assert.False(t, view.Degraded)
+
+		assignment, err := store.FetchAssignment(ctx, "cluster-a")
+		require.NoError(t, err)
+		assert.Equal(t, "epp-b", assignment.PrimaryInstanceID)
+	})
+
+	t.Run("unknown group", func(t *testing.T) {
+		_, err := m.OverrideAssignment(ctx, "cluster-a", "g9", "epp-a")
+		require.Error(t, err)
+	})
+
+	t.Run("primary not in group", func(t *testing.T) {
+		_, err := m.OverrideAssignment(ctx, "cluster-a", "g1", "epp-x")
+		require.Error(t, err)
+	})
+
+	t.Run("cluster not EPP", func(t *testing.T) {
+		// cluster-x is unknown and cluster-wrr is not in the EPP cluster list:
+		// both resolve to the record-not-exist error and must not upsert.
+		for _, cluster := range []string{"cluster-x", "cluster-wrr"} {
+			_, err := m.OverrideAssignment(ctx, cluster, "g1", "epp-a")
+			require.Error(t, err, cluster)
+			assert.Equal(t, 404, xerror.Resolve(err).ErrNo, cluster)
+
+			assignment, err := store.FetchAssignment(ctx, cluster)
+			require.NoError(t, err, cluster)
+			assert.Nil(t, assignment, cluster)
+		}
+	})
+
+	t.Run("cluster source not configured", func(t *testing.T) {
+		m := testManager(store, nil)
+		_, err := m.OverrideAssignment(ctx, "cluster-a", "g1", "epp-a")
+		require.Error(t, err)
+	})
+
+	t.Run("empty args", func(t *testing.T) {
+		_, err := m.OverrideAssignment(ctx, "", "g1", "epp-a")
+		require.Error(t, err)
+		_, err = m.OverrideAssignment(ctx, "cluster-a", "", "epp-a")
+		require.Error(t, err)
+		_, err = m.OverrideAssignment(ctx, "cluster-a", "g1", "")
+		require.Error(t, err)
+	})
+}
+
+func TestGetAssignmentsView(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	store.seedInstances(
+		inst("epp-a", "g1", "10.0.0.1", 9002),
+		inst("epp-b", "g1", "10.0.0.2", 9002),
+	)
+	source := &fakeClusterSource{clusters: []*EPPClusterInfo{
+		{Name: "cluster-a"},
+		{Name: "cluster-b"},
+	}}
+	store.seedAssignments(&AssignmentParam{Cluster: "cluster-a", GroupName: "g1", PrimaryInstanceID: "epp-a"})
+
+	m := testManager(store, source)
+
+	t.Run("full view", func(t *testing.T) {
+		view, err := m.GetAssignmentsView(ctx)
+		require.NoError(t, err)
+		require.Len(t, view.Clusters, 2)
+		assert.Equal(t, "epp-a", view.Clusters[0].Primary.ID)
+		assert.Equal(t, []string{"cluster-b"}, view.UnassignedClusters)
+		assert.Empty(t, view.IdleGroups)
+	})
+
+	t.Run("single cluster view", func(t *testing.T) {
+		entry, err := m.GetAssignmentView(ctx, "cluster-a")
+		require.NoError(t, err)
+		assert.Equal(t, "epp-a", entry.Primary.ID)
+
+		_, err = m.GetAssignmentView(ctx, "cluster-x")
+		require.Error(t, err)
+	})
+
+	t.Run("nil cluster source", func(t *testing.T) {
+		m := testManager(store, nil)
+		_, err := m.GetAssignmentsView(ctx)
+		require.Error(t, err)
+	})
+}
+
+func TestReconcile_BackfillsMissingAssignments(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryEppPoolStorager()
+	store.seedInstances(
+		inst("epp-a", "g1", "10.0.0.1", 9002),
+		inst("epp-b", "g1", "10.0.0.2", 9002),
+	)
+	source := &fakeClusterSource{clusters: []*EPPClusterInfo{
+		{Name: "cluster-a"},
+		{Name: "cluster-b"},
+	}}
+	m := testManager(store, source)
+
+	require.NoError(t, m.Reconcile(ctx))
+
+	assignmentA, err := store.FetchAssignment(ctx, "cluster-a")
+	require.NoError(t, err)
+	require.NotNil(t, assignmentA)
+
+	assignmentB, err := store.FetchAssignment(ctx, "cluster-b")
+	require.NoError(t, err)
+	require.NotNil(t, assignmentB)
+
+	// Reconcile is idempotent: a second pass performs no writes.
+	store.upsertCalls = 0
+	require.NoError(t, m.Reconcile(ctx))
+	assert.Equal(t, 0, store.upsertCalls)
+}
+
+func TestReconcile_NilSource(t *testing.T) {
+	m := testManager(newMemoryEppPoolStorager(), nil)
+	require.NoError(t, m.Reconcile(context.Background()))
+}
+
+func TestManagerOptionsDefaults(t *testing.T) {
+	m := NewEppPoolManager(&fakeTxn{}, newMemoryEppPoolStorager(), nil, nil, nil)
+	assert.Equal(t, DefaultEPPInstancePoolName, m.PoolName())
+	assert.Equal(t, ValidationModeProduction, m.validationMode)
+	assert.Equal(t, DefaultReconcileInterval, m.ReconcileInterval())
+}
+
+func TestManager_ReconcilerLifecycle(t *testing.T) {
+	m := NewEppPoolManager(&fakeTxn{}, newMemoryEppPoolStorager(), nil, nil, &ManagerOptions{
+		ReconcileInterval: 10,
+	})
+	m.StartReconciler()
+	m.StopReconciler()
+}

--- a/model/epp_pool/mocks_test.go
+++ b/model/epp_pool/mocks_test.go
@@ -1,0 +1,185 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iversion_control"
+)
+
+var errFakeConflict = errors.New("fake unique key conflict")
+
+type fakeTxn struct{}
+
+func (f *fakeTxn) AtomExecute(ctx context.Context, do func(context.Context) error) error {
+	return do(ctx)
+}
+
+// memoryEppPoolStorager is a hand-written in-memory implementation of
+// EppPoolStorager for manager tests.
+type memoryEppPoolStorager struct {
+	mu        sync.Mutex
+	instances map[string]*InstanceParam
+	// assignments keyed by cluster; nil value models a unique-key conflict on insert.
+	assignments      map[string]*AssignmentParam
+	upsertConflictAt int
+	upsertCalls      int
+}
+
+func newMemoryEppPoolStorager() *memoryEppPoolStorager {
+	return &memoryEppPoolStorager{
+		instances:   map[string]*InstanceParam{},
+		assignments: map[string]*AssignmentParam{},
+	}
+}
+
+func (s *memoryEppPoolStorager) seedInstances(instances ...*InstanceParam) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, inst := range instances {
+		s.instances[inst.ID] = inst
+	}
+}
+
+func (s *memoryEppPoolStorager) seedAssignments(assignments ...*AssignmentParam) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, assignment := range assignments {
+		s.assignments[assignment.Cluster] = assignment
+	}
+}
+
+func (s *memoryEppPoolStorager) FetchInstanceList(ctx context.Context, filter *InstanceFilter) ([]*InstanceParam, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rst := []*InstanceParam{}
+	for _, inst := range s.instances {
+		if filter != nil {
+			if filter.ID != nil && *filter.ID != inst.ID {
+				continue
+			}
+			if filter.GroupName != nil && *filter.GroupName != inst.GroupName {
+				continue
+			}
+		}
+		rst = append(rst, inst)
+	}
+	sort.Slice(rst, func(i, j int) bool { return rst[i].ID < rst[j].ID })
+	return rst, nil
+}
+
+func (s *memoryEppPoolStorager) CreateInstances(ctx context.Context, params []*InstanceParam) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, param := range params {
+		s.instances[param.ID] = param
+	}
+	return int64(len(params)), nil
+}
+
+func (s *memoryEppPoolStorager) DeleteInstances(ctx context.Context, filter *InstanceFilter) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var affected int64
+	for id, inst := range s.instances {
+		if filter != nil {
+			if filter.ID != nil && *filter.ID != inst.ID {
+				continue
+			}
+			if filter.GroupName != nil && *filter.GroupName != inst.GroupName {
+				continue
+			}
+		}
+		delete(s.instances, id)
+		affected++
+	}
+	return affected, nil
+}
+
+func (s *memoryEppPoolStorager) FetchAssignment(ctx context.Context, cluster string) (*AssignmentParam, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if assignment, ok := s.assignments[cluster]; ok {
+		return assignment, nil
+	}
+	return nil, nil
+}
+
+func (s *memoryEppPoolStorager) FetchAssignmentList(ctx context.Context) ([]*AssignmentParam, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rst := []*AssignmentParam{}
+	for _, assignment := range s.assignments {
+		rst = append(rst, assignment)
+	}
+	sort.Slice(rst, func(i, j int) bool { return rst[i].Cluster < rst[j].Cluster })
+	return rst, nil
+}
+
+func (s *memoryEppPoolStorager) UpsertAssignment(ctx context.Context, param *AssignmentParam) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.upsertCalls++
+	if s.upsertConflictAt > 0 && s.upsertCalls == s.upsertConflictAt {
+		s.upsertConflictAt = 0
+		return errFakeConflict
+	}
+
+	s.assignments[param.Cluster] = param
+	return nil
+}
+
+func (s *memoryEppPoolStorager) DeleteAssignment(ctx context.Context, cluster string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.assignments, cluster)
+	return nil
+}
+
+type fakeClusterSource struct {
+	clusters []*EPPClusterInfo
+	err      error
+}
+
+func (f *fakeClusterSource) FetchEPPClusters(ctx context.Context) ([]*EPPClusterInfo, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.clusters, nil
+}
+
+type fakeVersionControlStorager struct {
+	upsertFn func(ctx context.Context, css *iversion_control.ExportData) (string, error)
+}
+
+func (s *fakeVersionControlStorager) UpsertConfigLastExportedVersion(ctx context.Context, css *iversion_control.ExportData) (string, error) {
+	if s.upsertFn != nil {
+		return s.upsertFn(ctx, css)
+	}
+	return "20260906120000", nil
+}
+
+var _ iversion_control.VersionControlStorager = (*fakeVersionControlStorager)(nil)

--- a/model/epp_pool/reconciler.go
+++ b/model/epp_pool/reconciler.go
@@ -1,0 +1,101 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"context"
+	"runtime"
+	"time"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
+)
+
+// EppReconciler periodically reconciles EPP cluster assignments
+// (design-changes.md §4.3: idempotent scan plus back-fill allocation).
+// Start/Stop follow the process lifecycle like QuotaResetScheduler.
+type EppReconciler struct {
+	interval    time.Duration
+	reconcileFn func(ctx context.Context) error
+	stopCh      chan struct{}
+}
+
+// NewEppReconciler creates the reconciler. reconcile is invoked every interval.
+func NewEppReconciler(interval time.Duration, reconcile func(ctx context.Context) error) *EppReconciler {
+	if interval <= 0 {
+		interval = DefaultReconcileInterval
+	}
+	return &EppReconciler{
+		interval:    interval,
+		reconcileFn: reconcile,
+		stopCh:      make(chan struct{}),
+	}
+}
+
+// Start launches the reconcile loop in the background.
+func (r *EppReconciler) Start() {
+	go r.run()
+}
+
+// Stop terminates the reconcile loop.
+func (r *EppReconciler) Stop() {
+	close(r.stopCh)
+}
+
+func (r *EppReconciler) run() {
+	defer func() {
+		if err := recover(); err != nil {
+			stack := make([]byte, 1024*8)
+			stack = stack[:runtime.Stack(stack, false)]
+			stateful.ExceptionLogger.Error("PANIC in EppReconciler: err=%v\n%s", err, string(stack))
+		}
+	}()
+
+	r.reconcileWithRecover()
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			r.reconcileWithRecover()
+		case <-r.stopCh:
+			return
+		}
+	}
+}
+
+func (r *EppReconciler) reconcileWithRecover() {
+	defer func() {
+		if err := recover(); err != nil {
+			stack := make([]byte, 1024*8)
+			stack = stack[:runtime.Stack(stack, false)]
+			stateful.ExceptionLogger.Error("PANIC in EppReconciler reconcile: err=%v\n%s", err, string(stack))
+		}
+	}()
+
+	if r.reconcileFn == nil {
+		return
+	}
+
+	if err := r.reconcileFn(context.Background()); err != nil {
+		stateful.AccessLogger.Error("EppReconciler reconcile failed: %v", err)
+	}
+}
+
+// eppLogError logs a non-fatal epp pool error.
+func eppLogError(format string, args ...interface{}) {
+	stateful.AccessLogger.Error(format, args...)
+}

--- a/model/epp_pool/reconciler_test.go
+++ b/model/epp_pool/reconciler_test.go
@@ -1,0 +1,75 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEppReconciler_RunAndStop(t *testing.T) {
+	var calls int32
+	r := NewEppReconciler(5, func(ctx context.Context) error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	})
+
+	r.Start()
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) >= 2 }, time.Second, 5*time.Millisecond)
+	r.Stop()
+}
+
+func TestEppReconciler_ReconcileErrorSwallowed(t *testing.T) {
+	var calls int32
+	r := NewEppReconciler(5, func(ctx context.Context) error {
+		atomic.AddInt32(&calls, 1)
+		return errors.New("boom")
+	})
+
+	r.Start()
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) >= 1 }, time.Second, 5*time.Millisecond)
+	r.Stop()
+}
+
+func TestEppReconciler_PanicSwallowed(t *testing.T) {
+	var calls int32
+	r := NewEppReconciler(5, func(ctx context.Context) error {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			panic("boom")
+		}
+		return nil
+	})
+
+	r.Start()
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) >= 2 }, time.Second, 5*time.Millisecond)
+	r.Stop()
+}
+
+func TestEppReconciler_NilReconcile(t *testing.T) {
+	r := NewEppReconciler(5, nil)
+	r.Start()
+	r.Stop()
+}
+
+func TestEppReconciler_DefaultInterval(t *testing.T) {
+	r := NewEppReconciler(0, nil)
+	assert.Equal(t, DefaultReconcileInterval, r.interval)
+}

--- a/model/icluster_conf/cluster.go
+++ b/model/icluster_conf/cluster.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ibasic"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/imodel_price"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ioperlog"
@@ -143,6 +144,14 @@ type ClusterParam struct {
 	PassiveHealthCheck *ClusterPassiveHealthCheckParam
 
 	LLMConfig *LLMConfig
+
+	// BalanceMode is the explicit cluster balance mode (WRR default, EPP
+	// optional); it is the single source of truth for the export BalanceMode.
+	BalanceMode *string
+	// EppConfig is the raw JSON of the simplified per-cluster EPP scheduling
+	// configuration (user shape, unset keys not persisted). Non-empty values
+	// are validated regardless of BalanceMode; required when BalanceMode=EPP.
+	EppConfig *string
 
 	// InstancePool auto-creates instance-pool and sub-cluster from these instances
 	InstancePool []Instance
@@ -281,6 +290,14 @@ type Cluster struct {
 	Scheduler          map[string]map[string]int
 	PassiveHealthCheck *ClusterPassiveHealthCheck
 	LLMConfig          *LLMConfig
+
+	// BalanceMode is the explicit balance mode read from clusters.balance_mode
+	// (empty means the WRR column default). It replaces the removed SubCluster
+	// pool Role derivation as the single EPP-mode decision source.
+	BalanceMode string
+	// EppConfig is the raw JSON of the simplified EPP scheduling configuration
+	// (empty means unset). Stored verbatim so GET round-trips the written value.
+	EppConfig string
 }
 
 func (cluster *Cluster) SubClusterNames() []string {
@@ -293,12 +310,12 @@ func (cluster *Cluster) SubClusterNames() []string {
 }
 
 func (cluster *Cluster) getBalanceMode() string {
-	for _, sc := range cluster.SubClusters {
-		if sc.Role == ProductPoolRoleEPP {
-			return "EPP"
-		}
+	// balance_mode is the single source of truth for the EPP decision; the
+	// empty value falls back to the WRR column default (design-changes.md §2.1).
+	if cluster.BalanceMode == "" {
+		return BalanceModeWRR
 	}
-	return "WRR"
+	return cluster.BalanceMode
 }
 
 func ClusterList2MapByName(list []*Cluster) map[string]*Cluster {
@@ -366,6 +383,7 @@ type ClusterManager struct {
 
 	versionControlManager *iversion_control.VersionControlManager
 	operationLogManager   ioperlog.OperationLogRecorder
+	eppPoolManager        *epp_pool.EppPoolManager
 
 	deleteCheckers map[string]func(context.Context, *ibasic.Product, *Cluster) error
 	updateCheckers map[string]func(context.Context, *ibasic.Product, *Cluster, *ClusterParam) error
@@ -374,6 +392,13 @@ type ClusterManager struct {
 // SetOperationLogManager injects the operation log recorder.
 func (cm *ClusterManager) SetOperationLogManager(manager ioperlog.OperationLogRecorder) {
 	cm.operationLogManager = manager
+}
+
+// SetEppPoolManager injects the EPP pool manager used to trigger assignments
+// for EPP-mode clusters (create / WRR->EPP update). Assignment failures never
+// block cluster writes; the periodic reconciler converges (design-changes.md §2.3).
+func (cm *ClusterManager) SetEppPoolManager(manager *epp_pool.EppPoolManager) {
+	cm.eppPoolManager = manager
 }
 
 func (rm *ClusterManager) FetchClusterList(ctx context.Context, param *ClusterFilter) (list []*Cluster, err error) {
@@ -400,6 +425,17 @@ func (cm *ClusterManager) FetchCluster(ctx context.Context, param *ClusterFilter
 
 func (cm *ClusterManager) CreateCluster(ctx context.Context, product *ibasic.Product, param *ClusterParam) (err error) {
 	param.ProductID = &product.ID
+
+	balanceMode, eppConfigRaw, err := validateClusterBalanceConfig(param.BalanceMode, "", param.EppConfig, "")
+	if err != nil {
+		return err
+	}
+	if param.BalanceMode != nil {
+		*param.BalanceMode = balanceMode
+	}
+	if param.EppConfig != nil {
+		*param.EppConfig = eppConfigRaw
+	}
 
 	var clusterID int64
 	err = cm.txn.AtomExecute(ctx, func(ctx context.Context) error {
@@ -444,10 +480,20 @@ func (cm *ClusterManager) CreateCluster(ctx context.Context, product *ibasic.Pro
 				return xerror.WrapRecordExisted()
 			}
 
+			// balance_mode=EPP creates a Role=EPP pool that still carries the
+			// provider instance list, so cluster_table export has RS entries for
+			// EPP backend discovery and BFE local fallback (design-changes.md §2.3);
+			// WRR keeps the same provider-snapshot path.
+			poolRole := ProductPoolRoleCommon
+			if balanceMode == BalanceModeEPP {
+				poolRole = ProductPoolRoleEPP
+			}
+			poolInstances := providerInstancesToClusterInstances(provider.InstancePool)
+
 			pool, err := cm.poolStorager.CreatePool(ctx, product, &PoolParam{
 				Name:      &poolName,
-				Instances: providerInstancesToClusterInstances(provider.InstancePool),
-				Role:      lib.PString(ProductPoolRoleCommon),
+				Instances: poolInstances,
+				Role:      lib.PString(poolRole),
 				Tag:       &PoolTagProduct,
 			})
 			if err != nil {
@@ -537,6 +583,13 @@ func (cm *ClusterManager) CreateCluster(ctx context.Context, product *ibasic.Pro
 	}
 
 	cm.recordClusterOperation(ctx, string(ioperlog.ActionCreate), clusterID, clusterName, nil, clusterParamToMap(param), nil)
+
+	// Trigger the EPP assignment after a successful create; a failure here is
+	// logged, not propagated (reconciler convergence, design-changes.md §2.3).
+	if balanceMode == BalanceModeEPP {
+		cm.assignClusterToEPP(ctx, clusterName)
+	}
+
 	return nil
 }
 
@@ -696,6 +749,19 @@ func (cm *ClusterManager) checkBindingSubClusters(ctx context.Context, cluster *
 func (cm *ClusterManager) UpdateCluster(ctx context.Context, product *ibasic.Product, oldData *Cluster,
 	param *ClusterParam) (err error) {
 
+	oldBalanceMode := oldData.getBalanceMode()
+	balanceMode, eppConfigRaw, err := validateClusterBalanceConfig(param.BalanceMode, oldBalanceMode, param.EppConfig, oldData.EppConfig)
+	if err != nil {
+		cm.recordClusterOperation(ctx, string(ioperlog.ActionUpdate), oldData.ID, oldData.Name, clusterToMap(oldData), clusterParamToMap(param), err)
+		return err
+	}
+	if param.BalanceMode != nil {
+		*param.BalanceMode = balanceMode
+	}
+	if param.EppConfig != nil {
+		*param.EppConfig = eppConfigRaw
+	}
+
 	err = cm.txn.AtomExecute(ctx, func(ctx context.Context) error {
 		// Validate and sync provider changes.
 		if param.LLMConfig != nil && param.LLMConfig.Provider != nil && *param.LLMConfig.Provider != "" {
@@ -762,6 +828,14 @@ func (cm *ClusterManager) UpdateCluster(ctx context.Context, product *ibasic.Pro
 	}
 
 	cm.recordClusterOperation(ctx, string(ioperlog.ActionUpdate), oldData.ID, oldData.Name, clusterToMap(oldData), clusterParamToMap(param), nil)
+
+	// WRR -> EPP triggers the assignment after a successful write; a failure
+	// here is logged, not propagated (reconciler convergence). EPP -> WRR keeps
+	// the stored epp_config and the assignment dormant (design-changes.md §2.3).
+	if oldBalanceMode != BalanceModeEPP && balanceMode == BalanceModeEPP {
+		cm.assignClusterToEPP(ctx, oldData.Name)
+	}
+
 	return nil
 }
 
@@ -851,9 +925,13 @@ func (cm *ClusterManager) ProviderInstancePoolSyncer(ctx context.Context,
 		}
 
 		for _, sc := range cluster.SubClusters {
-			if sc.InstancePool == nil || sc.Role == ProductPoolRoleEPP {
+			if sc.InstancePool == nil {
 				continue
 			}
+			// EPP-role pools are synced as well: they carry the provider
+			// instance snapshot for EPP backend discovery and BFE local
+			// fallback, so instance_pool changes (e.g. weight=0 drain) must
+			// reach them too (same rationale as the creation path).
 			if err := cm.poolStorager.UpdatePool(ctx, sc.InstancePool, &PoolParam{
 				Instances: newInstances,
 			}); err != nil {
@@ -1126,11 +1204,12 @@ type ProviderPricingInfo struct {
 	Tiers    []cluster_conf.PriceTier
 }
 
-func NewBfeClusterConf(version string, clusters []*Cluster,
+func NewBfeClusterConf(ctx context.Context, version string, clusters []*Cluster,
 	providerModelTable map[string][]*imodel_price.ModelPrice,
 	providerKeyTable map[string][]iprovider.ProviderKey,
 	providerProtocolTable map[string][]string,
-	providerPricingTable map[string]ProviderPricingInfo) *cluster_conf.BfeClusterConf {
+	providerPricingTable map[string]ProviderPricingInfo,
+	eppResolver EPPAssignmentResolver) *cluster_conf.BfeClusterConf {
 	clusterConfMap := cluster_conf.ClusterToConf{}
 
 	int322intp := func(i int32) *int {
@@ -1180,8 +1259,17 @@ func NewBfeClusterConf(version string, clusters []*Cluster,
 			},
 		}
 
-		if clusterConf.GslbBasic.BalanceMode != nil && *clusterConf.GslbBasic.BalanceMode == ProductPoolRoleEPP {
-			clusterConf.GslbBasic.EPPAddr = buildEPPAddrsFromSubClusters(cluster.SubClusters)
+		if balanceMode := cluster.getBalanceMode(); balanceMode == BalanceModeEPP {
+			// EPPAddr is assignment-driven ([0]=primary, [1]=standby). Without a
+			// valid assignment the cluster degrades to WRR without EPPAddr and an
+			// error-level log is emitted; the rest of the export is unaffected
+			// (design-changes.md §4.3).
+			if addrs, ok := fetchEPPAssignmentAddrs(ctx, eppResolver, cluster.Name); ok {
+				clusterConf.GslbBasic.BalanceMode = lib.PString(BalanceModeEPP)
+				clusterConf.GslbBasic.EPPAddr = &addrs
+			} else {
+				clusterConf.GslbBasic.BalanceMode = lib.PString(BalanceModeWRR)
+			}
 		}
 
 		if cluster.Basic.Protocol != nil && *cluster.Basic.Protocol == "https" {
@@ -1357,39 +1445,4 @@ func isDomainPool(subClusters []*SubCluster) bool {
 	}
 
 	return false
-}
-
-func buildEPPAddrsFromSubClusters(subClusters []*SubCluster) *[]string {
-	if len(subClusters) == 0 || subClusters[0] == nil || subClusters[0].InstancePool == nil {
-		return nil
-	}
-
-	eppServer := subClusters[0].InstancePool.EPPServer
-	if eppServer == nil {
-		return nil
-	}
-
-	// Prefer domain+port mode; fallback to endpoints mode.
-	if eppServer.Domain != nil && *eppServer.Domain != "" && eppServer.Port != nil && *eppServer.Port > 0 {
-		addrs := []string{fmt.Sprintf("%s:%d", *eppServer.Domain, *eppServer.Port)}
-		return &addrs
-	}
-
-	addrs := make([]string, 0, len(eppServer.Endpoints))
-	for _, endpoint := range eppServer.Endpoints {
-		if endpoint == nil || endpoint.IP == nil || endpoint.Port == nil {
-			continue
-		}
-		if *endpoint.IP == "" || *endpoint.Port <= 0 {
-			continue
-		}
-
-		addrs = append(addrs, fmt.Sprintf("%s:%d", *endpoint.IP, *endpoint.Port))
-	}
-
-	if len(addrs) == 0 {
-		return nil
-	}
-
-	return &addrs
 }

--- a/model/icluster_conf/cluster_test.go
+++ b/model/icluster_conf/cluster_test.go
@@ -113,7 +113,7 @@ func TestClusterManager_ProviderInstancePoolSyncer(t *testing.T) {
 		assert.Equal(t, "5.6.7.8_443", updatedPools[1][0].Name)
 	})
 
-	t.Run("skips EPP sub-clusters", func(t *testing.T) {
+	t.Run("syncs EPP sub-clusters", func(t *testing.T) {
 		updatedPools := map[int64][]Instance{}
 		clusterStorager := &fakeClusterStorager{
 			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
@@ -140,7 +140,9 @@ func TestClusterManager_ProviderInstancePoolSyncer(t *testing.T) {
 		}
 		err := cm.ProviderInstancePoolSyncer(ctx, nil, newProvider)
 		require.NoError(t, err)
-		assert.Empty(t, updatedPools)
+		require.Len(t, updatedPools, 1)
+		require.Contains(t, updatedPools, int64(1))
+		assert.Equal(t, "5.6.7.8_443", updatedPools[1][0].Name)
 	})
 
 	t.Run("propagates update pool error", func(t *testing.T) {
@@ -413,11 +415,8 @@ func newTestClusterBase() *Cluster {
 
 func newTestClusterEPP() *Cluster {
 	c := newTestClusterBase()
-	c.SubClusters[0].Role = ProductPoolRoleEPP
-	c.SubClusters[0].InstancePool.EPPServer = &EPPServer{
-		Domain: lib.PString("epp.example.com"),
-		Port:   lib.PInt(8080),
-	}
+	c.BalanceMode = BalanceModeEPP
+	c.EppConfig = `{"scheduling_profile":"balanced"}`
 	return c
 }
 
@@ -469,14 +468,25 @@ func TestCluster_SubClusterNames(t *testing.T) {
 }
 
 func TestCluster_getBalanceMode(t *testing.T) {
-	t.Run("WRR", func(t *testing.T) {
+	t.Run("default WRR when unset", func(t *testing.T) {
 		c := newTestClusterBase()
-		assert.Equal(t, "WRR", c.getBalanceMode())
+		assert.Equal(t, BalanceModeWRR, c.getBalanceMode())
+	})
+	t.Run("explicit WRR", func(t *testing.T) {
+		c := newTestClusterBase()
+		c.BalanceMode = BalanceModeWRR
+		assert.Equal(t, BalanceModeWRR, c.getBalanceMode())
 	})
 
 	t.Run("EPP", func(t *testing.T) {
 		c := newTestClusterEPP()
-		assert.Equal(t, "EPP", c.getBalanceMode())
+		assert.Equal(t, BalanceModeEPP, c.getBalanceMode())
+	})
+
+	t.Run("SubCluster Role no longer derives balance mode", func(t *testing.T) {
+		c := newTestClusterBase()
+		c.SubClusters[0].Role = ProductPoolRoleEPP
+		assert.Equal(t, BalanceModeWRR, c.getBalanceMode())
 	})
 }
 
@@ -921,6 +931,7 @@ func TestClusterManager_UpdateCluster(t *testing.T) {
 
 	t.Run("EPP count invalid", func(t *testing.T) {
 		c := newTestClusterEPP()
+		c.SubClusters[0].Role = ProductPoolRoleEPP
 		c.SubClusters = append(c.SubClusters, &SubCluster{ID: 2, Name: "sc2", Role: ProductPoolRoleEPP})
 		m := NewClusterManager(&fakeTxn{}, &fakeClusterStorager{}, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
 		err := m.UpdateCluster(ctx, product, c, &ClusterParam{Name: lib.PString("c1")})
@@ -1089,7 +1100,7 @@ func TestAppendAdvancedRuleCluster(t *testing.T) {
 
 func TestNewBfeClusterConf(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterBase()}, nil, nil, nil, nil)
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{newTestClusterBase()}, nil, nil, nil, nil, nil)
 		require.NotNil(t, conf)
 		require.NotNil(t, conf.Config)
 		assert.Equal(t, "v1", *conf.Version)
@@ -1102,29 +1113,83 @@ func TestNewBfeClusterConf(t *testing.T) {
 	})
 
 	t.Run("skip system route", func(t *testing.T) {
-		conf := NewBfeClusterConf("v1", []*Cluster{
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{
 			newTestClusterBase(),
 			{ID: RouteAdvancedModeClusterID, Name: RouteAdvancedModeClusterName},
-		}, nil, nil, nil, nil)
+		}, nil, nil, nil, nil, nil)
 		require.Len(t, *conf.Config, 1)
 	})
 
-	t.Run("EPP addrs", func(t *testing.T) {
-		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterEPP()}, nil, nil, nil, nil)
+	t.Run("EPP addrs from assignment", func(t *testing.T) {
+		resolver := &fakeEPPAssignmentResolver{
+			endpointsFn: func(ctx context.Context, clusterName string) ([]string, bool, error) {
+				return []string{"10.0.0.1:9002", "10.0.0.2:9002"}, true, nil
+			},
+		}
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{newTestClusterEPP()}, nil, nil, nil, nil, resolver)
 		cConf := (*conf.Config)["c1"]
 		require.NotNil(t, cConf.GslbBasic.EPPAddr)
-		assert.Equal(t, []string{"epp.example.com:8080"}, *cConf.GslbBasic.EPPAddr)
+		assert.Equal(t, []string{"10.0.0.1:9002", "10.0.0.2:9002"}, *cConf.GslbBasic.EPPAddr)
+		require.NotNil(t, cConf.GslbBasic.BalanceMode)
+		assert.Equal(t, BalanceModeEPP, *cConf.GslbBasic.BalanceMode)
+	})
+
+	t.Run("EPP without assignment degrades to WRR", func(t *testing.T) {
+		resolver := &fakeEPPAssignmentResolver{
+			endpointsFn: func(ctx context.Context, clusterName string) ([]string, bool, error) {
+				return nil, false, nil
+			},
+		}
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{newTestClusterEPP()}, nil, nil, nil, nil, resolver)
+		cConf := (*conf.Config)["c1"]
+		assert.Nil(t, cConf.GslbBasic.EPPAddr)
+		require.NotNil(t, cConf.GslbBasic.BalanceMode)
+		assert.Equal(t, BalanceModeWRR, *cConf.GslbBasic.BalanceMode)
+	})
+
+	t.Run("EPP assignment lookup error degrades to WRR", func(t *testing.T) {
+		resolver := &fakeEPPAssignmentResolver{
+			endpointsFn: func(ctx context.Context, clusterName string) ([]string, bool, error) {
+				return nil, false, errors.New("db down")
+			},
+		}
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{newTestClusterEPP()}, nil, nil, nil, nil, resolver)
+		cConf := (*conf.Config)["c1"]
+		assert.Nil(t, cConf.GslbBasic.EPPAddr)
+		require.NotNil(t, cConf.GslbBasic.BalanceMode)
+		assert.Equal(t, BalanceModeWRR, *cConf.GslbBasic.BalanceMode)
+	})
+
+	t.Run("EPP without resolver degrades to WRR", func(t *testing.T) {
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{newTestClusterEPP()}, nil, nil, nil, nil, nil)
+		cConf := (*conf.Config)["c1"]
+		assert.Nil(t, cConf.GslbBasic.EPPAddr)
+		require.NotNil(t, cConf.GslbBasic.BalanceMode)
+		assert.Equal(t, BalanceModeWRR, *cConf.GslbBasic.BalanceMode)
+	})
+
+	t.Run("WRR cluster never exports EPPAddr even when assigned", func(t *testing.T) {
+		resolver := &fakeEPPAssignmentResolver{
+			endpointsFn: func(ctx context.Context, clusterName string) ([]string, bool, error) {
+				return []string{"10.0.0.1:9002"}, true, nil
+			},
+		}
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{newTestClusterBase()}, nil, nil, nil, nil, resolver)
+		cConf := (*conf.Config)["c1"]
+		assert.Nil(t, cConf.GslbBasic.EPPAddr)
+		require.NotNil(t, cConf.GslbBasic.BalanceMode)
+		assert.Equal(t, BalanceModeWRR, *cConf.GslbBasic.BalanceMode)
 	})
 
 	t.Run("https conf", func(t *testing.T) {
-		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterHTTPS()}, nil, nil, nil, nil)
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{newTestClusterHTTPS()}, nil, nil, nil, nil, nil)
 		cConf := (*conf.Config)["c1"]
 		require.NotNil(t, cConf.HTTPSConf)
 		assert.True(t, *cConf.HTTPSConf.RSInsecureSkipVerify)
 	})
 
 	t.Run("domain pool disable checks", func(t *testing.T) {
-		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterDomain()}, nil, nil, nil, nil)
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{newTestClusterDomain()}, nil, nil, nil, nil, nil)
 		cConf := (*conf.Config)["c1"]
 		assert.True(t, *cConf.ClusterBasic.DisableHealthCheck)
 		assert.True(t, *cConf.ClusterBasic.DisableHostHeader)
@@ -1140,7 +1205,7 @@ func TestNewBfeClusterConf(t *testing.T) {
 		providerProtocolTable := map[string][]string{
 			"openai": {"openai"},
 		}
-		conf := NewBfeClusterConf("v1", []*Cluster{newTestClusterLLM()}, nil, providerKeyTable, providerProtocolTable, nil)
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{newTestClusterLLM()}, nil, providerKeyTable, providerProtocolTable, nil, nil)
 		cConf := (*conf.Config)["c1"]
 		require.NotNil(t, cConf.AIConf)
 		require.Len(t, cConf.AIConf.Keys, 2)
@@ -1205,7 +1270,7 @@ func TestNewBfeClusterConf(t *testing.T) {
 		}
 		c := newTestClusterLLM()
 		c.LLMConfig.Provider = lib.PString("deepseek")
-		conf := NewBfeClusterConf("v1", []*Cluster{c}, providerModelTable, nil, nil, providerPricingTable)
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{c}, providerModelTable, nil, nil, providerPricingTable, nil)
 		cConf := (*conf.Config)["c1"]
 		require.NotNil(t, cConf.AIConf)
 		require.NotNil(t, cConf.AIConf.ModelTable)
@@ -1227,7 +1292,7 @@ func TestNewBfeClusterConf(t *testing.T) {
 			HashStrategy:  ClusterHashStrategyClientIDOnlyI,
 			HashHeader:    "",
 		}
-		conf := NewBfeClusterConf("v1", []*Cluster{c}, nil, nil, nil, nil)
+		conf := NewBfeClusterConf(context.Background(), "v1", []*Cluster{c}, nil, nil, nil, nil, nil)
 		cConf := (*conf.Config)["c1"]
 		require.NotNil(t, cConf.GslbBasic)
 		require.NotNil(t, cConf.GslbBasic.HashConf)
@@ -1304,30 +1369,6 @@ func TestIsDomainPool(t *testing.T) {
 
 	t.Run("domain", func(t *testing.T) {
 		assert.True(t, isDomainPool(newTestClusterDomain().SubClusters))
-	})
-}
-
-func TestBuildEPPAddrsFromSubClusters(t *testing.T) {
-	t.Run("domain mode", func(t *testing.T) {
-		got := buildEPPAddrsFromSubClusters(newTestClusterEPP().SubClusters)
-		require.NotNil(t, got)
-		assert.Equal(t, []string{"epp.example.com:8080"}, *got)
-	})
-
-	t.Run("endpoints mode", func(t *testing.T) {
-		c := newTestClusterEPP()
-		c.SubClusters[0].InstancePool.EPPServer = &EPPServer{
-			Endpoints: []*EPPEndpoint{
-				{IP: lib.PString("127.0.0.1"), Port: lib.PInt(9090)},
-			},
-		}
-		got := buildEPPAddrsFromSubClusters(c.SubClusters)
-		require.NotNil(t, got)
-		assert.Equal(t, []string{"127.0.0.1:9090"}, *got)
-	})
-
-	t.Run("empty", func(t *testing.T) {
-		assert.Nil(t, buildEPPAddrsFromSubClusters(nil))
 	})
 }
 

--- a/model/icluster_conf/epp.go
+++ b/model/icluster_conf/epp.go
@@ -1,0 +1,155 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package icluster_conf
+
+import (
+	"context"
+	"strings"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
+)
+
+const (
+	// BalanceModeWRR is the default cluster balance mode (BFE local WRR).
+	BalanceModeWRR = "WRR"
+	// BalanceModeEPP hands backend selection over to the EPP scheduler.
+	BalanceModeEPP = "EPP"
+)
+
+// EPPAssignmentResolver resolves the ordered EPP endpoint addresses of a
+// cluster's assignment ([0]=primary, [1]=standby). It is implemented by
+// epp_pool.EppPoolManager and injected at wiring time; the export path only
+// depends on this interface (dependency injection, no reverse reference).
+type EPPAssignmentResolver interface {
+	// GetAssignmentEndpoints returns [primary, standby] addresses joined by
+	// net.JoinHostPort (standby omitted for single instance groups).
+	// found is false when the cluster has no valid assignment.
+	GetAssignmentEndpoints(ctx context.Context, clusterName string) (endpoints []string, found bool, err error)
+}
+
+// validateClusterBalanceConfig validates the balance_mode/epp_config pair of
+// a cluster write (design-changes.md §2.3):
+//   - balance_mode is one of WRR/EPP (absent keeps oldMode, default WRR);
+//   - epp_config, whenever non-empty, is parsed strictly and field-validated,
+//     regardless of balance_mode (WRR hibernation keeps it validated);
+//   - balance_mode=EPP requires a non-empty, non-empty-object epp_config.
+//
+// It returns the effective balance mode and the effective raw epp_config JSON
+// (the carried value, or the stored one when not carried; hibernation
+// retention: fields not explicitly carried are not persisted).
+func validateClusterBalanceConfig(balanceMode *string, oldMode string, eppConfig *string, oldEppConfig string) (string, string, error) {
+	mode := oldMode
+	if mode == "" {
+		mode = BalanceModeWRR
+	}
+	if balanceMode != nil && *balanceMode != "" {
+		mode = *balanceMode
+	}
+	switch mode {
+	case BalanceModeWRR, BalanceModeEPP:
+	default:
+		return "", "", xerror.WrapParamErrorWithMsg("balance_mode must be one of %q/%q, got %q", BalanceModeWRR, BalanceModeEPP, mode)
+	}
+
+	raw := oldEppConfig
+	if eppConfig != nil {
+		raw = strings.TrimSpace(*eppConfig)
+	}
+
+	conf, err := epp_pool.ParseEppConfig(raw)
+	if err != nil {
+		return "", "", err
+	}
+	if conf != nil {
+		if err := conf.Validate(); err != nil {
+			return "", "", err
+		}
+	}
+
+	if mode == BalanceModeEPP && conf.IsEmpty() {
+		return "", "", xerror.WrapParamErrorWithMsg("epp_config is required when balance_mode is %q", BalanceModeEPP)
+	}
+
+	return mode, raw, nil
+}
+
+// assignClusterToEPP triggers the EPP assignment for the cluster. Assignment
+// failure never blocks the cluster write: it is logged at error level and the
+// periodic reconciler converges later (design-changes.md §2.3/§4.3).
+func (cm *ClusterManager) assignClusterToEPP(ctx context.Context, clusterName string) {
+	if cm.eppPoolManager == nil {
+		stateful.AccessLogger.Error("cluster %s is in EPP mode but epp pool manager is not configured, assignment deferred to reconciler", clusterName)
+		return
+	}
+
+	if err := cm.eppPoolManager.AssignCluster(ctx, clusterName); err != nil {
+		stateful.AccessLogger.Error("assign EPP cluster %s failed: %v (cluster write succeeds, reconciler will converge)", clusterName, err)
+	}
+}
+
+// FetchEPPClusters returns all clusters with balance_mode=EPP together with
+// their raw epp_config JSON. It implements epp_pool.EPPClusterSource and is
+// injected into EppPoolManager at wiring time.
+//
+// The cluster list is read straight from the storager without wrapping
+// AtomExecute: this is a pure read (no transaction needed) and one caller
+// runs inside the version-control export transaction (EppDataGenerator);
+// a nested AtomExecute there would reuse the enclosing DBContext and commit
+// the export transaction prematurely (errTxDone on the outer commit).
+func (cm *ClusterManager) FetchEPPClusters(ctx context.Context) ([]*epp_pool.EPPClusterInfo, error) {
+	clusters, err := cm.storager.FetchClusterList(ctx, &ClusterFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	rst := []*epp_pool.EPPClusterInfo{}
+	for _, cluster := range clusters {
+		if cluster.getBalanceMode() != BalanceModeEPP {
+			continue
+		}
+		rst = append(rst, &epp_pool.EPPClusterInfo{
+			Name:          cluster.Name,
+			EppConfigJSON: cluster.EppConfig,
+		})
+	}
+
+	return rst, nil
+}
+
+// fetchEPPAssignmentAddrs resolves the ordered EPP addresses of one cluster
+// for export. Degradation (design-changes.md §4.3/§5.1): when the cluster has
+// no valid assignment (or the lookup fails), the cluster is exported with
+// BalanceMode=WRR and without EPPAddr, and an error-level log carrying the
+// cluster name and the reason is emitted; the rest of the export proceeds.
+func fetchEPPAssignmentAddrs(ctx context.Context, resolver EPPAssignmentResolver, clusterName string) ([]string, bool) {
+	if resolver == nil {
+		stateful.AccessLogger.Error("export degrade: cluster %s balance_mode=EPP but EPP assignment resolver is not configured, export as WRR without EPPAddr", clusterName)
+		return nil, false
+	}
+
+	addrs, found, err := resolver.GetAssignmentEndpoints(ctx, clusterName)
+	if err != nil {
+		stateful.AccessLogger.Error("export degrade: cluster %s balance_mode=EPP but assignment lookup failed: %v, export as WRR without EPPAddr", clusterName, err)
+		return nil, false
+	}
+	if !found {
+		stateful.AccessLogger.Error("export degrade: cluster %s balance_mode=EPP but has no valid assignment, export as WRR without EPPAddr", clusterName)
+		return nil, false
+	}
+
+	return addrs, true
+}

--- a/model/icluster_conf/epp_test.go
+++ b/model/icluster_conf/epp_test.go
@@ -1,0 +1,520 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package icluster_conf
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/ibasic"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iprovider"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeEppPoolStorager struct {
+	fetchInstanceListFn   func(ctx context.Context, filter *epp_pool.InstanceFilter) ([]*epp_pool.InstanceParam, error)
+	createInstancesFn     func(ctx context.Context, params []*epp_pool.InstanceParam) (int64, error)
+	deleteInstancesFn     func(ctx context.Context, filter *epp_pool.InstanceFilter) (int64, error)
+	fetchAssignmentFn     func(ctx context.Context, cluster string) (*epp_pool.AssignmentParam, error)
+	fetchAssignmentListFn func(ctx context.Context) ([]*epp_pool.AssignmentParam, error)
+	upsertAssignmentFn    func(ctx context.Context, param *epp_pool.AssignmentParam) error
+	deleteAssignmentFn    func(ctx context.Context, cluster string) error
+}
+
+func (f *fakeEppPoolStorager) FetchInstanceList(ctx context.Context, filter *epp_pool.InstanceFilter) ([]*epp_pool.InstanceParam, error) {
+	if f.fetchInstanceListFn != nil {
+		return f.fetchInstanceListFn(ctx, filter)
+	}
+	return nil, nil
+}
+
+func (f *fakeEppPoolStorager) CreateInstances(ctx context.Context, params []*epp_pool.InstanceParam) (int64, error) {
+	if f.createInstancesFn != nil {
+		return f.createInstancesFn(ctx, params)
+	}
+	return 0, nil
+}
+
+func (f *fakeEppPoolStorager) DeleteInstances(ctx context.Context, filter *epp_pool.InstanceFilter) (int64, error) {
+	if f.deleteInstancesFn != nil {
+		return f.deleteInstancesFn(ctx, filter)
+	}
+	return 0, nil
+}
+
+func (f *fakeEppPoolStorager) FetchAssignment(ctx context.Context, cluster string) (*epp_pool.AssignmentParam, error) {
+	if f.fetchAssignmentFn != nil {
+		return f.fetchAssignmentFn(ctx, cluster)
+	}
+	return nil, nil
+}
+
+func (f *fakeEppPoolStorager) FetchAssignmentList(ctx context.Context) ([]*epp_pool.AssignmentParam, error) {
+	if f.fetchAssignmentListFn != nil {
+		return f.fetchAssignmentListFn(ctx)
+	}
+	return nil, nil
+}
+
+func (f *fakeEppPoolStorager) UpsertAssignment(ctx context.Context, param *epp_pool.AssignmentParam) error {
+	if f.upsertAssignmentFn != nil {
+		return f.upsertAssignmentFn(ctx, param)
+	}
+	return nil
+}
+
+func (f *fakeEppPoolStorager) DeleteAssignment(ctx context.Context, cluster string) error {
+	if f.deleteAssignmentFn != nil {
+		return f.deleteAssignmentFn(ctx, cluster)
+	}
+	return nil
+}
+
+// newFakeEppPoolManager builds an EppPoolManager (test validation mode) whose
+// assignment upserts are recorded in assigned.
+func newFakeEppPoolManager(assigned map[string]*epp_pool.AssignmentParam, storagerErr error) *epp_pool.EppPoolManager {
+	storager := &fakeEppPoolStorager{
+		fetchInstanceListFn: func(ctx context.Context, filter *epp_pool.InstanceFilter) ([]*epp_pool.InstanceParam, error) {
+			if storagerErr != nil {
+				return nil, storagerErr
+			}
+			return []*epp_pool.InstanceParam{
+				{ID: "epp-a", Host: "10.0.0.1", Port: 9002, GroupName: "g1"},
+			}, nil
+		},
+		fetchAssignmentListFn: func(ctx context.Context) ([]*epp_pool.AssignmentParam, error) {
+			if storagerErr != nil {
+				return nil, storagerErr
+			}
+			rst := []*epp_pool.AssignmentParam{}
+			for _, a := range assigned {
+				rst = append(rst, a)
+			}
+			return rst, nil
+		},
+		upsertAssignmentFn: func(ctx context.Context, param *epp_pool.AssignmentParam) error {
+			assigned[param.Cluster] = param
+			return storagerErr
+		},
+	}
+	return epp_pool.NewEppPoolManager(&fakeTxn{}, storager, nil, nil, &epp_pool.ManagerOptions{
+		ValidationMode: epp_pool.ValidationModeTest,
+	})
+}
+
+const validEppConfigJSON = `{"scheduling_profile":"balanced","kv_cache_utilization_max":0.9}`
+
+func TestValidateClusterBalanceConfig(t *testing.T) {
+	t.Run("default WRR without any input", func(t *testing.T) {
+		mode, raw, err := validateClusterBalanceConfig(nil, "", nil, "")
+		require.NoError(t, err)
+		assert.Equal(t, BalanceModeWRR, mode)
+		assert.Equal(t, "", raw)
+	})
+
+	t.Run("invalid balance_mode", func(t *testing.T) {
+		_, _, err := validateClusterBalanceConfig(lib.PString("ROUND_ROBIN"), "", nil, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "balance_mode must be one of")
+	})
+
+	t.Run("EPP requires epp_config", func(t *testing.T) {
+		for _, cfg := range []*string{nil, lib.PString(""), lib.PString("  "), lib.PString("{}")} {
+			_, _, err := validateClusterBalanceConfig(lib.PString(BalanceModeEPP), "", cfg, "")
+			require.Error(t, err, "cfg=%v", cfg)
+			assert.Contains(t, err.Error(), "epp_config is required")
+		}
+	})
+
+	t.Run("EPP with valid epp_config", func(t *testing.T) {
+		mode, raw, err := validateClusterBalanceConfig(lib.PString(BalanceModeEPP), "", lib.PString(validEppConfigJSON), "")
+		require.NoError(t, err)
+		assert.Equal(t, BalanceModeEPP, mode)
+		assert.Equal(t, validEppConfigJSON, raw)
+	})
+
+	t.Run("WRR accepts hibernated epp_config", func(t *testing.T) {
+		mode, raw, err := validateClusterBalanceConfig(nil, "", lib.PString(validEppConfigJSON), "")
+		require.NoError(t, err)
+		assert.Equal(t, BalanceModeWRR, mode)
+		assert.Equal(t, validEppConfigJSON, raw)
+	})
+
+	t.Run("non-empty epp_config validated regardless of balance_mode", func(t *testing.T) {
+		for _, cfg := range []string{
+			`{"scheduling_profile":"bogus"}`,
+			`{"cache_affinity":"extreme"}`,
+			`{"kv_cache_utilization_max":1.5}`,
+			`{"unknown_field":true}`,
+			`{"flow_control":{"queue_ttl":-1}}`,
+			`{"session_affinity_enabled":true}`,
+		} {
+			_, _, err := validateClusterBalanceConfig(nil, BalanceModeWRR, lib.PString(cfg), "")
+			require.Error(t, err, "cfg=%s", cfg)
+		}
+	})
+
+	t.Run("update keeps old mode and stored epp_config when not carried", func(t *testing.T) {
+		mode, raw, err := validateClusterBalanceConfig(nil, BalanceModeEPP, nil, validEppConfigJSON)
+		require.NoError(t, err)
+		assert.Equal(t, BalanceModeEPP, mode)
+		assert.Equal(t, validEppConfigJSON, raw)
+	})
+
+	t.Run("update to EPP reuses hibernated epp_config", func(t *testing.T) {
+		mode, raw, err := validateClusterBalanceConfig(lib.PString(BalanceModeEPP), BalanceModeWRR, nil, validEppConfigJSON)
+		require.NoError(t, err)
+		assert.Equal(t, BalanceModeEPP, mode)
+		assert.Equal(t, validEppConfigJSON, raw)
+	})
+
+	t.Run("carried epp_config is trimmed", func(t *testing.T) {
+		_, raw, err := validateClusterBalanceConfig(nil, "", lib.PString("  "+validEppConfigJSON+"  "), "")
+		require.NoError(t, err)
+		assert.Equal(t, validEppConfigJSON, raw)
+	})
+}
+
+func eppCreateClusterStores() (*fakeClusterStorager, *fakeSubClusterStorager, *fakePoolStorager, *fakeProviderStorager) {
+	clusterStore := &fakeClusterStorager{
+		fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+			return nil, nil
+		},
+		clusterCreateFn: func(ctx context.Context, product *ibasic.Product, param *ClusterParam, subClusters []*SubCluster) (int64, error) {
+			return 20, nil
+		},
+	}
+	subClusterStore := &fakeSubClusterStorager{
+		fetchSubClusterListFn: func(ctx context.Context, param *SubClusterFilter) ([]*SubCluster, error) {
+			return []*SubCluster{{ID: 2, Name: "c1", Ready: true}}, nil
+		},
+	}
+	poolStore := &fakePoolStorager{
+		fetchPoolFn: func(ctx context.Context, name string) (*Pool, error) {
+			return nil, nil
+		},
+	}
+	providerStore := &fakeProviderStorager{
+		fetchFn: func(ctx context.Context, filter *iprovider.ProviderFilter) (*iprovider.Provider, error) {
+			return &iprovider.Provider{
+				Name: "deepseek",
+				Models: []string{
+					"m1",
+				},
+				InstancePool: []iprovider.ProviderInstance{
+					{Addr: "5.6.7.8", Port: 443, Weight: 100},
+				},
+			}, nil
+		},
+	}
+	return clusterStore, subClusterStore, poolStore, providerStore
+}
+
+func TestClusterManager_CreateCluster_EPP(t *testing.T) {
+	ctx := context.Background()
+	product := &ibasic.Product{ID: 2, Name: "test"}
+	bfeClusterStore := &fakeBFEClusterStorager{
+		fetchBFEClustersFn: func(ctx context.Context, param *ibasic.BFEClusterFilter) ([]*ibasic.BFECluster, error) {
+			return []*ibasic.BFECluster{{Name: stateful.DefaultConfig.RunTime.DefaultAIClusterName}}, nil
+		},
+	}
+	llmConfig := func() *LLMConfig {
+		return &LLMConfig{Provider: lib.PString("deepseek"), Models: []string{"m1"}}
+	}
+
+	t.Run("EPP creates Role=EPP pool with provider instances synced and assigns", func(t *testing.T) {
+		clusterStore, subClusterStore, poolStore, providerStore := eppCreateClusterStores()
+		poolCreated := false
+		clusterWritten := false
+		poolStore.createPoolFn = func(ctx context.Context, product *ibasic.Product, data *PoolParam) (*Pool, error) {
+			poolCreated = true
+			require.NotNil(t, data.Role)
+			assert.Equal(t, ProductPoolRoleEPP, *data.Role)
+			require.Len(t, data.Instances, 1)
+			assert.Equal(t, "5.6.7.8", data.Instances[0].Addr)
+			return &Pool{ID: 1, Name: *data.Name, Role: *data.Role, Instances: data.Instances}, nil
+		}
+		clusterStore.clusterCreateFn = func(ctx context.Context, product *ibasic.Product, param *ClusterParam, subClusters []*SubCluster) (int64, error) {
+			clusterWritten = true
+			require.NotNil(t, param.BalanceMode)
+			assert.Equal(t, BalanceModeEPP, *param.BalanceMode)
+			require.NotNil(t, param.EppConfig)
+			assert.Equal(t, validEppConfigJSON, *param.EppConfig)
+			return 20, nil
+		}
+
+		assigned := map[string]*epp_pool.AssignmentParam{}
+		m := NewClusterManager(&fakeTxn{}, clusterStore, subClusterStore, bfeClusterStore, poolStore, providerStore, nil, nil, nil)
+		m.SetEppPoolManager(newFakeEppPoolManager(assigned, nil))
+
+		err := m.CreateCluster(ctx, product, &ClusterParam{
+			Name:        lib.PString("c1"),
+			BalanceMode: lib.PString(BalanceModeEPP),
+			EppConfig:   lib.PString(validEppConfigJSON),
+			LLMConfig:   llmConfig(),
+		})
+		require.NoError(t, err)
+		assert.True(t, poolCreated)
+		assert.True(t, clusterWritten)
+		require.Contains(t, assigned, "c1")
+		assert.Equal(t, "g1", assigned["c1"].GroupName)
+	})
+
+	t.Run("WRR keeps COMMON pool with provider instances", func(t *testing.T) {
+		clusterStore, subClusterStore, poolStore, providerStore := eppCreateClusterStores()
+		poolStore.createPoolFn = func(ctx context.Context, product *ibasic.Product, data *PoolParam) (*Pool, error) {
+			require.NotNil(t, data.Role)
+			assert.Equal(t, ProductPoolRoleCommon, *data.Role)
+			require.Len(t, data.Instances, 1)
+			return &Pool{ID: 1, Name: *data.Name, Role: *data.Role}, nil
+		}
+
+		m := NewClusterManager(&fakeTxn{}, clusterStore, subClusterStore, bfeClusterStore, poolStore, providerStore, nil, nil, nil)
+		err := m.CreateCluster(ctx, product, &ClusterParam{
+			Name:      lib.PString("c1"),
+			LLMConfig: llmConfig(),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("EPP without epp_config rejected", func(t *testing.T) {
+		clusterStore, subClusterStore, poolStore, providerStore := eppCreateClusterStores()
+		m := NewClusterManager(&fakeTxn{}, clusterStore, subClusterStore, bfeClusterStore, poolStore, providerStore, nil, nil, nil)
+		err := m.CreateCluster(ctx, product, &ClusterParam{
+			Name:        lib.PString("c1"),
+			BalanceMode: lib.PString(BalanceModeEPP),
+			LLMConfig:   llmConfig(),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "epp_config is required")
+	})
+
+	t.Run("WRR with invalid epp_config rejected", func(t *testing.T) {
+		clusterStore, subClusterStore, poolStore, providerStore := eppCreateClusterStores()
+		m := NewClusterManager(&fakeTxn{}, clusterStore, subClusterStore, bfeClusterStore, poolStore, providerStore, nil, nil, nil)
+		err := m.CreateCluster(ctx, product, &ClusterParam{
+			Name:      lib.PString("c1"),
+			EppConfig: lib.PString(`{"scheduling_profile":"bogus"}`),
+			LLMConfig: llmConfig(),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scheduling_profile")
+	})
+
+	t.Run("assignment failure does not block create", func(t *testing.T) {
+		clusterStore, subClusterStore, poolStore, providerStore := eppCreateClusterStores()
+		poolStore.createPoolFn = func(ctx context.Context, product *ibasic.Product, data *PoolParam) (*Pool, error) {
+			return &Pool{ID: 1, Name: *data.Name, Role: *data.Role}, nil
+		}
+
+		assigned := map[string]*epp_pool.AssignmentParam{}
+		m := NewClusterManager(&fakeTxn{}, clusterStore, subClusterStore, bfeClusterStore, poolStore, providerStore, nil, nil, nil)
+		m.SetEppPoolManager(newFakeEppPoolManager(assigned, errors.New("epp storage down")))
+
+		err := m.CreateCluster(ctx, product, &ClusterParam{
+			Name:        lib.PString("c1"),
+			BalanceMode: lib.PString(BalanceModeEPP),
+			EppConfig:   lib.PString(validEppConfigJSON),
+			LLMConfig:   llmConfig(),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, assigned)
+	})
+}
+
+func TestClusterManager_UpdateCluster_EPP(t *testing.T) {
+	ctx := context.Background()
+	product := &ibasic.Product{ID: 2, Name: "test"}
+
+	wrrCluster := func() *Cluster {
+		c := newTestClusterBase()
+		c.ID = 1
+		return c
+	}
+
+	t.Run("WRR to EPP assigns after successful write", func(t *testing.T) {
+		assigned := map[string]*epp_pool.AssignmentParam{}
+		updated := false
+		clusterStore := &fakeClusterStorager{
+			clusterUpdateFn: func(ctx context.Context, product *ibasic.Product, old *Cluster, param *ClusterParam) error {
+				updated = true
+				require.NotNil(t, param.BalanceMode)
+				assert.Equal(t, BalanceModeEPP, *param.BalanceMode)
+				require.NotNil(t, param.EppConfig)
+				assert.Equal(t, validEppConfigJSON, *param.EppConfig)
+				return nil
+			},
+		}
+		m := NewClusterManager(&fakeTxn{}, clusterStore, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
+		m.SetEppPoolManager(newFakeEppPoolManager(assigned, nil))
+
+		err := m.UpdateCluster(ctx, product, wrrCluster(), &ClusterParam{
+			Name:        lib.PString("c1"),
+			BalanceMode: lib.PString(BalanceModeEPP),
+			EppConfig:   lib.PString(validEppConfigJSON),
+		})
+		require.NoError(t, err)
+		assert.True(t, updated)
+		require.Contains(t, assigned, "c1")
+	})
+
+	t.Run("WRR to EPP without epp_config rejected", func(t *testing.T) {
+		m := NewClusterManager(&fakeTxn{}, &fakeClusterStorager{}, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
+		err := m.UpdateCluster(ctx, product, wrrCluster(), &ClusterParam{
+			Name:        lib.PString("c1"),
+			BalanceMode: lib.PString(BalanceModeEPP),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "epp_config is required")
+	})
+
+	t.Run("WRR to EPP reuses hibernated epp_config", func(t *testing.T) {
+		assigned := map[string]*epp_pool.AssignmentParam{}
+		old := wrrCluster()
+		old.EppConfig = validEppConfigJSON
+		clusterStore := &fakeClusterStorager{
+			clusterUpdateFn: func(ctx context.Context, product *ibasic.Product, old *Cluster, param *ClusterParam) error {
+				assert.Nil(t, param.EppConfig) // not carried: stored value retained
+				return nil
+			},
+		}
+		m := NewClusterManager(&fakeTxn{}, clusterStore, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
+		m.SetEppPoolManager(newFakeEppPoolManager(assigned, nil))
+
+		err := m.UpdateCluster(ctx, product, old, &ClusterParam{
+			Name:        lib.PString("c1"),
+			BalanceMode: lib.PString(BalanceModeEPP),
+		})
+		require.NoError(t, err)
+		require.Contains(t, assigned, "c1")
+	})
+
+	t.Run("assignment failure does not block update", func(t *testing.T) {
+		assigned := map[string]*epp_pool.AssignmentParam{}
+		updated := false
+		clusterStore := &fakeClusterStorager{
+			clusterUpdateFn: func(ctx context.Context, product *ibasic.Product, old *Cluster, param *ClusterParam) error {
+				updated = true
+				return nil
+			},
+		}
+		m := NewClusterManager(&fakeTxn{}, clusterStore, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
+		m.SetEppPoolManager(newFakeEppPoolManager(assigned, errors.New("epp storage down")))
+
+		err := m.UpdateCluster(ctx, product, wrrCluster(), &ClusterParam{
+			Name:        lib.PString("c1"),
+			BalanceMode: lib.PString(BalanceModeEPP),
+			EppConfig:   lib.PString(validEppConfigJSON),
+		})
+		require.NoError(t, err)
+		assert.True(t, updated)
+		assert.Empty(t, assigned)
+	})
+
+	t.Run("EPP to WRR keeps config dormant and does not assign", func(t *testing.T) {
+		assigned := map[string]*epp_pool.AssignmentParam{}
+		old := wrrCluster()
+		old.BalanceMode = BalanceModeEPP
+		old.EppConfig = validEppConfigJSON
+		clusterStore := &fakeClusterStorager{
+			clusterUpdateFn: func(ctx context.Context, product *ibasic.Product, old *Cluster, param *ClusterParam) error {
+				require.NotNil(t, param.BalanceMode)
+				assert.Equal(t, BalanceModeWRR, *param.BalanceMode)
+				assert.Nil(t, param.EppConfig) // dormant retention: not carried, not written
+				return nil
+			},
+		}
+		m := NewClusterManager(&fakeTxn{}, clusterStore, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
+		m.SetEppPoolManager(newFakeEppPoolManager(assigned, nil))
+
+		err := m.UpdateCluster(ctx, product, old, &ClusterParam{
+			Name:        lib.PString("c1"),
+			BalanceMode: lib.PString(BalanceModeWRR),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, assigned)
+	})
+
+	t.Run("EPP to WRR still validates carried epp_config", func(t *testing.T) {
+		old := wrrCluster()
+		old.BalanceMode = BalanceModeEPP
+		m := NewClusterManager(&fakeTxn{}, &fakeClusterStorager{}, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
+		err := m.UpdateCluster(ctx, product, old, &ClusterParam{
+			Name:        lib.PString("c1"),
+			BalanceMode: lib.PString(BalanceModeWRR),
+			EppConfig:   lib.PString(`{"kv_cache_utilization_max":2}`),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "kv_cache_utilization_max")
+	})
+}
+
+func TestClusterManager_FetchEPPClusters(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("filters EPP clusters with raw epp_config", func(t *testing.T) {
+		eppCluster := newTestClusterEPP()
+		eppCluster.Name = "c-epp"
+		wrrCluster := newTestClusterBase()
+		wrrCluster.Name = "c-wrr"
+		wrrCluster.EppConfig = validEppConfigJSON
+		clusterStore := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				return []*Cluster{eppCluster, wrrCluster}, nil
+			},
+		}
+		m := NewClusterManager(&fakeTxn{}, clusterStore, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
+
+		got, err := m.FetchEPPClusters(ctx)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "c-epp", got[0].Name)
+		assert.Equal(t, eppCluster.EppConfig, got[0].EppConfigJSON)
+	})
+
+	t.Run("storager error propagates", func(t *testing.T) {
+		clusterStore := &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *ClusterFilter) ([]*Cluster, error) {
+				return nil, errors.New("db down")
+			},
+		}
+		m := NewClusterManager(&fakeTxn{}, clusterStore, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
+		_, err := m.FetchEPPClusters(ctx)
+		require.Error(t, err)
+	})
+}
+
+func TestClusterManager_assignClusterToEPP(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil manager logs and returns", func(t *testing.T) {
+		m := NewClusterManager(&fakeTxn{}, &fakeClusterStorager{}, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
+		// Must not panic; the assignment is deferred to the reconciler.
+		m.assignClusterToEPP(ctx, "c1")
+	})
+
+	t.Run("manager error does not panic", func(t *testing.T) {
+		assigned := map[string]*epp_pool.AssignmentParam{}
+		m := NewClusterManager(&fakeTxn{}, &fakeClusterStorager{}, &fakeSubClusterStorager{}, &fakeBFEClusterStorager{}, &fakePoolStorager{}, nil, nil, nil, nil)
+		m.SetEppPoolManager(newFakeEppPoolManager(assigned, errors.New("epp storage down")))
+		m.assignClusterToEPP(ctx, "c1")
+		assert.Empty(t, assigned)
+	})
+}

--- a/model/icluster_conf/mocks_test.go
+++ b/model/icluster_conf/mocks_test.go
@@ -508,3 +508,14 @@ func (f *fakeQuotaBalanceStorager) DeleteQuotaBalance(ctx context.Context, quota
 }
 
 var fixedTestTime = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+type fakeEPPAssignmentResolver struct {
+	endpointsFn func(ctx context.Context, clusterName string) ([]string, bool, error)
+}
+
+func (f *fakeEPPAssignmentResolver) GetAssignmentEndpoints(ctx context.Context, clusterName string) ([]string, bool, error) {
+	if f.endpointsFn != nil {
+		return f.endpointsFn(ctx, clusterName)
+	}
+	return nil, false, nil
+}

--- a/model/iroute_conf/exporter.go
+++ b/model/iroute_conf/exporter.go
@@ -156,7 +156,7 @@ func (rm *RouteRuleManager) exportRouteRule(ctx context.Context) (*iversion_cont
 		Version:     emptyVersion,
 		RouteTable:  newRouteTableFile(emptyVersion, productMapID2Name, routeRules),
 		HostTable:   newHostTableConf(emptyVersion, productMapID2Name, domains),
-		ClusterConf: icluster_conf.NewBfeClusterConf(emptyVersion, clusters, providerModelTable, providerKeyTable, providerProtocolTable, providerPricingTable),
+		ClusterConf: icluster_conf.NewBfeClusterConf(ctx, emptyVersion, clusters, providerModelTable, providerKeyTable, providerProtocolTable, providerPricingTable, rm.eppAssignmentResolver),
 	}
 
 	return &iversion_control.ExportData{

--- a/model/iroute_conf/exporter_test.go
+++ b/model/iroute_conf/exporter_test.go
@@ -117,6 +117,55 @@ func TestRouteRuleManager_exportRouteRule(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "Domain refer Not Exist Product 1")
 	})
+
+	t.Run("EPP cluster exports ordered EPPAddr from assignment", func(t *testing.T) {
+		rm := newManagerForExport(t, "20240102000000")
+		rm.SetEPPAssignmentResolver(&fakeEPPAssignmentResolver{
+			endpointsFn: func(ctx context.Context, clusterName string) ([]string, bool, error) {
+				return []string{"10.0.0.1:9002", "10.0.0.2:9002"}, true, nil
+			},
+		})
+		rm.clusterStorager = &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+				c := newTestCluster()
+				c.BalanceMode = icluster_conf.BalanceModeEPP
+				return []*icluster_conf.Cluster{c}, nil
+			},
+		}
+
+		ed, err := rm.exportRouteRule(ctx)
+		require.NoError(t, err)
+		data := ed.DataWithoutVersion.(*RouteRuleExportData)
+		cConf := (*data.ClusterConf.Config)["c1"]
+		require.NotNil(t, cConf.GslbBasic.EPPAddr)
+		assert.Equal(t, []string{"10.0.0.1:9002", "10.0.0.2:9002"}, *cConf.GslbBasic.EPPAddr)
+		require.NotNil(t, cConf.GslbBasic.BalanceMode)
+		assert.Equal(t, icluster_conf.BalanceModeEPP, *cConf.GslbBasic.BalanceMode)
+	})
+
+	t.Run("EPP cluster without assignment degrades to WRR without failing export", func(t *testing.T) {
+		rm := newManagerForExport(t, "20240102000000")
+		rm.SetEPPAssignmentResolver(&fakeEPPAssignmentResolver{
+			endpointsFn: func(ctx context.Context, clusterName string) ([]string, bool, error) {
+				return nil, false, nil
+			},
+		})
+		rm.clusterStorager = &fakeClusterStorager{
+			fetchClusterListFn: func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+				c := newTestCluster()
+				c.BalanceMode = icluster_conf.BalanceModeEPP
+				return []*icluster_conf.Cluster{c}, nil
+			},
+		}
+
+		ed, err := rm.exportRouteRule(ctx)
+		require.NoError(t, err)
+		data := ed.DataWithoutVersion.(*RouteRuleExportData)
+		cConf := (*data.ClusterConf.Config)["c1"]
+		assert.Nil(t, cConf.GslbBasic.EPPAddr)
+		require.NotNil(t, cConf.GslbBasic.BalanceMode)
+		assert.Equal(t, icluster_conf.BalanceModeWRR, *cConf.GslbBasic.BalanceMode)
+	})
 }
 
 func newTestCluster() *icluster_conf.Cluster {

--- a/model/iroute_conf/mocks_test.go
+++ b/model/iroute_conf/mocks_test.go
@@ -186,3 +186,14 @@ func (f *fakeVersionControlStorager) UpsertConfigLastExportedVersion(ctx context
 	}
 	return "", nil
 }
+
+type fakeEPPAssignmentResolver struct {
+	endpointsFn func(ctx context.Context, clusterName string) ([]string, bool, error)
+}
+
+func (f *fakeEPPAssignmentResolver) GetAssignmentEndpoints(ctx context.Context, clusterName string) ([]string, bool, error) {
+	if f.endpointsFn != nil {
+		return f.endpointsFn(ctx, clusterName)
+	}
+	return nil, false, nil
+}

--- a/model/iroute_conf/route_rule.go
+++ b/model/iroute_conf/route_rule.go
@@ -195,6 +195,15 @@ type RouteRuleManager struct {
 	modelPriceStorager    imodel_price.ModelPriceStorager
 	providerStorager      iprovider.ProviderStorager
 	operationLogManager   ioperlog.OperationLogRecorder
+	eppAssignmentResolver icluster_conf.EPPAssignmentResolver
+}
+
+// SetEPPAssignmentResolver sets the optional resolver used to generate
+// assignment-driven ordered EPPAddr entries when exporting cluster conf.
+// Clusters in EPP mode without a valid assignment degrade to WRR export
+// with an error-level log (design-changes.md §4.3).
+func (rm *RouteRuleManager) SetEPPAssignmentResolver(resolver icluster_conf.EPPAssignmentResolver) {
+	rm.eppAssignmentResolver = resolver
 }
 
 // SetModelPriceStorager sets the optional model price storager used to enrich

--- a/stateful/config.go
+++ b/stateful/config.go
@@ -54,6 +54,11 @@ type RunTimeConfig struct {
 	AIRouteInnerProductName   string // AI inner product name,default AI_product
 	DefaultAIInstancePoolName string // default AI instance pool name, e.g. "BFE.aipool"
 	DefaultAIClusterName      string // default AI cluster name, e.g. "BFE-AI_product.szyf"
+
+	// EPP scheduling integration (see model/epp_pool).
+	DefaultEPPInstancePoolName  string // default EPP instance pool name, e.g. "EPP.pool"
+	EPPValidationMode           string // epp pool group size check: "production" (default, exactly 2 per group) / "test" (>=1)
+	EPPReconcileIntervalSeconds int    // assignment reconciler period in seconds, default 30
 }
 
 type Config struct {

--- a/stateful/container/components.go
+++ b/stateful/container/components.go
@@ -30,6 +30,7 @@ package container
 
 import (
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/api_key"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iai_route"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iauth"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ibasic"
@@ -114,4 +115,8 @@ var (
 	// Operation logs
 	OperationLogStorager ioperlog.OperationLogStorager
 	OperationLogManager  ioperlog.OperationLogManagerInterface
+
+	// EPP scheduling integration (see model/epp_pool and design-docs
+	// modifications/2026-09-08-epp-scheduling-integration).
+	EppPoolManager *epp_pool.EppPoolManager
 )

--- a/stateful/container/rdb/components.go
+++ b/stateful/container/rdb/components.go
@@ -30,9 +30,11 @@ package rdb
 
 import (
 	"context"
+	"time"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xreq"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/api_key"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iai_route"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iauth"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/ibasic"
@@ -64,6 +66,7 @@ import (
 	rateLimitPolicyStorage "github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/rate_limit_policy"
 	"github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/route_conf"
 	routeRulesStorage "github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/route_rules"
+	eppPoolStorage "github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/epp_pool"
 	"github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/txn"
 	"github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/version_control"
 
@@ -189,6 +192,24 @@ func Init() error {
 			"route_rules": container.RouteRulesManager.ClusterModelUpdateChecker,
 		})
 	container.ClusterManager.SetOperationLogManager(container.OperationLogManager)
+
+	// EPP pool manager: the cluster manager provides the EPPClusterSource
+	// (balance_mode=EPP clusters and their raw epp_config); ManagerOptions are
+	// read from the RunTime config. The reconciler lifecycle follows the
+	// process lifecycle like QuotaResetScheduler (design-changes.md §4.3).
+	container.EppPoolManager = epp_pool.NewEppPoolManager(
+		container.TxnStoragerSingleton,
+		eppPoolStorage.NewEppPoolStorager(stateful.NewBFEDBContext),
+		container.ClusterManager,
+		container.VersionControlManager,
+		&epp_pool.ManagerOptions{
+			PoolName:          stateful.DefaultConfig.RunTime.DefaultEPPInstancePoolName,
+			ValidationMode:    stateful.DefaultConfig.RunTime.EPPValidationMode,
+			ReconcileInterval: time.Duration(stateful.DefaultConfig.RunTime.EPPReconcileIntervalSeconds) * time.Second,
+		})
+	container.ClusterManager.SetEppPoolManager(container.EppPoolManager)
+	container.RouteRuleManager.SetEPPAssignmentResolver(container.EppPoolManager)
+	container.EppPoolManager.StartReconciler()
 
 	container.SubClusterManager = icluster_conf.NewSubClusterManager(
 		container.TxnStoragerSingleton,

--- a/storage/rdb/cluster_conf/cluster.go
+++ b/storage/rdb/cluster_conf/cluster.go
@@ -301,6 +301,9 @@ func newCluster(dc *dao.TCluster, subClusters []*icluster_conf.SubCluster, capac
 			Statuscode: dc.HealthcheckStatuscode,
 		},
 
+		BalanceMode: dc.BalanceMode,
+		EppConfig:   dc.EppConfig,
+
 		SubClusters: subClusters,
 	}
 
@@ -342,6 +345,9 @@ func newDaoClusterParam(param *icluster_conf.ClusterParam) *dao.TClusterParam {
 		Name:        param.Name,
 		ProductID:   param.ProductID,
 		Description: param.Description,
+
+		BalanceMode: param.BalanceMode,
+		EppConfig:   param.EppConfig,
 	}
 
 	if basic := param.Basic; basic != nil {

--- a/storage/rdb/cluster_conf/cluster_test.go
+++ b/storage/rdb/cluster_conf/cluster_test.go
@@ -1,0 +1,185 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package cluster_conf
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/ibasic"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/icluster_conf"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testClustersSchema = `
+CREATE TABLE clusters (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT 'no desc',
+  product_id INTEGER NOT NULL,
+  protocol TEXT NOT NULL DEFAULT 'http',
+  max_idle_conn_per_host INTEGER NOT NULL DEFAULT 2,
+  timeout_conn_serv INTEGER NOT NULL DEFAULT 50000,
+  timeout_response_header INTEGER NOT NULL DEFAULT 50000,
+  timeout_readbody_client INTEGER NOT NULL DEFAULT 30000,
+  timeout_read_client_again INTEGER NOT NULL DEFAULT 30000,
+  timeout_write_client INTEGER NOT NULL DEFAULT 60000,
+  healthcheck_schem TEXT NOT NULL DEFAULT 'http',
+  healthcheck_interval INTEGER NOT NULL DEFAULT 1000,
+  healthcheck_failnum INTEGER NOT NULL DEFAULT 10,
+  healthcheck_host TEXT NOT NULL DEFAULT '',
+  healthcheck_uri TEXT NOT NULL DEFAULT '/',
+  healthcheck_statuscode INTEGER NOT NULL DEFAULT 200,
+  clientip_carry INTEGER NOT NULL DEFAULT 0,
+  port_carry INTEGER NOT NULL DEFAULT 0,
+  max_retry_in_cluster INTEGER NOT NULL DEFAULT 3,
+  max_retry_cross_cluster INTEGER NOT NULL DEFAULT 0,
+  ready INTEGER NOT NULL DEFAULT 1,
+  hash_strategy INTEGER NOT NULL DEFAULT 0,
+  cookie_key TEXT NOT NULL DEFAULT 'BAIDUID',
+  hash_header TEXT NOT NULL DEFAULT 'Cookie:BAIDUID',
+  session_sticky INTEGER NOT NULL DEFAULT 0,
+  req_write_buffer_size INTEGER NOT NULL DEFAULT 512,
+  req_flush_interval INTEGER NOT NULL DEFAULT 0,
+  res_flush_interval INTEGER NOT NULL DEFAULT 20,
+  cancel_on_client_close INTEGER NOT NULL DEFAULT 0,
+  failure_status INTEGER NOT NULL DEFAULT 0,
+  max_conns_per_host INTEGER NOT NULL DEFAULT 0,
+  llm_config TEXT,
+  balance_mode TEXT NOT NULL DEFAULT 'WRR',
+  epp_config TEXT,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (name)
+);
+CREATE TABLE lb_matrices (
+  cluster_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  lb_matrix TEXT NOT NULL,
+  product_id INTEGER NOT NULL,
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);`
+
+type fakeSubClusterStorager struct{}
+
+func (f *fakeSubClusterStorager) FetchSubClusterList(ctx context.Context, param *icluster_conf.SubClusterFilter) ([]*icluster_conf.SubCluster, error) {
+	return nil, nil
+}
+
+func (f *fakeSubClusterStorager) CreateSubCluster(ctx context.Context, param *icluster_conf.SubClusterParam) error {
+	return nil
+}
+
+func (f *fakeSubClusterStorager) DeleteSubCluster(ctx context.Context, param *icluster_conf.SubCluster) error {
+	return nil
+}
+
+func (f *fakeSubClusterStorager) UpdateSubCluster(ctx context.Context, one *icluster_conf.SubCluster, param *icluster_conf.SubClusterParam) error {
+	return nil
+}
+
+func setupTestClusterStorager(t *testing.T) *RDBClusterStorager {
+	if stateful.DefaultConfig == nil {
+		stateful.DefaultConfig = &stateful.Config{}
+	}
+
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(testClustersSchema)
+	require.NoError(t, err)
+
+	factory := lib.DBContextFactory(func(ctx context.Context, ops ...*lib.Op) (*lib.DBContext, error) {
+		return lib.NewDBContext(ctx, db), nil
+	})
+
+	return NewRDBClusterStorager(factory, &fakeSubClusterStorager{})
+}
+
+func TestRDBClusterStorager_BalanceModeEppConfig(t *testing.T) {
+	ctx := context.Background()
+	product := &ibasic.Product{ID: 2, Name: "test"}
+	s := setupTestClusterStorager(t)
+
+	t.Run("create with EPP mode and epp_config round-trips", func(t *testing.T) {
+		eppConfig := `{"scheduling_profile":"balanced"}`
+		id, err := s.ClusterCreate(ctx, product, &icluster_conf.ClusterParam{
+			Name:        lib.PString("c-epp"),
+			ProductID:   lib.PInt64(product.ID),
+			BalanceMode: lib.PString(icluster_conf.BalanceModeEPP),
+			EppConfig:   lib.PString(eppConfig),
+		}, nil)
+		require.NoError(t, err)
+
+		cluster, err := s.FetchCluster(ctx, &icluster_conf.ClusterFilter{Name: lib.PString("c-epp")})
+		require.NoError(t, err)
+		require.NotNil(t, cluster)
+		assert.Equal(t, id, cluster.ID)
+		assert.Equal(t, icluster_conf.BalanceModeEPP, cluster.BalanceMode)
+		assert.Equal(t, eppConfig, cluster.EppConfig)
+	})
+
+	t.Run("create without fields defaults to WRR and empty config", func(t *testing.T) {
+		_, err := s.ClusterCreate(ctx, product, &icluster_conf.ClusterParam{
+			Name:      lib.PString("c-wrr"),
+			ProductID: lib.PInt64(product.ID),
+		}, nil)
+		require.NoError(t, err)
+
+		cluster, err := s.FetchCluster(ctx, &icluster_conf.ClusterFilter{Name: lib.PString("c-wrr")})
+		require.NoError(t, err)
+		require.NotNil(t, cluster)
+		assert.Equal(t, icluster_conf.BalanceModeWRR, cluster.BalanceMode)
+		assert.Equal(t, "", cluster.EppConfig)
+	})
+
+	t.Run("update without carrying fields retains stored values", func(t *testing.T) {
+		cluster, err := s.FetchCluster(ctx, &icluster_conf.ClusterFilter{Name: lib.PString("c-epp")})
+		require.NoError(t, err)
+		require.NotNil(t, cluster)
+
+		// EPP -> WRR with neither balance_mode nor epp_config carried: the row
+		// keeps its stored values (dormant retention).
+		require.NoError(t, s.ClusterUpdate(ctx, product, cluster, &icluster_conf.ClusterParam{}))
+
+		updated, err := s.FetchCluster(ctx, &icluster_conf.ClusterFilter{Name: lib.PString("c-epp")})
+		require.NoError(t, err)
+		assert.Equal(t, icluster_conf.BalanceModeEPP, updated.BalanceMode)
+		assert.NotEmpty(t, updated.EppConfig)
+	})
+
+	t.Run("update carrying fields overwrites them", func(t *testing.T) {
+		cluster, err := s.FetchCluster(ctx, &icluster_conf.ClusterFilter{Name: lib.PString("c-epp")})
+		require.NoError(t, err)
+		require.NotNil(t, cluster)
+
+		require.NoError(t, s.ClusterUpdate(ctx, product, cluster, &icluster_conf.ClusterParam{
+			BalanceMode: lib.PString(icluster_conf.BalanceModeWRR),
+			EppConfig:   lib.PString(`{"scheduling_profile":"latency-first"}`),
+		}))
+
+		updated, err := s.FetchCluster(ctx, &icluster_conf.ClusterFilter{Name: lib.PString("c-epp")})
+		require.NoError(t, err)
+		assert.Equal(t, icluster_conf.BalanceModeWRR, updated.BalanceMode)
+		assert.Equal(t, `{"scheduling_profile":"latency-first"}`, updated.EppConfig)
+	})
+}

--- a/storage/rdb/epp_pool/epp_pool.go
+++ b/storage/rdb/epp_pool/epp_pool.go
@@ -1,0 +1,222 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+// Package epp_pool implements model/epp_pool.EppPoolStorager on top of the
+// relational DAO layer (MySQL/SQLite).
+package epp_pool
+
+import (
+	"context"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
+	"github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/internal/dao"
+)
+
+// EppPoolStorager implements epp_pool.EppPoolStorager using RDB.
+type EppPoolStorager struct {
+	dbCtxFactory lib.DBContextFactory
+}
+
+var _ epp_pool.EppPoolStorager = &EppPoolStorager{}
+
+// NewEppPoolStorager creates a new RDB-backed epp pool storager.
+func NewEppPoolStorager(dbCtxFactory lib.DBContextFactory) *EppPoolStorager {
+	return &EppPoolStorager{
+		dbCtxFactory: dbCtxFactory,
+	}
+}
+
+func (s *EppPoolStorager) FetchInstanceList(ctx context.Context, filter *epp_pool.InstanceFilter) ([]*epp_pool.InstanceParam, error) {
+	dbCtx, err := s.dbCtxFactory(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	orderBy := "group_name, id"
+	list, err := dao.TEppInstanceList(dbCtx, &dao.TEppInstanceParam{
+		ID:        instanceFilterID(filter),
+		GroupName: instanceFilterGroupName(filter),
+		OrderBy:   &orderBy,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	rst := make([]*epp_pool.InstanceParam, 0, len(list))
+	for _, one := range list {
+		rst = append(rst, eppInstanceToParam(one))
+	}
+	return rst, nil
+}
+
+func (s *EppPoolStorager) CreateInstances(ctx context.Context, params []*epp_pool.InstanceParam) (int64, error) {
+	if len(params) == 0 {
+		return 0, nil
+	}
+
+	dbCtx, err := s.dbCtxFactory(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	data := make([]*dao.TEppInstanceParam, 0, len(params))
+	for _, param := range params {
+		data = append(data, eppInstanceToDAO(param))
+	}
+
+	return dao.TEppInstanceCreate(dbCtx, data...)
+}
+
+func (s *EppPoolStorager) DeleteInstances(ctx context.Context, filter *epp_pool.InstanceFilter) (int64, error) {
+	dbCtx, err := s.dbCtxFactory(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return dao.TEppInstanceDelete(dbCtx, &dao.TEppInstanceParam{
+		ID:        instanceFilterID(filter),
+		GroupName: instanceFilterGroupName(filter),
+	})
+}
+
+func (s *EppPoolStorager) FetchAssignment(ctx context.Context, cluster string) (*epp_pool.AssignmentParam, error) {
+	dbCtx, err := s.dbCtxFactory(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	one, err := dao.TEppAssignmentOne(dbCtx, &dao.TEppAssignmentParam{Cluster: &cluster})
+	if err != nil {
+		return nil, err
+	}
+	if one == nil {
+		return nil, nil
+	}
+
+	return eppAssignmentToParam(one), nil
+}
+
+func (s *EppPoolStorager) FetchAssignmentList(ctx context.Context) ([]*epp_pool.AssignmentParam, error) {
+	dbCtx, err := s.dbCtxFactory(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	orderBy := "cluster"
+	list, err := dao.TEppAssignmentList(dbCtx, &dao.TEppAssignmentParam{OrderBy: &orderBy})
+	if err != nil {
+		return nil, err
+	}
+
+	rst := make([]*epp_pool.AssignmentParam, 0, len(list))
+	for _, one := range list {
+		rst = append(rst, eppAssignmentToParam(one))
+	}
+	return rst, nil
+}
+
+// UpsertAssignment inserts or replaces the assignment of one cluster:
+// update first, insert when no row exists; a unique-key conflict (concurrent
+// insert) is resolved by one retry of the update path.
+func (s *EppPoolStorager) UpsertAssignment(ctx context.Context, param *epp_pool.AssignmentParam) error {
+	if param == nil || param.Cluster == "" {
+		return xerror.WrapParamErrorWithMsg("epp assignment cluster is empty")
+	}
+
+	dbCtx, err := s.dbCtxFactory(ctx)
+	if err != nil {
+		return err
+	}
+
+	val := &dao.TEppAssignmentParam{
+		GroupName:         &param.GroupName,
+		PrimaryInstanceID: &param.PrimaryInstanceID,
+	}
+	where := &dao.TEppAssignmentParam{Cluster: &param.Cluster}
+
+	affected, err := dao.TEppAssignmentUpdate(dbCtx, val, where)
+	if err != nil {
+		return err
+	}
+	if affected > 0 {
+		return nil
+	}
+
+	_, err = dao.TEppAssignmentCreate(dbCtx, &dao.TEppAssignmentParam{
+		Cluster:           &param.Cluster,
+		GroupName:         &param.GroupName,
+		PrimaryInstanceID: &param.PrimaryInstanceID,
+	})
+	if err != nil {
+		// Unique-key conflict fallback: the row appeared concurrently, update it.
+		if _, errUp := dao.TEppAssignmentUpdate(dbCtx, val, where); errUp == nil {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (s *EppPoolStorager) DeleteAssignment(ctx context.Context, cluster string) error {
+	dbCtx, err := s.dbCtxFactory(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = dao.TEppAssignmentDelete(dbCtx, &dao.TEppAssignmentParam{Cluster: &cluster})
+	return err
+}
+
+func instanceFilterID(filter *epp_pool.InstanceFilter) *string {
+	if filter == nil {
+		return nil
+	}
+	return filter.ID
+}
+
+func instanceFilterGroupName(filter *epp_pool.InstanceFilter) *string {
+	if filter == nil {
+		return nil
+	}
+	return filter.GroupName
+}
+
+func eppInstanceToParam(one *dao.TEppInstance) *epp_pool.InstanceParam {
+	return &epp_pool.InstanceParam{
+		ID:        one.ID,
+		Host:      one.Host,
+		Port:      one.Port,
+		GroupName: one.GroupName,
+	}
+}
+
+func eppInstanceToDAO(param *epp_pool.InstanceParam) *dao.TEppInstanceParam {
+	return &dao.TEppInstanceParam{
+		ID:        &param.ID,
+		Host:      &param.Host,
+		Port:      &param.Port,
+		GroupName: &param.GroupName,
+	}
+}
+
+func eppAssignmentToParam(one *dao.TEppAssignment) *epp_pool.AssignmentParam {
+	return &epp_pool.AssignmentParam{
+		Cluster:           one.Cluster,
+		GroupName:         one.GroupName,
+		PrimaryInstanceID: one.PrimaryInstanceID,
+	}
+}

--- a/storage/rdb/epp_pool/epp_pool_test.go
+++ b/storage/rdb/epp_pool/epp_pool_test.go
@@ -1,0 +1,139 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package epp_pool
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/epp_pool"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestStorager(t *testing.T) (*EppPoolStorager, *sql.DB) {
+	// The DAO layer consults stateful.DefaultConfig when recording SQL.
+	if stateful.DefaultConfig == nil {
+		stateful.DefaultConfig = &stateful.Config{}
+	}
+
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+CREATE TABLE epp_instances (
+  id TEXT NOT NULL PRIMARY KEY,
+  host TEXT NOT NULL,
+  port INTEGER NOT NULL,
+  group_name TEXT NOT NULL,
+  create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (host, port)
+);
+CREATE TABLE epp_assignments (
+  cluster TEXT NOT NULL PRIMARY KEY,
+  group_name TEXT NOT NULL,
+  primary_instance_id TEXT NOT NULL,
+  create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);`)
+	require.NoError(t, err)
+
+	factory := lib.DBContextFactory(func(ctx context.Context, ops ...*lib.Op) (*lib.DBContext, error) {
+		return lib.NewDBContext(ctx, db), nil
+	})
+
+	return NewEppPoolStorager(factory), db
+}
+
+func TestEppPoolStorager_Instances(t *testing.T) {
+	ctx := context.Background()
+	s, _ := setupTestStorager(t)
+
+	affected, err := s.CreateInstances(ctx, []*epp_pool.InstanceParam{
+		{ID: "epp-a", Host: "10.0.0.1", Port: 9002, GroupName: "g1"},
+		{ID: "epp-b", Host: "10.0.0.2", Port: 9002, GroupName: "g1"},
+		{ID: "epp-c", Host: "10.0.0.3", Port: 9002, GroupName: "g2"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), affected)
+
+	list, err := s.FetchInstanceList(ctx, &epp_pool.InstanceFilter{})
+	require.NoError(t, err)
+	assert.Len(t, list, 3)
+
+	grouped, err := s.FetchInstanceList(ctx, &epp_pool.InstanceFilter{GroupName: lib.PString("g1")})
+	require.NoError(t, err)
+	assert.Len(t, grouped, 2)
+
+	one, err := s.FetchInstanceList(ctx, &epp_pool.InstanceFilter{ID: lib.PString("epp-c")})
+	require.NoError(t, err)
+	require.Len(t, one, 1)
+	assert.Equal(t, "g2", one[0].GroupName)
+
+	affected, err = s.DeleteInstances(ctx, &epp_pool.InstanceFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), affected)
+
+	list, err = s.FetchInstanceList(ctx, &epp_pool.InstanceFilter{})
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+func TestEppPoolStorager_Assignments(t *testing.T) {
+	ctx := context.Background()
+	s, _ := setupTestStorager(t)
+
+	// Upsert inserts when absent.
+	err := s.UpsertAssignment(ctx, &epp_pool.AssignmentParam{
+		Cluster: "cluster-a", GroupName: "g1", PrimaryInstanceID: "epp-a",
+	})
+	require.NoError(t, err)
+
+	assignment, err := s.FetchAssignment(ctx, "cluster-a")
+	require.NoError(t, err)
+	require.NotNil(t, assignment)
+	assert.Equal(t, "epp-a", assignment.PrimaryInstanceID)
+
+	// Upsert updates when present.
+	err = s.UpsertAssignment(ctx, &epp_pool.AssignmentParam{
+		Cluster: "cluster-a", GroupName: "g1", PrimaryInstanceID: "epp-b",
+	})
+	require.NoError(t, err)
+
+	list, err := s.FetchAssignmentList(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "epp-b", list[0].PrimaryInstanceID)
+
+	require.NoError(t, s.DeleteAssignment(ctx, "cluster-a"))
+	assignment, err = s.FetchAssignment(ctx, "cluster-a")
+	require.NoError(t, err)
+	assert.Nil(t, assignment)
+}
+
+func TestEppPoolStorager_UpsertValidation(t *testing.T) {
+	ctx := context.Background()
+	s, _ := setupTestStorager(t)
+
+	require.Error(t, s.UpsertAssignment(ctx, nil))
+	require.Error(t, s.UpsertAssignment(ctx, &epp_pool.AssignmentParam{Cluster: ""}))
+}

--- a/storage/rdb/internal/dao/table_clusters.go
+++ b/storage/rdb/internal/dao/table_clusters.go
@@ -58,6 +58,8 @@ type TCluster struct {
 	CancelOnClientClose    bool      `db:"cancel_on_client_close"`
 	FailureStatus          bool      `db:"failure_status"`
 	LLMConfig              string    `db:"llm_config"`
+	BalanceMode            string    `db:"balance_mode"`
+	EppConfig              string    `db:"epp_config"`
 	CreatedAt              time.Time `db:"created_at"`
 	UpdatedAt              time.Time `db:"updated_at"`
 }
@@ -127,6 +129,8 @@ type TClusterParam struct {
 	CancelOnClientClose    *bool      `db:"cancel_on_client_close"`
 	FailureStatus          *bool      `db:"failure_status"`
 	LLMConfig              *string    `db:"llm_config"`
+	BalanceMode            *string    `db:"balance_mode"`
+	EppConfig              *string    `db:"epp_config"`
 	CreatedAt              *time.Time `db:"created_at"`
 	UpdatedAt              *time.Time `db:"updated_at"`
 

--- a/storage/rdb/internal/dao/table_epp_assignments.go
+++ b/storage/rdb/internal/dao/table_epp_assignments.go
@@ -1,0 +1,100 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package dao
+
+import (
+	"time"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/internal/dao/internal"
+)
+
+const tEppAssignmentTableName = "epp_assignments"
+
+type TEppAssignment struct {
+	Cluster           string    `db:"cluster"`
+	GroupName         string    `db:"group_name"`
+	PrimaryInstanceID string    `db:"primary_instance_id"`
+	CreateTime        time.Time `db:"create_time"`
+	UpdateTime        time.Time `db:"update_time"`
+}
+
+// TEppAssignmentOne Query One
+// return nil, nil if record not existed
+func TEppAssignmentOne(dbCtx lib.DBContexter, where *TEppAssignmentParam) (*TEppAssignment, error) {
+	t := &TEppAssignment{}
+	err := internal.QueryOne(dbCtx, tEppAssignmentTableName, where, t)
+	if err == nil {
+		return t, nil
+	}
+	if xerror.Cause(err) == internal.ErrRecordNotFound {
+		return nil, nil
+	}
+	return nil, err
+}
+
+// TEppAssignmentList Query Multiple
+func TEppAssignmentList(dbCtx lib.DBContexter, where *TEppAssignmentParam) ([]*TEppAssignment, error) {
+	t := []*TEppAssignment{}
+	err := internal.QueryList(dbCtx, tEppAssignmentTableName, where, &t)
+	if err == nil {
+		return t, nil
+	}
+	if xerror.Cause(err) == internal.ErrRecordNotFound {
+		return nil, nil
+	}
+	return nil, err
+}
+
+type TEppAssignmentParam struct {
+	Cluster           *string    `db:"cluster"`
+	GroupName         *string    `db:"group_name"`
+	PrimaryInstanceID *string    `db:"primary_instance_id"`
+	CreateTime        *time.Time `db:"create_time"`
+	UpdateTime        *time.Time `db:"update_time"`
+
+	OrderBy *string `db:"_orderby"`
+}
+
+// TEppAssignmentCreate One/Multiple
+func TEppAssignmentCreate(dbCtx lib.DBContexter, data ...*TEppAssignmentParam) (int64, error) {
+	if len(data) == 1 {
+		if data[0].CreateTime == nil {
+			data[0].CreateTime = internal.PTimeNow()
+		}
+		return internal.Create(dbCtx, tEppAssignmentTableName, data[0])
+	}
+
+	list := make([]interface{}, len(data))
+	for i, one := range data {
+		if one.CreateTime == nil {
+			one.CreateTime = internal.PTimeNow()
+		}
+		list[i] = one
+	}
+
+	return internal.Create(dbCtx, tEppAssignmentTableName, list...)
+}
+
+// TEppAssignmentUpdate Update One
+func TEppAssignmentUpdate(dbCtx lib.DBContexter, val, where *TEppAssignmentParam) (int64, error) {
+	return internal.Update(dbCtx, tEppAssignmentTableName, where, val)
+}
+
+// TEppAssignmentDelete Delete One/Multiple
+func TEppAssignmentDelete(dbCtx lib.DBContexter, where *TEppAssignmentParam) (int64, error) {
+	return internal.Delete(dbCtx, tEppAssignmentTableName, where)
+}

--- a/storage/rdb/internal/dao/table_epp_instances.go
+++ b/storage/rdb/internal/dao/table_epp_instances.go
@@ -1,0 +1,102 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package dao
+
+import (
+	"time"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib/xerror"
+	"github.com/rainway-ai-gateway/ai-gateway-api/storage/rdb/internal/dao/internal"
+)
+
+const tEppInstanceTableName = "epp_instances"
+
+type TEppInstance struct {
+	ID         string    `db:"id"`
+	Host       string    `db:"host"`
+	Port       int       `db:"port"`
+	GroupName  string    `db:"group_name"`
+	CreateTime time.Time `db:"create_time"`
+	UpdateTime time.Time `db:"update_time"`
+}
+
+// TEppInstanceOne Query One
+// return nil, nil if record not existed
+func TEppInstanceOne(dbCtx lib.DBContexter, where *TEppInstanceParam) (*TEppInstance, error) {
+	t := &TEppInstance{}
+	err := internal.QueryOne(dbCtx, tEppInstanceTableName, where, t)
+	if err == nil {
+		return t, nil
+	}
+	if xerror.Cause(err) == internal.ErrRecordNotFound {
+		return nil, nil
+	}
+	return nil, err
+}
+
+// TEppInstanceList Query Multiple
+func TEppInstanceList(dbCtx lib.DBContexter, where *TEppInstanceParam) ([]*TEppInstance, error) {
+	t := []*TEppInstance{}
+	err := internal.QueryList(dbCtx, tEppInstanceTableName, where, &t)
+	if err == nil {
+		return t, nil
+	}
+	if xerror.Cause(err) == internal.ErrRecordNotFound {
+		return nil, nil
+	}
+	return nil, err
+}
+
+type TEppInstanceParam struct {
+	ID         *string    `db:"id"`
+	Host       *string    `db:"host"`
+	Port       *int       `db:"port"`
+	GroupName  *string    `db:"group_name"`
+	CreateTime *time.Time `db:"create_time"`
+	UpdateTime *time.Time `db:"update_time"`
+
+	OrderBy *string `db:"_orderby"`
+}
+
+// TEppInstanceCreate One/Multiple
+func TEppInstanceCreate(dbCtx lib.DBContexter, data ...*TEppInstanceParam) (int64, error) {
+	if len(data) == 1 {
+		if data[0].CreateTime == nil {
+			data[0].CreateTime = internal.PTimeNow()
+		}
+		return internal.Create(dbCtx, tEppInstanceTableName, data[0])
+	}
+
+	list := make([]interface{}, len(data))
+	for i, one := range data {
+		if one.CreateTime == nil {
+			one.CreateTime = internal.PTimeNow()
+		}
+		list[i] = one
+	}
+
+	return internal.Create(dbCtx, tEppInstanceTableName, list...)
+}
+
+// TEppInstanceUpdate Update One
+func TEppInstanceUpdate(dbCtx lib.DBContexter, val, where *TEppInstanceParam) (int64, error) {
+	return internal.Update(dbCtx, tEppInstanceTableName, where, val)
+}
+
+// TEppInstanceDelete Delete One/Multiple
+func TEppInstanceDelete(dbCtx lib.DBContexter, where *TEppInstanceParam) (int64, error) {
+	return internal.Delete(dbCtx, tEppInstanceTableName, where)
+}

--- a/storage/rdb/internal/dao/table_epp_test.go
+++ b/storage/rdb/internal/dao/table_epp_test.go
@@ -1,0 +1,183 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dao
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupEppTestDB(t *testing.T) (*sql.DB, lib.DBContexter) {
+	// The DAO layer consults stateful.DefaultConfig when recording SQL.
+	if stateful.DefaultConfig == nil {
+		stateful.DefaultConfig = &stateful.Config{}
+	}
+
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+CREATE TABLE epp_instances (
+  id TEXT NOT NULL PRIMARY KEY,
+  host TEXT NOT NULL,
+  port INTEGER NOT NULL,
+  group_name TEXT NOT NULL,
+  create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (host, port)
+);
+CREATE TABLE epp_assignments (
+  cluster TEXT NOT NULL PRIMARY KEY,
+  group_name TEXT NOT NULL,
+  primary_instance_id TEXT NOT NULL,
+  create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);`)
+	require.NoError(t, err)
+
+	return db, lib.NewDBContext(context.Background(), db)
+}
+
+func TestTEppInstanceCRUD(t *testing.T) {
+	_, dbCtx := setupEppTestDB(t)
+
+	affected, err := TEppInstanceCreate(dbCtx, &TEppInstanceParam{
+		ID:        lib.PString("epp-a"),
+		Host:      lib.PString("10.0.0.1"),
+		Port:      lib.PInt(9002),
+		GroupName: lib.PString("g1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), affected)
+
+	_, err = TEppInstanceCreate(dbCtx,
+		&TEppInstanceParam{ID: lib.PString("epp-b"), Host: lib.PString("10.0.0.2"), Port: lib.PInt(9002), GroupName: lib.PString("g1")},
+		&TEppInstanceParam{ID: lib.PString("epp-c"), Host: lib.PString("10.0.0.3"), Port: lib.PInt(9002), GroupName: lib.PString("g2")},
+	)
+	require.NoError(t, err)
+
+	one, err := TEppInstanceOne(dbCtx, &TEppInstanceParam{ID: lib.PString("epp-a")})
+	require.NoError(t, err)
+	require.NotNil(t, one)
+	assert.Equal(t, "g1", one.GroupName)
+	assert.False(t, one.CreateTime.IsZero())
+
+	// Not found returns nil, nil.
+	none, err := TEppInstanceOne(dbCtx, &TEppInstanceParam{ID: lib.PString("epp-x")})
+	require.NoError(t, err)
+	assert.Nil(t, none)
+
+	// Group filter.
+	list, err := TEppInstanceList(dbCtx, &TEppInstanceParam{GroupName: lib.PString("g1")})
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+
+	// Full list.
+	list, err = TEppInstanceList(dbCtx, &TEppInstanceParam{})
+	require.NoError(t, err)
+	assert.Len(t, list, 3)
+
+	// Unique(host, port) enforced.
+	_, err = TEppInstanceCreate(dbCtx, &TEppInstanceParam{
+		ID:        lib.PString("epp-d"),
+		Host:      lib.PString("10.0.0.1"),
+		Port:      lib.PInt(9002),
+		GroupName: lib.PString("g1"),
+	})
+	require.Error(t, err)
+
+	// Update.
+	affected, err = TEppInstanceUpdate(dbCtx,
+		&TEppInstanceParam{GroupName: lib.PString("g2")},
+		&TEppInstanceParam{ID: lib.PString("epp-a")},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), affected)
+
+	one, err = TEppInstanceOne(dbCtx, &TEppInstanceParam{ID: lib.PString("epp-a")})
+	require.NoError(t, err)
+	assert.Equal(t, "g2", one.GroupName)
+
+	// Delete by filter.
+	affected, err = TEppInstanceDelete(dbCtx, &TEppInstanceParam{GroupName: lib.PString("g2")})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), affected)
+
+	list, err = TEppInstanceList(dbCtx, &TEppInstanceParam{})
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+}
+
+func TestTEppAssignmentCRUD(t *testing.T) {
+	_, dbCtx := setupEppTestDB(t)
+
+	affected, err := TEppAssignmentCreate(dbCtx, &TEppAssignmentParam{
+		Cluster:           lib.PString("cluster-a"),
+		GroupName:         lib.PString("g1"),
+		PrimaryInstanceID: lib.PString("epp-a"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), affected)
+
+	one, err := TEppAssignmentOne(dbCtx, &TEppAssignmentParam{Cluster: lib.PString("cluster-a")})
+	require.NoError(t, err)
+	require.NotNil(t, one)
+	assert.Equal(t, "epp-a", one.PrimaryInstanceID)
+
+	none, err := TEppAssignmentOne(dbCtx, &TEppAssignmentParam{Cluster: lib.PString("cluster-x")})
+	require.NoError(t, err)
+	assert.Nil(t, none)
+
+	// Primary key conflict on duplicate cluster.
+	_, err = TEppAssignmentCreate(dbCtx, &TEppAssignmentParam{
+		Cluster:           lib.PString("cluster-a"),
+		GroupName:         lib.PString("g2"),
+		PrimaryInstanceID: lib.PString("epp-b"),
+	})
+	require.Error(t, err)
+
+	list, err := TEppAssignmentList(dbCtx, &TEppAssignmentParam{})
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+
+	affected, err = TEppAssignmentUpdate(dbCtx,
+		&TEppAssignmentParam{PrimaryInstanceID: lib.PString("epp-b")},
+		&TEppAssignmentParam{Cluster: lib.PString("cluster-a")},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), affected)
+
+	one, err = TEppAssignmentOne(dbCtx, &TEppAssignmentParam{Cluster: lib.PString("cluster-a")})
+	require.NoError(t, err)
+	assert.Equal(t, "epp-b", one.PrimaryInstanceID)
+
+	affected, err = TEppAssignmentDelete(dbCtx, &TEppAssignmentParam{Cluster: lib.PString("cluster-a")})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), affected)
+
+	list, err = TEppAssignmentList(dbCtx, &TEppAssignmentParam{})
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}

--- a/test/integration/conf/ai_gateway_api.toml
+++ b/test/integration/conf/ai_gateway_api.toml
@@ -56,3 +56,8 @@ Debug = false
 AIRouteInnerProductName = "AI_product"
 DefaultAIInstancePoolName = "BFE.aipool"
 DefaultAIClusterName = "BFE-AI_product.szyf"
+# EPP 调度对接：测试环境允许单实例组；reconciler 周期调小以便
+# 未分配 cluster 在容量恢复后快速自动分配（生产默认 30s）。
+DefaultEPPInstancePoolName = "EPP.pool"
+EPPValidationMode = "test"
+EPPReconcileIntervalSeconds = 1

--- a/test/integration/tests/clusters/epp/epp_test.go
+++ b/test/integration/tests/clusters/epp/epp_test.go
@@ -1,0 +1,316 @@
+package clusters_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sm *testutil.ServerManager
+
+func TestMain(m *testing.M) {
+	var err error
+	sm, err = testutil.StartServer()
+	if err != nil {
+		panic("failed to start server: " + err.Error())
+	}
+	code := m.Run()
+	sm.Shutdown()
+	os.Exit(code)
+}
+
+func minEPPClusterBody(name, provider string, eppConfig interface{}) map[string]interface{} {
+	body := map[string]interface{}{
+		"name": name,
+		"llm_config": map[string]interface{}{
+			"models":   []string{"deepseek-chat"},
+			"provider": provider,
+		},
+	}
+	if eppConfig != nil {
+		body["balance_mode"] = "EPP"
+		body["epp_config"] = eppConfig
+	}
+	return body
+}
+
+func getCluster(t *testing.T, name string) map[string]interface{} {
+	t.Helper()
+	resp, err := testutil.GetClient().Get("/open-api/v1/clusters/" + name)
+	if err != nil {
+		t.Fatalf("get cluster failed: %v", err)
+	}
+	testutil.AssertSuccess(t, resp)
+	var data map[string]interface{}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("unmarshal cluster failed: %v", err)
+	}
+	return data
+}
+
+func TestClusters_EPP(t *testing.T) {
+	providerName := testutil.UniqueProviderName()
+	if _, err := testutil.CreateProvider(providerName); err != nil {
+		t.Fatalf("setup provider failed: %v", err)
+	}
+	defer testutil.DeleteProvider(providerName)
+
+	validConfig := map[string]interface{}{
+		"scheduling_profile":        "balanced",
+		"prefix_cache_affinity":     true,
+		"kv_cache_utilization_max":  0.9,
+		"session_affinity_enabled":  true,
+		"session_affinity_header":   "x-session-id",
+		"flow_control": map[string]interface{}{
+			"max_requests":         100,
+			"queue_ttl":            30,
+			"no_endpoint_queue_ttl": 600,
+			"enable_eviction":      false,
+		},
+	}
+
+	t.Run("CL-EPP-001 EPP 模式缺少 epp_config 返回 422", func(t *testing.T) {
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name":         testutil.UniqueClusterName(),
+			"balance_mode": "EPP",
+			"llm_config": map[string]interface{}{
+				"models":   []string{"deepseek-chat"},
+				"provider": providerName,
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("CL-EPP-002 epp_config 空对象视为未配置返回 422", func(t *testing.T) {
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", minEPPClusterBody(
+			testutil.UniqueClusterName(), providerName, map[string]interface{}{}))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("CL-EPP-003 scheduling_profile 枚举越界返回 422", func(t *testing.T) {
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", minEPPClusterBody(
+			testutil.UniqueClusterName(), providerName, map[string]interface{}{
+				"scheduling_profile": "super-fast",
+			}))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("CL-EPP-004 cache_affinity 枚举越界返回 422", func(t *testing.T) {
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", minEPPClusterBody(
+			testutil.UniqueClusterName(), providerName, map[string]interface{}{
+				"cache_affinity": "extreme",
+			}))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("CL-EPP-005 kv_cache_utilization_max 越界返回 422", func(t *testing.T) {
+		for _, v := range []interface{}{0, -0.1, 1.1, 2} {
+			resp, err := testutil.GetClient().Post("/open-api/v1/clusters", minEPPClusterBody(
+				testutil.UniqueClusterName(), providerName, map[string]interface{}{
+					"kv_cache_utilization_max": v,
+				}))
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			testutil.AssertErrCode(t, resp, 422)
+		}
+	})
+
+	t.Run("CL-EPP-006 queue_ttl 负数返回 422", func(t *testing.T) {
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", minEPPClusterBody(
+			testutil.UniqueClusterName(), providerName, map[string]interface{}{
+				"flow_control": map[string]interface{}{"queue_ttl": -1},
+			}))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("CL-EPP-007 max_requests 非法值返回 422", func(t *testing.T) {
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", minEPPClusterBody(
+			testutil.UniqueClusterName(), providerName, map[string]interface{}{
+				"flow_control": map[string]interface{}{"max_requests": 0},
+			}))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("CL-EPP-008 session_affinity_enabled=true 缺 header 返回 422", func(t *testing.T) {
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", minEPPClusterBody(
+			testutil.UniqueClusterName(), providerName, map[string]interface{}{
+				"session_affinity_enabled": true,
+			}))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("CL-EPP-009 epp_config 携带未知字段返回 422", func(t *testing.T) {
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", minEPPClusterBody(
+			testutil.UniqueClusterName(), providerName, map[string]interface{}{
+				"scheduling_profile": "balanced",
+				"unknown_field":      1,
+			}))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("CL-EPP-010 balance_mode 非法枚举返回 422", func(t *testing.T) {
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name":         testutil.UniqueClusterName(),
+			"balance_mode": "LC",
+			"llm_config": map[string]interface{}{
+				"models":   []string{"deepseek-chat"},
+				"provider": providerName,
+			},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("CL-EPP-011 EPP 完整配置创建成功并原样回读", func(t *testing.T) {
+		clusterName := testutil.UniqueClusterName()
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", minEPPClusterBody(clusterName, providerName, validConfig))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		data := getCluster(t, clusterName)
+		assert.Equal(t, "EPP", data["balance_mode"])
+		eppConfig, ok := data["epp_config"].(map[string]interface{})
+		require.True(t, ok, "epp_config should be echoed back")
+		assert.Equal(t, "balanced", eppConfig["scheduling_profile"])
+		assert.Equal(t, true, eppConfig["prefix_cache_affinity"])
+		assert.Equal(t, 0.9, eppConfig["kv_cache_utilization_max"])
+		assert.Equal(t, true, eppConfig["session_affinity_enabled"])
+		assert.Equal(t, "x-session-id", eppConfig["session_affinity_header"])
+		fc := eppConfig["flow_control"].(map[string]interface{})
+		assert.Equal(t, float64(100), fc["max_requests"])
+		assert.Equal(t, float64(30), fc["queue_ttl"])
+
+		t.Cleanup(func() { testutil.DeleteCluster(clusterName) })
+	})
+
+	t.Run("CL-EPP-012 WRR 携带合法 epp_config 创建成功（休眠保留）", func(t *testing.T) {
+		clusterName := testutil.UniqueClusterName()
+		body := map[string]interface{}{
+			"name":         clusterName,
+			"balance_mode": "WRR",
+			"epp_config":   map[string]interface{}{"scheduling_profile": "throughput-first"},
+			"llm_config": map[string]interface{}{
+				"models":   []string{"deepseek-chat"},
+				"provider": providerName,
+			},
+		}
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", body)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		data := getCluster(t, clusterName)
+		assert.Equal(t, "WRR", data["balance_mode"])
+		eppConfig, ok := data["epp_config"].(map[string]interface{})
+		require.True(t, ok, "epp_config should be retained in WRR mode")
+		assert.Equal(t, "throughput-first", eppConfig["scheduling_profile"])
+
+		t.Cleanup(func() { testutil.DeleteCluster(clusterName) })
+	})
+
+	t.Run("CL-EPP-013 balance_mode 缺省回读为 WRR 且 epp_config 为 null", func(t *testing.T) {
+		clusterName := testutil.UniqueClusterName()
+		if _, err := testutil.CreateCluster(clusterName); err != nil {
+			t.Fatalf("setup cluster failed: %v", err)
+		}
+		defer testutil.DeleteCluster(clusterName)
+
+		data := getCluster(t, clusterName)
+		assert.Equal(t, "WRR", data["balance_mode"])
+		eppConfig, exists := data["epp_config"]
+		assert.True(t, exists, "epp_config field should be present")
+		assert.Nil(t, eppConfig, "epp_config should be null when never configured")
+	})
+
+	t.Run("CL-EPP-014 EPP 到 WRR 再回 EPP 配置与分配保留", func(t *testing.T) {
+		clusterName := testutil.UniqueClusterName()
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", minEPPClusterBody(clusterName, providerName, map[string]interface{}{
+			"scheduling_profile": "latency-first",
+		}))
+		if err != nil {
+			t.Fatalf("create failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+		defer testutil.DeleteCluster(clusterName)
+
+		// EPP -> WRR：仅改 balance_mode，epp_config 休眠保留
+		resp, err = testutil.GetClient().Patch("/open-api/v1/clusters/"+clusterName, map[string]interface{}{
+			"balance_mode": "WRR",
+		})
+		if err != nil {
+			t.Fatalf("patch to WRR failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		data := getCluster(t, clusterName)
+		assert.Equal(t, "WRR", data["balance_mode"])
+		eppConfig, ok := data["epp_config"].(map[string]interface{})
+		require.True(t, ok, "epp_config should be retained after EPP -> WRR")
+		assert.Equal(t, "latency-first", eppConfig["scheduling_profile"])
+
+		// WRR -> EPP：无需重新携带 epp_config，休眠配置继续生效
+		resp, err = testutil.GetClient().Patch("/open-api/v1/clusters/"+clusterName, map[string]interface{}{
+			"balance_mode": "EPP",
+		})
+		if err != nil {
+			t.Fatalf("patch to EPP failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		data = getCluster(t, clusterName)
+		assert.Equal(t, "EPP", data["balance_mode"])
+		eppConfig, ok = data["epp_config"].(map[string]interface{})
+		require.True(t, ok, "epp_config should survive WRR -> EPP")
+		assert.Equal(t, "latency-first", eppConfig["scheduling_profile"])
+	})
+
+	t.Run("CL-EPP-015 WRR 休眠状态下更新携带非法 epp_config 返回 422", func(t *testing.T) {
+		clusterName := testutil.UniqueClusterName()
+		if _, err := testutil.CreateCluster(clusterName); err != nil {
+			t.Fatalf("setup cluster failed: %v", err)
+		}
+		defer testutil.DeleteCluster(clusterName)
+
+		resp, err := testutil.GetClient().Patch("/open-api/v1/clusters/"+clusterName, map[string]interface{}{
+			"epp_config": map[string]interface{}{"kv_cache_utilization_max": 1.5},
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 422)
+	})
+}

--- a/test/integration/tests/epp_assignments/get/get_test.go
+++ b/test/integration/tests/epp_assignments/get/get_test.go
@@ -1,0 +1,180 @@
+package epp_assignments_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sm *testutil.ServerManager
+
+func TestMain(m *testing.M) {
+	var err error
+	sm, err = testutil.StartServer()
+	if err != nil {
+		panic("failed to start server: " + err.Error())
+	}
+	code := m.Run()
+	sm.Shutdown()
+	os.Exit(code)
+}
+
+func patchEppPool(t *testing.T, body map[string]interface{}) *testutil.APIResponse {
+	resp, err := testutil.GetClient().Patch("/open-api/v1/epp-pool", body)
+	if err != nil {
+		t.Fatalf("patch epp pool failed: %v", err)
+	}
+	return resp
+}
+
+func twoGroupsBody() map[string]interface{} {
+	return map[string]interface{}{
+		"groups": []interface{}{
+			map[string]interface{}{
+				"name": "g1",
+				"instances": []interface{}{
+					map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+					map[string]interface{}{"id": "epp-b", "host": "10.0.0.2", "port": 9002},
+				},
+			},
+			map[string]interface{}{
+				"name": "g2",
+				"instances": []interface{}{
+					map[string]interface{}{"id": "epp-c", "host": "10.0.0.3", "port": 9002},
+				},
+			},
+		},
+	}
+}
+
+// createEPPCluster creates an EPP-mode cluster (provider auto-created) and
+// returns its name.
+func createEPPCluster(t *testing.T, name string) string {
+	t.Helper()
+	providerName := testutil.UniqueProviderName()
+	if _, err := testutil.CreateProvider(providerName); err != nil {
+		t.Fatalf("setup provider failed: %v", err)
+	}
+	resp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+		"name":         name,
+		"balance_mode": "EPP",
+		"epp_config":   map[string]interface{}{"scheduling_profile": "balanced"},
+		"llm_config": map[string]interface{}{
+			"models":   []string{"deepseek-chat"},
+			"provider": providerName,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create epp cluster failed: %v", err)
+	}
+	if resp.ErrNum != 200 {
+		t.Fatalf("create epp cluster failed: %d %s", resp.ErrNum, resp.ErrMsg)
+	}
+	return name
+}
+
+func getAssignments(t *testing.T, query ...map[string]string) map[string]interface{} {
+	t.Helper()
+	var resp *testutil.APIResponse
+	var err error
+	if len(query) > 0 {
+		resp, err = testutil.GetClient().Get("/open-api/v1/epp-assignments", query[0])
+	} else {
+		resp, err = testutil.GetClient().Get("/open-api/v1/epp-assignments")
+	}
+	if err != nil {
+		t.Fatalf("get assignments failed: %v", err)
+	}
+	testutil.AssertSuccess(t, resp)
+	var data map[string]interface{}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("unmarshal assignments failed: %v", err)
+	}
+	return data
+}
+
+func findClusterEntry(t *testing.T, data map[string]interface{}, cluster string) map[string]interface{} {
+	t.Helper()
+	clusters := data["clusters"].([]interface{})
+	for _, item := range clusters {
+		entry := item.(map[string]interface{})
+		if entry["cluster"] == cluster {
+			return entry
+		}
+	}
+	return nil
+}
+
+func TestEppAssignments_Get(t *testing.T) {
+	clusterName := testutil.UniqueClusterName()
+
+	t.Cleanup(func() {
+		testutil.DeleteCluster(clusterName)
+	})
+
+	t.Run("EA-1-001 配置实例池后创建 EPP 集群自动分配", func(t *testing.T) {
+		resp := patchEppPool(t, twoGroupsBody())
+		testutil.AssertSuccess(t, resp)
+
+		createEPPCluster(t, clusterName)
+
+		data := getAssignments(t)
+		entry := findClusterEntry(t, data, clusterName)
+		require.NotNil(t, entry, "cluster should appear in assignment view")
+		assert.False(t, entry["degraded"].(bool))
+		assert.Equal(t, "g1", entry["group"], "greedy allocator picks least-loaded group, tie-break by name")
+
+		primary, ok := entry["primary"].(map[string]interface{})
+		require.True(t, ok, "primary should be non-null after auto assignment")
+		assert.Contains(t, []string{"epp-a", "epp-b"}, primary["id"])
+		assert.NotEmpty(t, primary["host"])
+		assert.NotEmpty(t, primary["port"])
+
+		standby, ok := entry["standby"].(map[string]interface{})
+		require.True(t, ok, "standby should be expanded from the same group")
+		assert.NotEqual(t, primary["id"], standby["id"])
+		assert.Contains(t, []string{"epp-a", "epp-b"}, standby["id"])
+
+		assert.Contains(t, data["idle_groups"], "g2")
+		assert.NotContains(t, data["unassigned_clusters"], clusterName)
+	})
+
+	t.Run("EA-1-002 按 cluster 过滤查询", func(t *testing.T) {
+		data := getAssignments(t, map[string]string{"cluster": clusterName})
+		clusters := data["clusters"].([]interface{})
+		require.Len(t, clusters, 1)
+		entry := clusters[0].(map[string]interface{})
+		assert.Equal(t, clusterName, entry["cluster"])
+		assert.NotNil(t, entry["primary"])
+	})
+
+	t.Run("EA-1-003 过滤不存在的 cluster 返回 404", func(t *testing.T) {
+		resp, err := testutil.GetClient().Get("/open-api/v1/epp-assignments", map[string]string{
+			"cluster": "not_exist_cluster",
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 404)
+	})
+
+	t.Run("EA-1-004 过滤 WRR 集群返回 404", func(t *testing.T) {
+		wrrCluster := testutil.UniqueClusterName()
+		if _, err := testutil.CreateCluster(wrrCluster); err != nil {
+			t.Fatalf("setup wrr cluster failed: %v", err)
+		}
+		defer testutil.DeleteCluster(wrrCluster)
+
+		resp, err := testutil.GetClient().Get("/open-api/v1/epp-assignments", map[string]string{
+			"cluster": wrrCluster,
+		})
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 404)
+	})
+}

--- a/test/integration/tests/epp_assignments/put/put_test.go
+++ b/test/integration/tests/epp_assignments/put/put_test.go
@@ -1,0 +1,232 @@
+package epp_assignments_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sm *testutil.ServerManager
+
+func TestMain(m *testing.M) {
+	var err error
+	sm, err = testutil.StartServer()
+	if err != nil {
+		panic("failed to start server: " + err.Error())
+	}
+	code := m.Run()
+	sm.Shutdown()
+	os.Exit(code)
+}
+
+func patchEppPool(t *testing.T, body map[string]interface{}) *testutil.APIResponse {
+	resp, err := testutil.GetClient().Patch("/open-api/v1/epp-pool", body)
+	if err != nil {
+		t.Fatalf("patch epp pool failed: %v", err)
+	}
+	return resp
+}
+
+func twoGroupsBody() map[string]interface{} {
+	return map[string]interface{}{
+		"groups": []interface{}{
+			map[string]interface{}{
+				"name": "g1",
+				"instances": []interface{}{
+					map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+					map[string]interface{}{"id": "epp-b", "host": "10.0.0.2", "port": 9002},
+				},
+			},
+			map[string]interface{}{
+				"name": "g2",
+				"instances": []interface{}{
+					map[string]interface{}{"id": "epp-c", "host": "10.0.0.3", "port": 9002},
+				},
+			},
+		},
+	}
+}
+
+// createEPPCluster creates an EPP-mode cluster (provider auto-created) and
+// returns its name.
+func createEPPCluster(t *testing.T, name string) string {
+	t.Helper()
+	providerName := testutil.UniqueProviderName()
+	if _, err := testutil.CreateProvider(providerName); err != nil {
+		t.Fatalf("setup provider failed: %v", err)
+	}
+	resp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+		"name":         name,
+		"balance_mode": "EPP",
+		"epp_config":   map[string]interface{}{"scheduling_profile": "balanced"},
+		"llm_config": map[string]interface{}{
+			"models":   []string{"deepseek-chat"},
+			"provider": providerName,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create epp cluster failed: %v", err)
+	}
+	if resp.ErrNum != 200 {
+		t.Fatalf("create epp cluster failed: %d %s", resp.ErrNum, resp.ErrMsg)
+	}
+	return name
+}
+
+func getAssignments(t *testing.T, query ...map[string]string) map[string]interface{} {
+	t.Helper()
+	var resp *testutil.APIResponse
+	var err error
+	if len(query) > 0 {
+		resp, err = testutil.GetClient().Get("/open-api/v1/epp-assignments", query[0])
+	} else {
+		resp, err = testutil.GetClient().Get("/open-api/v1/epp-assignments")
+	}
+	if err != nil {
+		t.Fatalf("get assignments failed: %v", err)
+	}
+	testutil.AssertSuccess(t, resp)
+	var data map[string]interface{}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("unmarshal assignments failed: %v", err)
+	}
+	return data
+}
+
+func findClusterEntry(t *testing.T, data map[string]interface{}, cluster string) map[string]interface{} {
+	t.Helper()
+	clusters := data["clusters"].([]interface{})
+	for _, item := range clusters {
+		entry := item.(map[string]interface{})
+		if entry["cluster"] == cluster {
+			return entry
+		}
+	}
+	return nil
+}
+
+func putOverride(t *testing.T, cluster string, body map[string]interface{}) *testutil.APIResponse {
+	resp, err := testutil.GetClient().Put("/open-api/v1/epp-assignments/"+cluster, body)
+	if err != nil {
+		t.Fatalf("put override failed: %v", err)
+	}
+	return resp
+}
+
+func TestEppAssignments_Put(t *testing.T) {
+	clusterName := testutil.UniqueClusterName()
+
+	patchResp := patchEppPool(t, twoGroupsBody())
+	testutil.AssertSuccess(t, patchResp)
+	createEPPCluster(t, clusterName)
+
+	t.Cleanup(func() {
+		testutil.DeleteCluster(clusterName)
+	})
+
+	t.Run("EA-2-001 手工覆写切换 primary 并回读验证", func(t *testing.T) {
+		data := getAssignments(t)
+		entry := findClusterEntry(t, data, clusterName)
+		require.NotNil(t, entry)
+		primary := entry["primary"].(map[string]interface{})
+		standby := entry["standby"].(map[string]interface{})
+
+		newPrimary := standby["id"].(string)
+		resp := putOverride(t, clusterName, map[string]interface{}{
+			"group_name":          "g1",
+			"primary_instance_id": newPrimary,
+		})
+		testutil.AssertSuccess(t, resp)
+
+		var respData map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &respData); err != nil {
+			t.Fatalf("unmarshal failed: %v", err)
+		}
+		assert.Equal(t, clusterName, respData["cluster"])
+		assert.Equal(t, "g1", respData["group"])
+		respPrimary := respData["primary"].(map[string]interface{})
+		assert.Equal(t, newPrimary, respPrimary["id"])
+		respStandby := respData["standby"].(map[string]interface{})
+		assert.Equal(t, primary["id"], respStandby["id"])
+
+		// GET 视图验证覆写生效
+		view := getAssignments(t, map[string]string{"cluster": clusterName})
+		viewEntry := findClusterEntry(t, view, clusterName)
+		require.NotNil(t, viewEntry)
+		assert.Equal(t, newPrimary, viewEntry["primary"].(map[string]interface{})["id"])
+		assert.Equal(t, primary["id"], viewEntry["standby"].(map[string]interface{})["id"])
+	})
+
+	t.Run("EA-2-002 覆写到另一组（单实例组无 standby）", func(t *testing.T) {
+		resp := putOverride(t, clusterName, map[string]interface{}{
+			"group_name":          "g2",
+			"primary_instance_id": "epp-c",
+		})
+		testutil.AssertSuccess(t, resp)
+
+		var respData map[string]interface{}
+		json.Unmarshal(resp.Data, &respData)
+		assert.Equal(t, "g2", respData["group"])
+		assert.Equal(t, "epp-c", respData["primary"].(map[string]interface{})["id"])
+		assert.Nil(t, respData["standby"])
+
+		view := getAssignments(t, map[string]string{"cluster": clusterName})
+		viewEntry := findClusterEntry(t, view, clusterName)
+		require.NotNil(t, viewEntry)
+		assert.Nil(t, viewEntry["standby"])
+	})
+
+	t.Run("EA-2-003 覆写不存在的 cluster 返回 404", func(t *testing.T) {
+		resp := putOverride(t, "not_exist_cluster", map[string]interface{}{
+			"group_name":          "g1",
+			"primary_instance_id": "epp-a",
+		})
+		testutil.AssertErrCode(t, resp, 404)
+	})
+
+	t.Run("EA-2-004 覆写 WRR 集群返回 404", func(t *testing.T) {
+		wrrCluster := testutil.UniqueClusterName()
+		if _, err := testutil.CreateCluster(wrrCluster); err != nil {
+			t.Fatalf("setup wrr cluster failed: %v", err)
+		}
+		defer testutil.DeleteCluster(wrrCluster)
+
+		resp := putOverride(t, wrrCluster, map[string]interface{}{
+			"group_name":          "g1",
+			"primary_instance_id": "epp-a",
+		})
+		testutil.AssertErrCode(t, resp, 404)
+	})
+
+	t.Run("EA-2-005 覆写到不存在的组返回 422", func(t *testing.T) {
+		resp := putOverride(t, clusterName, map[string]interface{}{
+			"group_name":          "not_exist_group",
+			"primary_instance_id": "epp-a",
+		})
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("EA-2-006 primary 不在目标组返回 422", func(t *testing.T) {
+		resp := putOverride(t, clusterName, map[string]interface{}{
+			"group_name":          "g1",
+			"primary_instance_id": "epp-c",
+		})
+		testutil.AssertErrCode(t, resp, 422)
+	})
+
+	t.Run("EA-2-007 缺少必填参数返回 422", func(t *testing.T) {
+		resp := putOverride(t, clusterName, map[string]interface{}{
+			"group_name": "g1",
+		})
+		testutil.AssertErrCode(t, resp, 422)
+
+		resp = putOverride(t, clusterName, map[string]interface{}{
+			"primary_instance_id": "epp-a",
+		})
+		testutil.AssertErrCode(t, resp, 422)
+	})
+}

--- a/test/integration/tests/epp_pool/get/get_test.go
+++ b/test/integration/tests/epp_pool/get/get_test.go
@@ -1,0 +1,98 @@
+package epp_pool_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sm *testutil.ServerManager
+
+func TestMain(m *testing.M) {
+	var err error
+	sm, err = testutil.StartServer()
+	if err != nil {
+		panic("failed to start server: " + err.Error())
+	}
+	code := m.Run()
+	sm.Shutdown()
+	os.Exit(code)
+}
+
+func patchEppPool(t *testing.T, body map[string]interface{}) *testutil.APIResponse {
+	resp, err := testutil.GetClient().Patch("/open-api/v1/epp-pool", body)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	return resp
+}
+
+func TestEppPool_Get(t *testing.T) {
+	t.Run("EP-1-001 池不存在返回 404 语义错误", func(t *testing.T) {
+		// 契约 epp-pool.md §2.1：池由首次 PATCH 创建，从未配置过时返回错误。
+		resp, err := testutil.GetClient().Get("/open-api/v1/epp-pool")
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		testutil.AssertErrCode(t, resp, 404)
+	})
+
+	t.Run("EP-1-002 配置后回读组与实例字段", func(t *testing.T) {
+		resp := patchEppPool(t, map[string]interface{}{
+			"groups": []interface{}{
+				map[string]interface{}{
+					"name": "g1",
+					"instances": []interface{}{
+						map[string]interface{}{"id": "epp-b", "host": "10.0.0.2", "port": 9002},
+						map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+					},
+				},
+				map[string]interface{}{
+					"name": "g2",
+					"instances": []interface{}{
+						map[string]interface{}{"id": "epp-c", "host": "10.0.0.3", "port": 9002},
+					},
+				},
+			},
+		})
+		testutil.AssertSuccess(t, resp)
+
+		// 响应体即池详情：组按名称排序、组内实例按 id 排序
+		var data map[string]interface{}
+		if err := json.Unmarshal(resp.Data, &data); err != nil {
+			t.Fatalf("unmarshal data failed: %v", err)
+		}
+		assert.Equal(t, "EPP.pool", data["name"])
+		groups := data["groups"].([]interface{})
+		require.Len(t, groups, 2)
+
+		g1 := groups[0].(map[string]interface{})
+		assert.Equal(t, "g1", g1["name"])
+		insts := g1["instances"].([]interface{})
+		require.Len(t, insts, 2)
+		inst0 := insts[0].(map[string]interface{})
+		assert.Equal(t, "epp-a", inst0["id"])
+		assert.Equal(t, "10.0.0.1", inst0["host"])
+		assert.Equal(t, float64(9002), inst0["port"])
+		inst1 := insts[1].(map[string]interface{})
+		assert.Equal(t, "epp-b", inst1["id"])
+		assert.Equal(t, "10.0.0.2", inst1["host"])
+
+		g2 := groups[1].(map[string]interface{})
+		assert.Equal(t, "g2", g2["name"])
+		insts2 := g2["instances"].([]interface{})
+		require.Len(t, insts2, 1)
+
+		// GET 回读与 PATCH 响应一致
+		getResp, err := testutil.GetClient().Get("/open-api/v1/epp-pool")
+		if err != nil {
+			t.Fatalf("get failed: %v", err)
+		}
+		testutil.AssertSuccess(t, getResp)
+		assert.Equal(t, string(resp.Data), string(getResp.Data), "GET should match PATCH response")
+	})
+}

--- a/test/integration/tests/epp_pool/update/update_test.go
+++ b/test/integration/tests/epp_pool/update/update_test.go
@@ -1,0 +1,268 @@
+package epp_pool_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sm *testutil.ServerManager
+
+func TestMain(m *testing.M) {
+	var err error
+	sm, err = testutil.StartServer()
+	if err != nil {
+		panic("failed to start server: " + err.Error())
+	}
+	code := m.Run()
+	sm.Shutdown()
+	os.Exit(code)
+}
+
+func patchEppPool(t *testing.T, body map[string]interface{}) *testutil.APIResponse {
+	resp, err := testutil.GetClient().Patch("/open-api/v1/epp-pool", body)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	return resp
+}
+
+func TestEppPool_Update(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     map[string]interface{}
+		wantCode int
+		check    func(t *testing.T, resp *testutil.APIResponse)
+	}{
+		{
+			name: "EP-2-001 全量替换两组（含单实例组）",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name": "g1",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+							map[string]interface{}{"id": "epp-b", "host": "10.0.0.2", "port": 9002},
+						},
+					},
+					map[string]interface{}{
+						"name": "g2",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-c", "host": "10.0.0.3", "port": 9002},
+						},
+					},
+				},
+			},
+			wantCode: 200,
+			check: func(t *testing.T, resp *testutil.APIResponse) {
+				var data map[string]interface{}
+				json.Unmarshal(resp.Data, &data)
+				groups := data["groups"].([]interface{})
+				assert.Len(t, groups, 2)
+			},
+		},
+		{
+			name: "EP-2-002 全量替换语义（第二次 PATCH 覆盖第一次）",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name": "g-only",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-x", "host": "10.0.1.1", "port": 9002},
+						},
+					},
+				},
+			},
+			wantCode: 200,
+			check: func(t *testing.T, resp *testutil.APIResponse) {
+				getResp, err := testutil.GetClient().Get("/open-api/v1/epp-pool")
+				if err != nil {
+					t.Fatalf("get failed: %v", err)
+				}
+				testutil.AssertSuccess(t, getResp)
+				assert.Equal(t, string(resp.Data), string(getResp.Data))
+				var data map[string]interface{}
+				json.Unmarshal(getResp.Data, &data)
+				groups := data["groups"].([]interface{})
+				require.Len(t, groups, 1)
+				assert.Equal(t, "g-only", groups[0].(map[string]interface{})["name"])
+			},
+		},
+		{
+			name:     "EP-2-003 groups 为空数组",
+			body:     map[string]interface{}{"groups": []interface{}{}},
+			wantCode: 422,
+		},
+		{
+			name:     "EP-2-004 缺少 groups",
+			body:     map[string]interface{}{},
+			wantCode: 422,
+		},
+		{
+			name: "EP-2-005 组名重复",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name": "g1",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+						},
+					},
+					map[string]interface{}{
+						"name": "g1",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-b", "host": "10.0.0.2", "port": 9002},
+						},
+					},
+				},
+			},
+			wantCode: 422,
+		},
+		{
+			name: "EP-2-006 空组（instances 为空）",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name":      "g1",
+						"instances": []interface{}{},
+					},
+				},
+			},
+			wantCode: 422,
+		},
+		{
+			name: "EP-2-007 实例 id 池内重复（跨组）",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name": "g1",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+						},
+					},
+					map[string]interface{}{
+						"name": "g2",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-a", "host": "10.0.0.2", "port": 9002},
+						},
+					},
+				},
+			},
+			wantCode: 422,
+		},
+		{
+			name: "EP-2-008 (host, port) 池内重复",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name": "g1",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+						},
+					},
+					map[string]interface{}{
+						"name": "g2",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-b", "host": "10.0.0.1", "port": 9002},
+						},
+					},
+				},
+			},
+			wantCode: 422,
+		},
+		{
+			name: "EP-2-009 非法 port（0）",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name": "g1",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 0},
+						},
+					},
+				},
+			},
+			wantCode: 422,
+		},
+		{
+			name: "EP-2-010 非法 port（65536）",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name": "g1",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 65536},
+						},
+					},
+				},
+			},
+			wantCode: 422,
+		},
+		{
+			name: "EP-2-011 非法 host",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name": "g1",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-a", "host": "-bad-host", "port": 9002},
+						},
+					},
+				},
+			},
+			wantCode: 422,
+		},
+		{
+			name: "EP-2-012 实例 id 为空",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name": "g1",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "", "host": "10.0.0.1", "port": 9002},
+						},
+					},
+				},
+			},
+			wantCode: 422,
+		},
+		{
+			name: "EP-2-013 单实例组在 test 模式校验通过",
+			body: map[string]interface{}{
+				"groups": []interface{}{
+					map[string]interface{}{
+						"name": "g1",
+						"instances": []interface{}{
+							map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+						},
+					},
+				},
+			},
+			wantCode: 200,
+			check: func(t *testing.T, resp *testutil.APIResponse) {
+				var data map[string]interface{}
+				json.Unmarshal(resp.Data, &data)
+				groups := data["groups"].([]interface{})
+				require.Len(t, groups, 1)
+				insts := groups[0].(map[string]interface{})["instances"].([]interface{})
+				assert.Len(t, insts, 1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := patchEppPool(t, tt.body)
+			if resp.ErrNum != tt.wantCode {
+				t.Errorf("expected ErrNum=%d, got ErrNum=%d, ErrMsg=%s", tt.wantCode, resp.ErrNum, resp.ErrMsg)
+			}
+			if tt.check != nil && resp.ErrNum == 200 {
+				tt.check(t, resp)
+			}
+		})
+	}
+}

--- a/test/integration/tests/innerapi/epp_data/epp_data_test.go
+++ b/test/integration/tests/innerapi/epp_data/epp_data_test.go
@@ -1,0 +1,346 @@
+package innerapi_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sm *testutil.ServerManager
+
+func TestMain(m *testing.M) {
+	var err error
+	sm, err = testutil.StartServer()
+	if err != nil {
+		panic("failed to start server: " + err.Error())
+	}
+	code := m.Run()
+	sm.Shutdown()
+	os.Exit(code)
+}
+
+// getServerDataConfCluster 导出 server_data_conf 并返回指定 cluster 的导出配置。
+func getServerDataConfCluster(t *testing.T, clusterName string) map[string]interface{} {
+	t.Helper()
+	resp, err := testutil.GetClient().Get("/inner-api/v1/configs/tls_conf/server_data_conf")
+	if err != nil {
+		t.Fatalf("export server_data_conf failed: %v", err)
+	}
+	testutil.AssertSuccess(t, resp)
+	var data map[string]interface{}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		t.Fatalf("unmarshal server_data_conf failed: %v", err)
+	}
+	clusterConf := data["ClusterConf"].(map[string]interface{})
+	config := clusterConf["Config"].(map[string]interface{})
+	cluster, ok := config[clusterName].(map[string]interface{})
+	require.True(t, ok, "cluster %s should exist in server_data_conf export", clusterName)
+	return cluster
+}
+
+// getEppData 拉取 epp_data 导出，version 为空表示首次拉取。
+func getEppData(t *testing.T, version string) *testutil.APIResponse {
+	t.Helper()
+	var resp *testutil.APIResponse
+	var err error
+	if version == "" {
+		resp, err = testutil.GetClient().Get("/inner-api/v1/configs/epp_data/config")
+	} else {
+		resp, err = testutil.GetClient().Get("/inner-api/v1/configs/epp_data/config", map[string]string{
+			"version": version,
+		})
+	}
+	if err != nil {
+		t.Fatalf("export epp_data failed: %v", err)
+	}
+	testutil.AssertSuccess(t, resp)
+	return resp
+}
+
+func findAssignmentEntry(t *testing.T, data map[string]interface{}, cluster string) map[string]interface{} {
+	t.Helper()
+	clusters := data["clusters"].([]interface{})
+	for _, item := range clusters {
+		entry := item.(map[string]interface{})
+		if entry["cluster"] == cluster {
+			return entry
+		}
+	}
+	return nil
+}
+
+func waitAssignmentPrimary(t *testing.T, cluster string, timeout time.Duration) map[string]interface{} {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := testutil.GetClient().Get("/open-api/v1/epp-assignments", map[string]string{"cluster": cluster})
+		if err != nil {
+			t.Fatalf("get assignments failed: %v", err)
+		}
+		if resp.ErrNum == 200 {
+			var data map[string]interface{}
+			if err := json.Unmarshal(resp.Data, &data); err == nil {
+				entry := findAssignmentEntry(t, data, cluster)
+				if entry != nil {
+					if primary, ok := entry["primary"].(map[string]interface{}); ok {
+						return primary
+					}
+				}
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("cluster %s not assigned within %v", cluster, timeout)
+	return nil
+}
+
+func TestInnerAPI_EppData(t *testing.T) {
+	pt := t
+	// degradeCluster 在空池上创建，进入未分配态；degradePrimary 在恢复后赋值。
+	var degradeCluster string
+	var degradePrimary map[string]interface{}
+
+	t.Run("IN-EPP-001 空池创建 EPP 集群进入未分配态并降级导出", func(t *testing.T) {
+		degradeCluster = testutil.UniqueClusterName()
+		providerName := testutil.UniqueProviderName()
+		if _, err := testutil.CreateProvider(providerName); err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		// 清理注册到父测试，避免子测试结束即删除（cleanup 按 LIFO，
+		// 先注册 provider 后注册 cluster，保证先删 cluster 再删 provider）。
+		pt.Cleanup(func() { testutil.DeleteProvider(providerName) })
+
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name":         degradeCluster,
+			"balance_mode": "EPP",
+			"epp_config":   map[string]interface{}{"scheduling_profile": "balanced"},
+			"llm_config": map[string]interface{}{
+				"models":   []string{"deepseek-chat"},
+				"provider": providerName,
+			},
+		})
+		if err != nil {
+			t.Fatalf("create epp cluster failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+		pt.Cleanup(func() { testutil.DeleteCluster(degradeCluster) })
+
+		// 分配视图：未分配，primary 为 null
+		view, err := testutil.GetClient().Get("/open-api/v1/epp-assignments", map[string]string{"cluster": degradeCluster})
+		if err != nil {
+			t.Fatalf("get assignments failed: %v", err)
+		}
+		testutil.AssertSuccess(t, view)
+		var viewData map[string]interface{}
+		json.Unmarshal(view.Data, &viewData)
+		entry := findAssignmentEntry(t, viewData, degradeCluster)
+		require.NotNil(t, entry)
+		assert.Nil(t, entry["primary"])
+		assert.Contains(t, viewData["unassigned_clusters"], degradeCluster)
+
+		// server_data_conf 降级导出：BalanceMode=WRR，无 EPPAddr
+		cluster := getServerDataConfCluster(t, degradeCluster)
+		gslbBasic, ok := cluster["GslbBasic"].(map[string]interface{})
+		require.True(t, ok, "GslbBasic should exist")
+		assert.Equal(t, "WRR", gslbBasic["BalanceMode"], "unassigned EPP cluster degrades to WRR")
+		assert.Nil(t, gslbBasic["EPPAddr"], "degraded cluster should not export EPPAddr")
+	})
+
+	t.Run("IN-EPP-002 恢复容量后 reconciler 自动分配并回到 EPP", func(t *testing.T) {
+		resp, err := testutil.GetClient().Patch("/open-api/v1/epp-pool", map[string]interface{}{
+			"groups": []interface{}{
+				map[string]interface{}{
+					"name": "g1",
+					"instances": []interface{}{
+						map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+						map[string]interface{}{"id": "epp-b", "host": "10.0.0.2", "port": 9002},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("patch epp pool failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		// reconciler 周期 1s（测试配置），轮询等待自动分配
+		degradePrimary = waitAssignmentPrimary(t, degradeCluster, 15*time.Second)
+		assert.Contains(t, []string{"epp-a", "epp-b"}, degradePrimary["id"])
+
+		cluster := getServerDataConfCluster(t, degradeCluster)
+		gslbBasic := cluster["GslbBasic"].(map[string]interface{})
+		assert.Equal(t, "EPP", gslbBasic["BalanceMode"])
+		eppAddr, ok := gslbBasic["EPPAddr"].([]interface{})
+		require.True(t, ok, "EPPAddr should be exported after assignment")
+		require.Len(t, eppAddr, 2, "two-instance group exports [primary, standby]")
+		expectedPrimary := fmt.Sprintf("%s:%v", degradePrimary["host"], int(degradePrimary["port"].(float64)))
+		assert.Equal(t, expectedPrimary, eppAddr[0], "EPPAddr[0] should be primary")
+		assert.NotEqual(t, eppAddr[0], eppAddr[1])
+	})
+
+	var fullCluster string
+	var fullPrimary, fullStandby map[string]interface{}
+	var firstVersion string
+
+	t.Run("IN-EPP-003 epp_data 导出含编译后 epp_config 与 assignment 两段", func(t *testing.T) {
+		fullCluster = testutil.UniqueClusterName()
+		providerName := testutil.UniqueProviderName()
+		if _, err := testutil.CreateProvider(providerName); err != nil {
+			t.Fatalf("setup provider failed: %v", err)
+		}
+		// 注册到父测试且先于 cluster 注册，保证清理时先删 cluster 再删 provider。
+		pt.Cleanup(func() { testutil.DeleteProvider(providerName) })
+
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name":         fullCluster,
+			"balance_mode": "EPP",
+			"epp_config": map[string]interface{}{
+				"scheduling_profile":       "latency-first",
+				"kv_cache_utilization_max": 0.85,
+				"session_affinity_enabled": true,
+				"session_affinity_header":  "x-session-id",
+				"flow_control": map[string]interface{}{
+					"max_requests":          200,
+					"queue_ttl":             45,
+					"no_endpoint_queue_ttl": 120,
+					"enable_eviction":       true,
+				},
+			},
+			"llm_config": map[string]interface{}{
+				"models":   []string{"deepseek-chat"},
+				"provider": providerName,
+			},
+		})
+		if err != nil {
+			t.Fatalf("create epp cluster failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+		pt.Cleanup(func() { testutil.DeleteCluster(fullCluster) })
+
+		// 自动分配：与 degradeCluster 共享 g1，allocator 选负载低的实例
+		fullPrimary = waitAssignmentPrimary(t, fullCluster, 15*time.Second)
+
+		viewResp, err := testutil.GetClient().Get("/open-api/v1/epp-assignments", map[string]string{"cluster": fullCluster})
+		if err != nil {
+			t.Fatalf("get assignments failed: %v", err)
+		}
+		var viewData map[string]interface{}
+		json.Unmarshal(viewResp.Data, &viewData)
+		entry := findAssignmentEntry(t, viewData, fullCluster)
+		require.NotNil(t, entry)
+		fullStandby = entry["standby"].(map[string]interface{})
+
+		exportResp := getEppData(t, "")
+		testutil.AssertDataNotEmpty(t, exportResp)
+		firstVersionBytes, err := testutil.GetDataField(exportResp, "Version")
+		require.NoError(t, err)
+		firstVersion = firstVersionBytes.(string)
+		require.NotEmpty(t, firstVersion)
+
+		configVal, err := testutil.GetDataField(exportResp, "Config")
+		if err != nil {
+			t.Fatalf("Config missing: %v", err)
+		}
+		config := configVal.(map[string]interface{})
+
+		// epp_config 段：编译后的 EndpointPickerConfig
+		eppConfig := config["epp_config"].(map[string]interface{})
+		compiled, ok := eppConfig[fullCluster].(map[string]interface{})
+		require.True(t, ok, "compiled epp_config should contain the cluster")
+		assert.Equal(t, []interface{}{"flowControl"}, compiled["featureGates"])
+
+		flowControl := compiled["flowControl"].(map[string]interface{})
+		assert.Equal(t, "200", flowControl["maxRequests"])
+		assert.Equal(t, "45s", flowControl["defaultRequestTTL"])
+		assert.Equal(t, "2m0s", flowControl["noEndpointRequestTTL"])
+		assert.Equal(t, true, flowControl["enableEviction"])
+
+		plugins := compiled["plugins"].([]interface{})
+		pluginTypes := map[string]bool{}
+		for _, p := range plugins {
+			plugin := p.(map[string]interface{})
+			pluginTypes[plugin["name"].(string)] = true
+		}
+		for _, name := range []string{"ep-discover", "util-filter", "kv-scorer", "queue-scorer", "prefix-scorer", "session-scorer", "max-score", "openai-parser"} {
+			assert.True(t, pluginTypes[name], "plugin %s should exist", name)
+		}
+
+		// session scorer 携带 header 配置
+		for _, p := range plugins {
+			plugin := p.(map[string]interface{})
+			if plugin["name"] == "session-scorer" {
+				params := plugin["parameters"].(map[string]interface{})
+				sessionCfg := params["sessionIdConfig"].(map[string]interface{})
+				sources := sessionCfg["sources"].([]interface{})
+				source := sources[0].(map[string]interface{})
+				assert.Equal(t, "x-session-id", source["header"])
+			}
+			if plugin["name"] == "util-filter" {
+				params := plugin["parameters"].(map[string]interface{})
+				conditions := params["conditions"].([]interface{})
+				condition := conditions[0].(map[string]interface{})
+				assert.Equal(t, "kv-cache-utilization", condition["metric"])
+				assert.Equal(t, 0.85, condition["maxValue"])
+			}
+		}
+
+		// latency-first 档位权重：kv=0.2，queue=1.0
+		profiles := compiled["schedulingProfiles"].([]interface{})
+		profile := profiles[0].(map[string]interface{})
+		weights := map[string]float64{}
+		for _, pp := range profile["plugins"].([]interface{}) {
+			profilePlugin := pp.(map[string]interface{})
+			if w, ok := profilePlugin["weight"].(float64); ok {
+				weights[profilePlugin["pluginRef"].(string)] = w
+			}
+		}
+		assert.Equal(t, 0.2, weights["kv-scorer"])
+		assert.Equal(t, 1.0, weights["queue-scorer"])
+
+		// assignment 段：全量视图，primary/standby 与分配视图一致
+		assignment := config["assignment"].(map[string]interface{})
+		entry1, ok := assignment[fullCluster].(map[string]interface{})
+		require.True(t, ok, "assignment should contain the cluster")
+		assert.Equal(t, fullPrimary["id"], entry1["primary"])
+		assert.Equal(t, fullStandby["id"], entry1["standby"])
+
+		entry2, ok := assignment[degradeCluster].(map[string]interface{})
+		require.True(t, ok, "assignment should contain all EPP clusters")
+		assert.NotEmpty(t, entry2["primary"])
+	})
+
+	t.Run("IN-EPP-004 epp_data 增量拉取同版本返回 Data null", func(t *testing.T) {
+		resp := getEppData(t, firstVersion)
+		assert.Equal(t, "null", string(resp.Data), "same version pull should return Data null")
+	})
+
+	t.Run("IN-EPP-005 手工覆写后版本推进且 assignment 更新", func(t *testing.T) {
+		newPrimaryID := fullStandby["id"].(string)
+		resp, err := testutil.GetClient().Put("/open-api/v1/epp-assignments/"+fullCluster, map[string]interface{}{
+			"group_name":          "g1",
+			"primary_instance_id": newPrimaryID,
+		})
+		if err != nil {
+			t.Fatalf("override failed: %v", err)
+		}
+		testutil.AssertSuccess(t, resp)
+
+		exportResp := getEppData(t, firstVersion)
+		require.NotEqual(t, "null", string(exportResp.Data), "override should bump epp_data version")
+		configVal, _ := testutil.GetDataField(exportResp, "Config")
+		assignment := configVal.(map[string]interface{})["assignment"].(map[string]interface{})
+		entry := assignment[fullCluster].(map[string]interface{})
+		assert.Equal(t, newPrimaryID, entry["primary"])
+
+		// 新版本再次拉取返回 null
+		newVersionVal, _ := testutil.GetDataField(exportResp, "Version")
+		reResp := getEppData(t, newVersionVal.(string))
+		assert.Equal(t, "null", string(reResp.Data))
+	})
+}

--- a/test/integration/tests/schema/innerapi/innerapi_schema_test.go
+++ b/test/integration/tests/schema/innerapi/innerapi_schema_test.go
@@ -2,6 +2,7 @@ package innerapi
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -34,6 +35,8 @@ func TestInnerAPI_Schema(t *testing.T) {
 	t.Run("mod_body_process", testModBodyProcessSchema)
 	t.Run("rate_limit_policy", testRateLimitPolicySchema)
 	t.Run("ai_route", testAIRouteSchema)
+	t.Run("epp_data", testEppDataSchema)
+	t.Run("server_data_conf_epp", testServerDataConfEppSchema)
 }
 
 // setupCluster 创建一个测试集群并返回名称
@@ -671,4 +674,172 @@ func testAIRouteSchema(t *testing.T) {
 		testutil.DeleteAPIKey(apiKeyID)
 		testutil.DeleteCluster(clusterName)
 	})
+}
+
+// ---------- epp_data ----------
+
+// patchEppPoolForSchema 为 EPP schema 用例配置独立的实例池布局（EPP 池为单例）。
+func patchEppPoolForSchema(t *testing.T) {
+	resp, err := testutil.GetClient().Patch("/open-api/v1/epp-pool", map[string]interface{}{
+		"groups": []interface{}{
+			map[string]interface{}{
+				"name": "g1",
+				"instances": []interface{}{
+					map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+					map[string]interface{}{"id": "epp-b", "host": "10.0.0.2", "port": 9002},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.ErrNum, resp.ErrMsg)
+}
+
+// createEPPClusterForSchema 创建一个 EPP 模式集群（自带 provider），返回名称。
+func createEPPClusterForSchema(t *testing.T, eppConfig map[string]interface{}) string {
+	t.Helper()
+	providerName := testutil.UniqueProviderName()
+	_, err := testutil.CreateProvider(providerName)
+	require.NoError(t, err)
+
+	clusterName := testutil.UniqueClusterName()
+	resp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+		"name":         clusterName,
+		"balance_mode": "EPP",
+		"epp_config":   eppConfig,
+		"llm_config": map[string]interface{}{
+			"models":   []string{"deepseek-chat"},
+			"provider": providerName,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.ErrNum, resp.ErrMsg)
+	return clusterName
+}
+
+func testEppDataSchema(t *testing.T) {
+	patchEppPoolForSchema(t)
+
+	clusterName := createEPPClusterForSchema(t, map[string]interface{}{
+		"scheduling_profile": "throughput-first",
+		"flow_control": map[string]interface{}{
+			"max_requests": 100,
+			"queue_ttl":    30,
+		},
+	})
+	t.Cleanup(func() { testutil.DeleteCluster(clusterName) })
+
+	resp, err := testutil.GetClient().Get("/inner-api/v1/configs/epp_data/config")
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, resp)
+	testutil.AssertSchema(t, resp, EppDataSchema)
+
+	// 定向断言（epp-data.md §3.2/§3.3）：
+	// assignment 含该 cluster 条目且 primary 非空；epp_config 编译产物关键字段存在。
+	var payload map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Data, &payload))
+	config := payload["Config"].(map[string]interface{})
+
+	assignment := config["assignment"].(map[string]interface{})
+	entry, ok := assignment[clusterName].(map[string]interface{})
+	require.True(t, ok, "assignment should contain cluster %s", clusterName)
+	primary, ok := entry["primary"].(string)
+	require.True(t, ok, "assignment.primary should be a string")
+	require.NotEmpty(t, primary)
+
+	eppConfig := config["epp_config"].(map[string]interface{})
+	compiled, ok := eppConfig[clusterName].(map[string]interface{})
+	require.True(t, ok, "epp_config should contain cluster %s", clusterName)
+	plugins, ok := compiled["plugins"].([]interface{})
+	require.True(t, ok, "compiled epp_config.plugins should be an array")
+	require.NotEmpty(t, plugins)
+	require.Contains(t, compiled, "featureGates")
+	require.Contains(t, compiled, "schedulingProfiles")
+	require.Contains(t, compiled, "dataLayer")
+}
+
+// ---------- server_data_conf EPP 导出 ----------
+
+func testServerDataConfEppSchema(t *testing.T) {
+	patchEppPoolForSchema(t)
+
+	eppClusterName := createEPPClusterForSchema(t, map[string]interface{}{
+		"scheduling_profile": "balanced",
+	})
+	wrrClusterName := testutil.UniqueClusterName()
+	{
+		providerName := testutil.UniqueProviderName()
+		_, err := testutil.CreateProvider(providerName)
+		require.NoError(t, err)
+		resp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+			"name": wrrClusterName,
+			"llm_config": map[string]interface{}{
+				"models":   []string{"deepseek-chat"},
+				"provider": providerName,
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.ErrNum, resp.ErrMsg)
+		t.Cleanup(func() { testutil.DeleteProvider(providerName) })
+	}
+	t.Cleanup(func() {
+		testutil.DeleteCluster(eppClusterName)
+		testutil.DeleteCluster(wrrClusterName)
+	})
+
+	resp, err := testutil.GetClient().Get("/inner-api/v1/configs/tls_conf/server_data_conf")
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, resp)
+	testutil.AssertSchema(t, resp, ServerDataConfSchema)
+
+	// EPP cluster：BalanceMode=EPP 且 EPPAddr 有序 [主, 备]（server-data-conf.md §3.3）。
+	assignResp, err := testutil.GetClient().Get("/open-api/v1/epp-assignments", map[string]string{
+		"cluster": eppClusterName,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 200, assignResp.ErrNum, assignResp.ErrMsg)
+	var assignView map[string]interface{}
+	require.NoError(t, json.Unmarshal(assignResp.Data, &assignView))
+	entries := assignView["clusters"].([]interface{})
+	entry := entries[0].(map[string]interface{})
+	primary := entry["primary"].(map[string]interface{})
+	standby := entry["standby"].(map[string]interface{})
+	expectedAddrs := []interface{}{
+		fmt.Sprintf("%s:%v", primary["host"], int(primary["port"].(float64))),
+		fmt.Sprintf("%s:%v", standby["host"], int(standby["port"].(float64))),
+	}
+	assertServerDataConfEpp(t, resp.Data, eppClusterName, "EPP", expectedAddrs)
+
+	// WRR cluster：BalanceMode=WRR 且无 EPPAddr。
+	assertServerDataConfEpp(t, resp.Data, wrrClusterName, "WRR", nil)
+}
+
+// assertServerDataConfEpp 校验导出结果中指定 cluster 的 GslbBasic.BalanceMode / EPPAddr
+// （server-data-conf.md §3.3：EPPAddr 有序 [主, 备]，WRR 时为 null）。
+func assertServerDataConfEpp(t *testing.T, data []byte, clusterName, wantMode string, wantEPPAddr []interface{}) {
+	t.Helper()
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal server_data_conf data: %v", err)
+	}
+	clusterConf := payload["ClusterConf"].(map[string]interface{})
+	config := clusterConf["Config"].(map[string]interface{})
+	cluster, ok := config[clusterName].(map[string]interface{})
+	if !ok {
+		t.Fatalf("cluster %s not found in ClusterConf.Config", clusterName)
+	}
+	gslbBasic, ok := cluster["GslbBasic"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("GslbBasic not found for cluster %s", clusterName)
+	}
+	assert.Equal(t, wantMode, gslbBasic["BalanceMode"])
+	if wantEPPAddr == nil {
+		assert.Nil(t, gslbBasic["EPPAddr"], "WRR cluster should not export EPPAddr")
+		return
+	}
+	eppAddr, ok := gslbBasic["EPPAddr"].([]interface{})
+	if !assert.True(t, ok, "EPPAddr should be an array for cluster %s", clusterName) {
+		return
+	}
+	assert.Equal(t, wantEPPAddr, eppAddr, "EPPAddr should be ordered [primary, standby]")
 }

--- a/test/integration/tests/schema/innerapi/schema.go
+++ b/test/integration/tests/schema/innerapi/schema.go
@@ -167,3 +167,23 @@ var AIRouteSchema = &testutil.ObjectSchema{
 		"ApikeyRouteTableBindings": {Type: testutil.TypeObject},
 	},
 }
+
+// EppDataConfigBodySchema /configs/epp_data/config 返回 Config 段的 schema。
+// epp_config / assignment 均为 cluster 名动态 key 的 map（见 epp-data.md §3），
+// 按本包惯例仅校验为 object；条目级结构由测试中的定向断言覆盖。
+var EppDataConfigBodySchema = &testutil.ObjectSchema{
+	Required: []string{"epp_config", "assignment"},
+	Fields: map[string]testutil.FieldSpec{
+		"epp_config": {Type: testutil.TypeObject},
+		"assignment": {Type: testutil.TypeObject},
+	},
+}
+
+// EppDataSchema /configs/epp_data/config 返回 schema（epp-data.md §3.1）
+var EppDataSchema = &testutil.ObjectSchema{
+	Required: []string{"Version", "Config"},
+	Fields: map[string]testutil.FieldSpec{
+		"Version": {Type: testutil.TypeString},
+		"Config":  {Type: testutil.TypeObject, Nested: EppDataConfigBodySchema},
+	},
+}

--- a/test/integration/tests/schema/openapi/cluster.go
+++ b/test/integration/tests/schema/openapi/cluster.go
@@ -69,9 +69,9 @@ var BasicSchema = &testutil.ObjectSchema{
 var StickySessionsSchema = &testutil.ObjectSchema{
 	Required: []string{"enabled", "hash_strategy", "hash_header"},
 	Fields: map[string]testutil.FieldSpec{
-		"enabled":      {Type: testutil.TypeBool},
-		"hash_strategy":{Type: testutil.TypeString},
-		"hash_header":  {Type: testutil.TypeString},
+		"enabled":       {Type: testutil.TypeBool},
+		"hash_strategy": {Type: testutil.TypeString},
+		"hash_header":   {Type: testutil.TypeString},
 	},
 }
 
@@ -148,13 +148,48 @@ var LLMConfigSchema = &testutil.ObjectSchema{
 	},
 }
 
+// EppConfigFlowControlSchema epp_config.flow_control schema
+// （clusters.md 表：epp_config.flow_control）
+var EppConfigFlowControlSchema = &testutil.ObjectSchema{
+	Optional: []string{"max_requests", "queue_ttl", "no_endpoint_queue_ttl", "enable_eviction"},
+	Fields: map[string]testutil.FieldSpec{
+		"max_requests":          {Type: testutil.TypeInt},
+		"queue_ttl":             {Type: testutil.TypeInt},
+		"no_endpoint_queue_ttl": {Type: testutil.TypeInt},
+		"enable_eviction":       {Type: testutil.TypeBool},
+	},
+}
+
+// EppConfigSchema 集群 epp_config（简化用户形态）schema。
+// 存储保留用户原始 JSON——未显式携带的字段不落盘，因此全部可选；
+// balance_mode=WRR 时 epp_config 可为 null（休眠保留），故 ClusterSchema 中设为 Optional。
+var EppConfigSchema = &testutil.ObjectSchema{
+	Optional: []string{
+		"scheduling_profile", "cache_affinity",
+		"prefix_cache_affinity", "session_affinity_enabled", "session_affinity_header",
+		"kv_cache_utilization_max", "flow_control",
+	},
+	Fields: map[string]testutil.FieldSpec{
+		"scheduling_profile": {Type: testutil.TypeString, Enum: []interface{}{"latency-first", "balanced", "throughput-first"}},
+		"cache_affinity":     {Type: testutil.TypeString, Enum: []interface{}{"low", "medium", "high"}},
+		"prefix_cache_affinity":    {Type: testutil.TypeBool},
+		"session_affinity_enabled": {Type: testutil.TypeBool},
+		"session_affinity_header":  {Type: testutil.TypeString},
+		"kv_cache_utilization_max": {Type: testutil.TypeNumber},
+		"flow_control":             {Type: testutil.TypeObject, Nested: EppConfigFlowControlSchema},
+	},
+}
+
 // ClusterSchema Cluster 数据模型 schema
 // 通过 /clusters 接口创建的集群 llm_config 必填。
+// balance_mode 必返回（缺省 WRR）；epp_config 未配置时为 null（Optional 允许 null）。
 var ClusterSchema = &testutil.ObjectSchema{
 	Required: []string{
 		"name", "description", "llm_config",
 		"basic", "sticky_sessions", "passive_health_check",
+		"balance_mode",
 	},
+	Optional: []string{"epp_config"},
 	Fields: map[string]testutil.FieldSpec{
 		"name":                 {Type: testutil.TypeString},
 		"description":          {Type: testutil.TypeString},
@@ -162,5 +197,7 @@ var ClusterSchema = &testutil.ObjectSchema{
 		"sticky_sessions":      {Type: testutil.TypeObject, Nested: StickySessionsSchema},
 		"passive_health_check": {Type: testutil.TypeObject, Nested: PassiveHealthCheckSchema},
 		"llm_config":           {Type: testutil.TypeObject, Nested: LLMConfigSchema},
+		"balance_mode":         {Type: testutil.TypeString, Enum: []interface{}{"WRR", "EPP"}},
+		"epp_config":           {Type: testutil.TypeObject, Nested: EppConfigSchema},
 	},
 }

--- a/test/integration/tests/schema/openapi/epp_assignments.go
+++ b/test/integration/tests/schema/openapi/epp_assignments.go
@@ -1,0 +1,42 @@
+package openapi
+
+import "github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+
+// EppClusterAssignmentSchema /epp-assignments §2.1 全量视图 clusters[] 元素 schema。
+// group/primary/standby 在未分配或单实例组（无备）时为 null，故设为 Optional
+// （testutil schema 校验中 Optional 字段为 null 时跳过类型校验）。
+var EppClusterAssignmentSchema = &testutil.ObjectSchema{
+	Required: []string{"cluster", "degraded"},
+	Optional: []string{"group", "primary", "standby"},
+	Fields: map[string]testutil.FieldSpec{
+		"cluster":  {Type: testutil.TypeString},
+		"group":    {Type: testutil.TypeString},
+		"primary":  {Type: testutil.TypeObject, Nested: EppInstanceSchema},
+		"standby":  {Type: testutil.TypeObject, Nested: EppInstanceSchema},
+		"degraded": {Type: testutil.TypeBool},
+	},
+}
+
+// EppClusterAssignmentOverrideSchema /epp-assignments §2.2 PUT 覆写响应 schema。
+// 实现（ClusterAssignmentOverrideData）按契约注释不含 degraded 标记，故此处不要求。
+var EppClusterAssignmentOverrideSchema = &testutil.ObjectSchema{
+	Required: []string{"cluster"},
+	Optional: []string{"group", "primary", "standby"},
+	Fields: map[string]testutil.FieldSpec{
+		"cluster": {Type: testutil.TypeString},
+		"group":   {Type: testutil.TypeString},
+		"primary": {Type: testutil.TypeObject, Nested: EppInstanceSchema},
+		"standby": {Type: testutil.TypeObject, Nested: EppInstanceSchema},
+	},
+}
+
+// EppAssignmentsViewSchema /epp-assignments 全量视图 schema
+// （GET 全量视图与 GET ?cluster= 过滤响应同结构）。
+var EppAssignmentsViewSchema = &testutil.ObjectSchema{
+	Required: []string{"clusters", "unassigned_clusters", "idle_groups"},
+	Fields: map[string]testutil.FieldSpec{
+		"clusters":            {Type: testutil.TypeArray, Elem: EppClusterAssignmentSchema},
+		"unassigned_clusters": {Type: testutil.TypeArray, Item: &testutil.FieldSpec{Type: testutil.TypeString}},
+		"idle_groups":         {Type: testutil.TypeArray, Item: &testutil.FieldSpec{Type: testutil.TypeString}},
+	},
+}

--- a/test/integration/tests/schema/openapi/epp_pool.go
+++ b/test/integration/tests/schema/openapi/epp_pool.go
@@ -1,0 +1,32 @@
+package openapi
+
+import "github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+
+// EppInstanceSchema EPP 实例 schema（/epp-pool 与 /epp-assignments 共用：
+// 仅 id/host/port 三个字段，见 epp-pool.md 数据模型）。
+var EppInstanceSchema = &testutil.ObjectSchema{
+	Required: []string{"id", "host", "port"},
+	Fields: map[string]testutil.FieldSpec{
+		"id":   {Type: testutil.TypeString},
+		"host": {Type: testutil.TypeString},
+		"port": {Type: testutil.TypeInt},
+	},
+}
+
+// EppPoolGroupSchema /epp-pool groups 元素 schema
+var EppPoolGroupSchema = &testutil.ObjectSchema{
+	Required: []string{"name", "instances"},
+	Fields: map[string]testutil.FieldSpec{
+		"name":      {Type: testutil.TypeString},
+		"instances": {Type: testutil.TypeArray, Elem: EppInstanceSchema},
+	},
+}
+
+// EppPoolSchema /epp-pool（GET/PATCH 响应）schema
+var EppPoolSchema = &testutil.ObjectSchema{
+	Required: []string{"name", "groups"},
+	Fields: map[string]testutil.FieldSpec{
+		"name":   {Type: testutil.TypeString},
+		"groups": {Type: testutil.TypeArray, Elem: EppPoolGroupSchema},
+	},
+}

--- a/test/integration/tests/schema/openapi/openapi_schema_test.go
+++ b/test/integration/tests/schema/openapi/openapi_schema_test.go
@@ -34,6 +34,8 @@ func TestOpenAPI_Schema(t *testing.T) {
 	t.Run("model_prices", testModelPriceSchema)
 	t.Run("route_tables", testRouteTableSchema)
 	t.Run("global_route_rules", testGlobalRouteRulesSchema)
+	t.Run("epp_pool", testEppPoolSchema)
+	t.Run("epp_assignments", testEppAssignmentsSchema)
 }
 
 // ---------- entity-types ----------
@@ -369,10 +371,107 @@ func testClusterSchema(t *testing.T) {
 	testutil.AssertSuccess(t, patchResp)
 	testutil.AssertSchema(t, patchResp, ClusterSchema)
 
+	// EPP 模式集群：balance_mode/epp_config 字段与嵌套结构校验。
+	eppProviderName := testutil.UniqueProviderName()
+	_, err = testutil.CreateProvider(eppProviderName)
+	require.NoError(t, err)
+
+	eppClusterName := testutil.UniqueClusterName()
+	eppClusterBody := map[string]interface{}{
+		"name":         eppClusterName,
+		"description":  "schema test epp",
+		"balance_mode": "EPP",
+		"epp_config": map[string]interface{}{
+			"scheduling_profile":       "latency-first",
+			"cache_affinity":           "high",
+			"prefix_cache_affinity":    true,
+			"session_affinity_enabled": true,
+			"session_affinity_header":  "x-session-id",
+			"kv_cache_utilization_max": 0.85,
+			"flow_control": map[string]interface{}{
+				"max_requests":          200,
+				"queue_ttl":             45,
+				"no_endpoint_queue_ttl": 120,
+				"enable_eviction":       true,
+			},
+		},
+		"llm_config": map[string]interface{}{
+			"models":   []string{"deepseek-chat"},
+			"provider": eppProviderName,
+		},
+	}
+	eppCreateResp, err := testutil.GetClient().Post("/open-api/v1/clusters", eppClusterBody)
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, eppCreateResp)
+	testutil.AssertSchema(t, eppCreateResp, ClusterSchema)
+
+	eppOneResp, err := testutil.GetClient().Get("/open-api/v1/clusters/" + eppClusterName)
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, eppOneResp)
+	testutil.AssertSchema(t, eppOneResp, ClusterSchema)
+
+	// epp_config 原样回读（存储保留用户原始 JSON，未携带字段不落盘）。
+	assertEppConfigEcho(t, eppOneResp.Data, map[string]interface{}{
+		"scheduling_profile":       "latency-first",
+		"cache_affinity":           "high",
+		"prefix_cache_affinity":    true,
+		"session_affinity_enabled": true,
+		"session_affinity_header":  "x-session-id",
+		"kv_cache_utilization_max": 0.85,
+		"flow_control": map[string]interface{}{
+			"max_requests":          float64(200),
+			"queue_ttl":             float64(45),
+			"no_endpoint_queue_ttl": float64(120),
+			"enable_eviction":       true,
+		},
+	})
+
+	// WRR 集群携带 epp_config（休眠保留）：创建成功且 GET 原样返回。
+	dormantClusterName := testutil.UniqueClusterName()
+	dormantResp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+		"name":         dormantClusterName,
+		"balance_mode": "WRR",
+		"epp_config":   map[string]interface{}{"scheduling_profile": "throughput-first"},
+		"llm_config": map[string]interface{}{
+			"models":   []string{"deepseek-chat"},
+			"provider": eppProviderName,
+		},
+	})
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, dormantResp)
+	testutil.AssertSchema(t, dormantResp, ClusterSchema)
+
+	dormantOneResp, err := testutil.GetClient().Get("/open-api/v1/clusters/" + dormantClusterName)
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, dormantOneResp)
+	testutil.AssertSchema(t, dormantOneResp, ClusterSchema)
+	assertEppConfigEcho(t, dormantOneResp.Data, map[string]interface{}{
+		"scheduling_profile": "throughput-first",
+	})
+
 	t.Cleanup(func() {
 		testutil.DeleteCluster(clusterName)
+		testutil.DeleteCluster(eppClusterName)
+		testutil.DeleteCluster(dormantClusterName)
 		testutil.DeleteProvider(providerName)
+		testutil.DeleteProvider(eppProviderName)
 	})
+}
+
+// assertEppConfigEcho 校验 GET cluster 回读中 epp_config 与写入值一致（原样回读）。
+func assertEppConfigEcho(t *testing.T, data []byte, want map[string]interface{}) {
+	t.Helper()
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal cluster data: %v", err)
+	}
+	eppConfig, ok := payload["epp_config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("epp_config is not an object: %v", payload["epp_config"])
+	}
+	for key, wantVal := range want {
+		require.Equal(t, wantVal, eppConfig[key], "epp_config.%s echo mismatch", key)
+	}
 }
 
 // ---------- certificates ----------
@@ -629,3 +728,172 @@ func testGlobalRouteRulesSchema(t *testing.T) {
 }
 
 
+
+// ---------- epp-pool ----------
+
+func testEppPoolSchema(t *testing.T) {
+	// EPP 池为单例：本用例 PATCH 自己的组布局后回读。
+	patchResp, err := testutil.GetClient().Patch("/open-api/v1/epp-pool", map[string]interface{}{
+		"groups": []interface{}{
+			map[string]interface{}{
+				"name": "g1",
+				"instances": []interface{}{
+					map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+					map[string]interface{}{"id": "epp-b", "host": "10.0.0.2", "port": 9002},
+				},
+			},
+			map[string]interface{}{
+				"name": "g2",
+				"instances": []interface{}{
+					map[string]interface{}{"id": "epp-c", "host": "10.0.0.3", "port": 9002},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, patchResp)
+	testutil.AssertSchema(t, patchResp, EppPoolSchema)
+
+	getResp, err := testutil.GetClient().Get("/open-api/v1/epp-pool")
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, getResp)
+	testutil.AssertSchema(t, getResp, EppPoolSchema)
+
+	// 定向断言：name 为配置的单例池名，组与实例字段完整回读。
+	nameVal, err := testutil.GetDataField(getResp, "name")
+	require.NoError(t, err)
+	require.Equal(t, "EPP.pool", nameVal)
+	groupsVal, err := testutil.GetDataField(getResp, "groups")
+	require.NoError(t, err)
+	groups := groupsVal.([]interface{})
+	require.Len(t, groups, 2)
+	g1 := groups[0].(map[string]interface{})
+	require.Equal(t, "g1", g1["name"])
+	insts := g1["instances"].([]interface{})
+	require.Len(t, insts, 2)
+	inst0 := insts[0].(map[string]interface{})
+	require.Equal(t, "epp-a", inst0["id"])
+	require.Equal(t, "10.0.0.1", inst0["host"])
+	require.Equal(t, float64(9002), inst0["port"])
+}
+
+// ---------- epp-assignments ----------
+
+func testEppAssignmentsSchema(t *testing.T) {
+	// PATCH 自己的组布局（EPP 池单例，不依赖其他用例的池状态）。
+	patchResp, err := testutil.GetClient().Patch("/open-api/v1/epp-pool", map[string]interface{}{
+		"groups": []interface{}{
+			map[string]interface{}{
+				"name": "g1",
+				"instances": []interface{}{
+					map[string]interface{}{"id": "epp-a", "host": "10.0.0.1", "port": 9002},
+					map[string]interface{}{"id": "epp-b", "host": "10.0.0.2", "port": 9002},
+				},
+			},
+			map[string]interface{}{
+				"name": "g2",
+				"instances": []interface{}{
+					map[string]interface{}{"id": "epp-c", "host": "10.0.0.3", "port": 9002},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, patchResp)
+
+	providerName := testutil.UniqueProviderName()
+	_, err = testutil.CreateProvider(providerName)
+	require.NoError(t, err)
+
+	clusterName := testutil.UniqueClusterName()
+	createResp, err := testutil.GetClient().Post("/open-api/v1/clusters", map[string]interface{}{
+		"name":         clusterName,
+		"balance_mode": "EPP",
+		"epp_config":   map[string]interface{}{"scheduling_profile": "balanced"},
+		"llm_config": map[string]interface{}{
+			"models":   []string{"deepseek-chat"},
+			"provider": providerName,
+		},
+	})
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, createResp)
+
+	t.Cleanup(func() {
+		testutil.DeleteCluster(clusterName)
+		testutil.DeleteProvider(providerName)
+	})
+
+	// 全量视图：结构 + 定向断言（该 cluster 已自动分配、g2 空闲）。
+	viewResp, err := testutil.GetClient().Get("/open-api/v1/epp-assignments")
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, viewResp)
+	testutil.AssertSchema(t, viewResp, EppAssignmentsViewSchema)
+
+	assertAssignmentEntry(t, viewResp.Data, clusterName, false)
+
+	idleVal, err := testutil.GetDataField(viewResp, "idle_groups")
+	require.NoError(t, err)
+	require.Contains(t, idleVal, "g2")
+	unassignedVal, err := testutil.GetDataField(viewResp, "unassigned_clusters")
+	require.NoError(t, err)
+	require.NotContains(t, unassignedVal, clusterName)
+
+	// 单条过滤查询：同结构 schema。
+	oneResp, err := testutil.GetClient().Get("/open-api/v1/epp-assignments", map[string]string{
+		"cluster": clusterName,
+	})
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, oneResp)
+	testutil.AssertSchema(t, oneResp, EppAssignmentsViewSchema)
+	assertAssignmentEntry(t, oneResp.Data, clusterName, false)
+
+	// 手工覆写后单条响应结构（standby 换为另一实例）。
+	entry := findAssignmentEntry(t, oneResp.Data, clusterName)
+	standby := entry["standby"].(map[string]interface{})
+	putResp, err := testutil.GetClient().Put("/open-api/v1/epp-assignments/"+clusterName, map[string]interface{}{
+		"group_name":          "g1",
+		"primary_instance_id": standby["id"],
+	})
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, putResp)
+	testutil.AssertSchema(t, putResp, EppClusterAssignmentOverrideSchema)
+
+	putPrimary, err := testutil.GetDataField(putResp, "primary")
+	require.NoError(t, err)
+	require.Equal(t, standby["id"], putPrimary.(map[string]interface{})["id"])
+}
+
+// findAssignmentEntry 从全量视图中取出指定 cluster 的分配条目。
+func findAssignmentEntry(t *testing.T, data []byte, clusterName string) map[string]interface{} {
+	t.Helper()
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal assignments data: %v", err)
+	}
+	clusters := payload["clusters"].([]interface{})
+	for _, item := range clusters {
+		entry := item.(map[string]interface{})
+		if entry["cluster"] == clusterName {
+			return entry
+		}
+	}
+	t.Fatalf("cluster %s not found in assignments view", clusterName)
+	return nil
+}
+
+// assertAssignmentEntry 定向断言指定 cluster 已分配（group/primary/standby 非空）。
+func assertAssignmentEntry(t *testing.T, data []byte, clusterName string, unassigned bool) {
+	t.Helper()
+	entry := findAssignmentEntry(t, data, clusterName)
+	require.Equal(t, unassigned, entry["degraded"].(bool))
+	if unassigned {
+		require.Nil(t, entry["primary"])
+		return
+	}
+	require.NotNil(t, entry["group"])
+	primary, ok := entry["primary"].(map[string]interface{})
+	require.True(t, ok, "primary should be an object")
+	require.NotEmpty(t, primary["id"])
+	require.NotEmpty(t, primary["host"])
+	require.NotNil(t, entry["standby"])
+}


### PR DESCRIPTION
- OpenAPI: /clusters 新增 balance_mode(WRR|EPP) 与 epp_config（档位+调优参数的用户侧简化形态）；新增 /epp-pool（单例池，仿 /alb-pool）与 /epp-assignments（分配全量视图）
- InnerAPI: 新增 /configs/epp_data/config（编译后的 EndpointPickerConfig + assignment 合并下发，version 增量）；cluster_table 导出对 EPP cluster 同步 provider 实例（EPP 发现与 BFE 兜底依赖）
- 修复 ProviderInstancePoolSyncer 跳过 Role=EPP 实例池导致 provider 实例池变更（如 weight=0 摘流）不生效的问题（SC28 五组件集成测试 TC-07 暴露）
- 分配：确定性贪心算法，导出 server_data_conf 时无有效分配的 EPP cluster 降级 WRR 并输出 error 日志
- 设计文档：modifications/2026-09-08-epp-scheduling-integration、api-define、sys-design 同步更新