### PR TITLE
fix(provider): PATCH /providers 部分更新语义，省略字段保留原值

### DIFF
--- a/design-docs/api-define/OpenAPI接口定义/providers.md
+++ b/design-docs/api-define/OpenAPI接口定义/providers.md
@@ -330,9 +330,10 @@
 
 可修改字段含义同创建接口，但**输入参数不包括 `name`，即不能修改 provider 的 name**（名称由 URI 中的 `provider_name` 指定）。若请求体中仍包含 `name`，返回 422。若传入 `instance_pool` 字段，系统会自动同步更新被引用该 provider 的所有 cluster 所生成的实例池。
 
-> **注意**：
-> - `keys` 作为数组，按**全量替换**处理，即调用方需传入完整的最新 Key 列表。Key 的 `name` 删除/重命名会校验无 cluster 仍引用旧 name；若被引用，返回 `409 Conflict`。
-> - `models` 作为数组，按**全量替换**处理。删除 model 会校验无 cluster 仍引用该 model；若被引用，返回 `409 Conflict`。
+> **注意**：本接口为**部分更新**语义——请求体中未提供的字段（`description`、`model_endpoint`、`models`、`keys`、`time_zone`、`tiers` 等）保持原值不变。
+> - `keys` 作为数组，**显式提供时按全量替换**处理，即调用方需传入完整的最新 Key 列表；省略时保留原值。Key 的 `name` 删除/重命名会校验无 cluster 仍引用旧 name；若被引用，返回 `409 Conflict`。
+> - `models` 作为数组，**显式提供时按全量替换**处理；省略时保留原值。删除 model 会校验无 cluster 仍引用该 model；若被引用，返回 `409 Conflict`。
+> - `tiers`、`time_zone`、`model_endpoint`：提供即更新，省略保留原值。`time_zone` 取值须为合法时区名（如 `Asia/Shanghai`、`UTC`）。
 
 **HTTP BODY 参数示例**
 

--- a/design-docs/modifications/2026-09-09-issue-147-provider-patch-partial-update/change-summary.md
+++ b/design-docs/modifications/2026-09-09-issue-147-provider-patch-partial-update/change-summary.md
@@ -1,0 +1,166 @@
+# Issue #147：PATCH /providers/{provider_name} 省略字段被静默覆盖修复方案
+
+## 1. 问题来源
+
+[rainway-ai-gateway/ai-gateway-api/issues/147](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/147)
+
+> 调用 PATCH /providers/{provider_name} 只修改部分字段、请求体省略其他非必填字段时，被省略的字段不会保留原值，而是被静默覆盖。
+
+受影响字段与现象：
+
+| 省略字段 | 实际行为 | 影响 |
+|------|------|------|
+| `time_zone` | 被重置为 `Asia/Shanghai` | 此前自定义时区（如 UTC）丢失 |
+| `tiers` | 被清空（DB 写入 `"null"`） | peak 时段定价丢失 |
+| `models` | 被清空（写入 `"[]"`） | 模型列表丢失 |
+| `keys` | 被清空（写入 `"[]"`） | API Key 列表丢失 |
+| `model_endpoint` | 被重置为默认 `{https, /v1/models}` | 自定义端点丢失 |
+
+`description`（`*string`）不受影响——nil 指针被 DAO 跳过，原值保留。`instance_pool`、`model_protocols` 因 `ValidateProviderParam` 强制非空（`model/iprovider/provider.go:441-460`），PATCH 必须提供，不在本次范围。
+
+## 2. 根因
+
+调用链：`UpdateAction`（`endpoints/openapi_v1/provider/update.go:41`）→ `ProviderManager.UpdateProvider`（`model/iprovider/provider.go:195`）→ `RDBProviderStorager.UpdateProvider`（`storage/rdb/provider/provider.go:54`）→ `toDAOParam`（同文件 :156）→ `dao.TProviderUpdate` → `struct2map`（`storage/rdb/internal/dao/internal/builder.go:43`）。
+
+DAO 层 `struct2map` 本就支持部分更新：nil 指针字段跳过（`builder.go:58-63`）、零值切片跳过（:65-68），不进 SET 子句即保留列原值。
+
+问题出在上游 `toDAOParam` 在写库前把"未提供（nil）"抹平成"显式提供默认值"：
+
+1. **`FillDefaults` 补默认值**（`storage/rdb/provider/provider.go:161` → `model/iprovider/provider.go:725-750`）：`ModelEndpoint == nil` → `DefaultModelEndpoint()`；`Models == nil` → `[]string{}`；`Keys == nil` → `[]ProviderKey{}`；`TimeZone == nil` → `&"Asia/Shanghai"`。指针/切片由 nil 变为非 nil。
+2. **`marshalJSON` 把 nil 切片固化为非 nil 指针**（`storage/rdb/provider/provider.go:244-251`）：`if v == nil` 只判 nil interface；`[]T` 类型的 nil 切片作为 `interface{}` 传入时动态类型非 nil，于是走 `json.Marshal`——nil 切片 → `"null"`、`FillDefaults` 产出的空切片 → `"[]"`，两种结果都是非 nil `*string`。
+3. 最终 `TProviderParam` 中 `TimeZone`、`ModelEndpoint`、`Models`、`Keys`、`Tiers` 全为非 nil 指针，`struct2map` 不再跳过，五个字段全部进 SET 子句，原值被覆盖。
+
+对照：`4106af9` 给 `instance_pool`/`keys`/`models` 加的 origX 快照 + 还原 nil 逻辑（`model/iprovider/provider.go:218-251`）只服务于 sync hook 的触发判定与快照构建，不影响 DB 写入语义——storager 拿到的仍是被抹平后的 param。
+
+历史：`models`/`keys` 的"省略即清空"自 provider/cluster 分离（`c52dbab`）起存在；`time_zone`/`tiers` 在 `faf9556`（RMB 分时段定价能力）落地后加入同一覆盖路径。属初始缺陷，非近期回归。
+
+## 3. 目标
+
+1. PATCH 请求体未提供的字段（`model_endpoint` / `models` / `keys` / `time_zone` / `tiers`），保持 provider 原配置不变——部分更新语义，与 `description` 现有行为一致；
+2. 请求体显式提供的字段仍正常更新（含显式传空数组/空 tiers 的"全量替换/清空"语义）；
+3. Create 路径默认值语义不变：不传 `time_zone` 仍默认 `Asia/Shanghai`，不传 `models`/`keys` 仍为空数组；
+4. 合同文档（`providers.md` §2.4）明确 PATCH 部分更新语义。
+
+## 4. 范围
+
+| 范围 | 说明 |
+|------|------|
+| 涉及仓库 | `ai-gateway-api` |
+| 主要文件 | `storage/rdb/provider/provider.go`（`toDAOParam` / `marshalJSON` / `RDBProviderStorager.UpdateProvider`）；`model/iprovider/provider.go`（`UpdateProvider` hook 快照段，可选简化） |
+| 接口契约 | PATCH 请求/响应结构不变；仅"省略字段"语义从"被覆盖为默认/空"修正为"保留原值" |
+| 不在范围 | `instance_pool` / `model_protocols` 仍保持必填校验；Create 路径行为不变 |
+| 数据迁移 | 无（已被静默覆盖的历史数据不回溯修复） |
+
+## 5. 最终方案
+
+核心思路：让 Update 路径产出 nil 指针，交给 DAO 的 nil-skip 保留原值。为 Update 提供独立的 param→DAO 转换路径，不调用 `FillDefaults`。
+
+### 5.1 拆分 create/update 转换路径
+
+`storage/rdb/provider/provider.go`：
+
+- `RDBProviderStorager.CreateProvider` 继续走原 `toDAOParam`（含 `FillDefaults`），创建默认值语义不变；
+- 新增 `toDAOParamForUpdate`，`RDBProviderStorager.UpdateProvider` 改用它，**不调用 `FillDefaults`**；
+- 指针字段直接透传：`TimeZone: param.TimeZone`——nil 即保留 nil，DAO 跳过；非 nil 即更新。
+
+### 5.2 nil 切片 → nil 指针
+
+新增 `marshalJSONPtr`（或等价短路逻辑），替代 Update 路径的 `marshalJSON`：
+
+```go
+// marshalJSONPtr returns nil for a nil interface or nil slice, so the DAO
+// layer's nil-skip keeps the existing column value on partial updates.
+func marshalJSONPtr(v interface{}) (*string, error) {
+    if v == nil {
+        return nil, nil
+    }
+    rv := reflect.ValueOf(v)
+    if rv.Kind() == reflect.Slice && rv.IsNil() {
+        return nil, nil
+    }
+    data, err := json.Marshal(v)
+    if err != nil {
+        return nil, err
+    }
+    return lib.PString(string(data)), nil
+}
+```
+
+`toDAOParamForUpdate` 中 `Models` / `Keys` / `Tiers` / `InstancePool` / `ModelProtocols` 均改用 `marshalJSONPtr`：省略（nil 切片）→ nil 指针 → DAO 跳过；显式提供（含空数组）→ 正常 marshal 进 SET 子句。
+
+> 语义对照：`models: []` 显式传入仍写 `"[]"`（清空），`models` 省略则保留原值——"提供即更新、省略即保留"双向正确。
+
+### 5.3 ModelEndpoint 子字段默认值
+
+`ValidateProviderParam` 在非 nil 时已对 `ModelEndpoint` 补 `Schema`/`URI` 默认值（`model/iprovider/provider.go:462-471`），因此 Update 路径去掉 `FillDefaults` 后，显式提供 endpoint 的兜底行为不受影响；省略时 nil 指针被 DAO 跳过。
+
+### 5.4 manager 层 hook 快照段（伴随清理，非必需）
+
+修复后 storager 不再调用 `FillDefaults`，param 不会再被原地 mutation，`model/iprovider/provider.go:241-251` 的"还原 nil"块（`if origKeys == nil { param.Keys = nil }` 等）退化为 no-op。可保留作防御，也可删除；origX 快照 + `clusterConfigChanged` 判定逻辑保留不动。`applyProviderUpdate` 本就按 nil 保留 existing 值（`:866-872`），无需修改。
+
+### 5.5 顺带修正：PATCH 的 time_zone 合法性校验
+
+`ValidateProviderParam` 当前不校验 `TimeZone`（`validateTimeZone` 仅被 `ValidatePricingTiersParam` 调用）。修复后 PATCH 可显式传 `time_zone`，建议在 `ValidateProviderParam` 内补：`if param.TimeZone != nil { validateTimeZone(*param.TimeZone) }`——`validateTimeZone` 对空串放行，对非法时区报错，不影响省略场景。
+
+### 5.6 修复点一览
+
+| 字段 | 当前 nil 时的抹平点 | 修复后 nil 处理 |
+|------|------|------|
+| `model_endpoint` | `FillDefaults` → `DefaultModelEndpoint()`（provider.go:726-734） | Update 路径不补默认，nil → DAO skip |
+| `models` | `FillDefaults` → `[]string{}` → `"[]"` | Update 路径 nil → nil 指针 → DAO skip |
+| `keys` | `FillDefaults` → `[]ProviderKey{}` → `"[]"` | 同上 |
+| `time_zone` | `FillDefaults` → `&"Asia/Shanghai"`（provider.go:745-748） | Update 路径不补默认，nil → DAO skip |
+| `tiers` | `marshalJSON`（nil 切片）→ `"null"` | Update 路径 nil → nil 指针 → DAO skip |
+
+## 6. 合同文档补充（providers.md §2.4）
+
+`design-docs/api-define/OpenAPI接口定义/providers.md` §2.4"注意"处调整为：
+
+- PATCH 为**部分更新**语义：未提供的字段保留原值不变；
+- `keys`、`models`、`tiers` 作为数组，**显式提供时按全量替换处理**；省略时保留原值（本次修复前省略会被静默清空，属缺陷）；
+- `time_zone`、`model_endpoint` 同理：提供即更新，省略保留原值。
+
+## 7. 回归防护
+
+1. **storager 单测**（`storage/rdb/provider/provider_test.go`，新文件）：
+   - `toDAOParamForUpdate`：五个字段分别为 nil 时，`TProviderParam` 对应字段为 nil 指针；
+   - 显式空切片（`[]string{}`、`[]PricingTier{}`）产出非 nil 指针（`"[]"`），与 nil 区分；
+   - `toDAOParam`（Create 路径）行为不变：nil 输入仍补默认值；
+   - `marshalJSONPtr`：nil interface、nil 切片、空切片、非空切片的四种分支。
+2. **manager 单测**（`model/iprovider/provider_test.go` 补充）：
+   - PATCH 只传 `description`，断言 storager 收到的 param 五个字段仍为 nil（配合 fake storager 捕获入参）；
+   - PATCH 显式传 `keys: []`，断言触发 `ProviderKeyRefChecker` 且写库参数为非 nil 空数组。
+3. **E2E / 集成测试**：
+   - 设 `time_zone="UTC"` + peak tier + 自定义 models/keys/model_endpoint，PATCH 只改 description，断言五项原值不变；
+   - PATCH 只改 `instance_pool`，断言其余字段不变；
+   - PATCH 只改 `time_zone`（提供值），断言 tiers 等其他字段不变；
+   - Create 回归：不传 `time_zone` 仍默认 `Asia/Shanghai`，不传 models/keys 仍为空数组。
+   - 修复部署前 grep 集成测试与上游脚本，确认无调用方依赖"PATCH 省略 keys/models 即清空"的旧（缺陷）行为。
+
+## 8. 风险与兼容性
+
+| 项目 | 说明 |
+|------|------|
+| 兼容性 | PATCH 请求/响应结构不变；仅"省略字段"语义修正为保留原值，属缺陷修复而非行为变更 |
+| 主要风险 | 若调用方依赖"PATCH 不传 keys/models 即清空"的旧行为会被打破——该行为与部分更新语义相悖，应视为修复；需要清空的调用方应显式传 `[]` |
+| Create 路径 | `FillDefaults` 仍被 `CreateProvider` 使用，拆分路径后创建默认值语义不受影响 |
+| 校验层 | `validatePricingTiers(nil)` 对 nil 放行，`instance_pool`/`model_protocols` 必填校验不变，无需放宽 |
+| sync hook | origX 快照 + `clusterConfigChanged` 判定与 `applyProviderUpdate` 均按"显式提供才触发、nil 保留 existing"工作，与修复后语义一致，无需改动 |
+
+---
+
+## 9. 实施记录（2026-09-09）
+
+已按本方案完成实施：
+
+| 变更 | 文件 | 说明 |
+|------|------|------|
+| 拆分 Update 转换路径 | `storage/rdb/provider/provider.go` | 新增 `toDAOParamForUpdate`（不调用 `FillDefaults`），`RDBProviderStorager.UpdateProvider` 改用它；`marshalJSONPtr` 对 nil interface/nil 指针/nil 切片返回 nil 指针，空切片正常 marshal |
+| time_zone 校验 | `model/iprovider/provider.go` | `ValidateProviderParam` 新增 `TimeZone != nil` 时的 `validateTimeZone` 校验，省略仍放行 |
+| storager 单测 | `storage/rdb/provider/provider_test.go`（新文件） | 转换函数分支 + 基于内存 SQLite 的端到端部分更新/显式清空/Create 默认值测试 |
+| manager 单测 | `model/iprovider/provider_test.go` | 省略字段以 nil 到达 storager、显式空 keys 触发 ref checker hook、time_zone 校验三分支 |
+| 合同文档 | `design-docs/api-define/OpenAPI接口定义/providers.md` §2.4 | 明确 PATCH 部分更新语义 |
+
+验证：`go test ./...` 全量通过；`model/iprovider` 覆盖率 72.2%（门槛 70%）。集成测试侧确认：`UpdateProvider` 客户端封装（`integration-test/test-cases/implementation/common/api_client.go:723`）注释本就声明"fields left unset are preserved by the server"，唯一调用点 SC28 只覆盖 `instance_pool`，无"省略即清空"依赖。
+
+*文档生成日期：2026-09-09*

--- a/model/iprovider/provider.go
+++ b/model/iprovider/provider.go
@@ -510,6 +510,12 @@ func ValidateProviderParam(param *ProviderParam) error {
 		}
 	}
 
+	if param.TimeZone != nil {
+		if err := validateTimeZone(*param.TimeZone); err != nil {
+			return err
+		}
+	}
+
 	if err := validatePricingTiers(param.Tiers); err != nil {
 		return err
 	}

--- a/model/iprovider/provider_test.go
+++ b/model/iprovider/provider_test.go
@@ -276,6 +276,97 @@ func TestProviderManager_UpdateProvider(t *testing.T) {
 	})
 }
 
+func TestProviderManager_UpdateProvider_OmittedFieldsReachStoragerAsNil(t *testing.T) {
+	ctx := context.Background()
+
+	var captured *ProviderParam
+	store := &fakeProviderStorager{
+		fetchFn: func(ctx context.Context, filter *ProviderFilter) (*Provider, error) {
+			return &Provider{
+				Name:         "deepseek",
+				Models:       []string{"deepseek-chat"},
+				Keys:         []ProviderKey{{Name: "key-primary", Key: "sk-aaaaaaaaaaaa"}},
+				TimeZone:     "UTC",
+				InstancePool: []ProviderInstance{{Addr: "api.deepseek.com", Port: 443, Weight: 100}},
+			}, nil
+		},
+		updateFn: func(ctx context.Context, name string, param *ProviderParam) error {
+			captured = param
+			return nil
+		},
+	}
+	m := NewProviderManager(&fakeTxn{}, store)
+
+	// PATCH body only carries instance_pool/model_protocols (required by
+	// validation) plus a new description; all other fields are omitted.
+	param := &ProviderParam{
+		Name:           lib.PString("deepseek"),
+		Description:    lib.PString("new description"),
+		InstancePool:   []ProviderInstance{{Addr: "api.deepseek.com", Port: 443, Weight: 100}},
+		ModelProtocols: []string{"openai"},
+	}
+	err := m.UpdateProvider(ctx, "deepseek", param)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	// Omitted fields must reach the storager as nil so the DAO layer keeps
+	// the existing column values (partial update semantics).
+	assert.Nil(t, captured.ModelEndpoint)
+	assert.Nil(t, captured.Models)
+	assert.Nil(t, captured.Keys)
+	assert.Nil(t, captured.TimeZone)
+	assert.Nil(t, captured.Tiers)
+	// Provided fields are passed through.
+	require.NotNil(t, captured.Description)
+	assert.Equal(t, "new description", *captured.Description)
+	assert.NotEmpty(t, captured.InstancePool)
+	assert.NotEmpty(t, captured.ModelProtocols)
+}
+
+func TestProviderManager_UpdateProvider_ExplicitEmptyKeysTriggerHook(t *testing.T) {
+	ctx := context.Background()
+
+	var captured *ProviderParam
+	store := &fakeProviderStorager{
+		fetchFn: func(ctx context.Context, filter *ProviderFilter) (*Provider, error) {
+			return &Provider{
+				Name:           "deepseek",
+				Models:         []string{"deepseek-chat"},
+				Keys:           []ProviderKey{{Name: "key-primary", Key: "sk-aaaaaaaaaaaa"}},
+				InstancePool:   []ProviderInstance{{Addr: "api.deepseek.com", Port: 443, Weight: 100}},
+				ModelProtocols: []string{"openai"},
+			}, nil
+		},
+		updateFn: func(ctx context.Context, name string, param *ProviderParam) error {
+			captured = param
+			return nil
+		},
+	}
+	m := NewProviderManager(&fakeTxn{}, store)
+
+	hookCalled := 0
+	hook := func(ctx context.Context, oldProvider, newProvider *Provider) error {
+		hookCalled++
+		return nil
+	}
+
+	// Explicitly passing an empty key list is an intentional clear; the key
+	// ref checker hook must run, and the storager must receive a non-nil
+	// empty slice (not nil, which would mean "keep existing").
+	param := &ProviderParam{
+		Name:           lib.PString("deepseek"),
+		Keys:           []ProviderKey{},
+		InstancePool:   []ProviderInstance{{Addr: "api.deepseek.com", Port: 443, Weight: 100}},
+		ModelProtocols: []string{"openai"},
+	}
+	err := m.UpdateProvider(ctx, "deepseek", param, hook)
+	require.NoError(t, err)
+	assert.Equal(t, 1, hookCalled)
+	require.NotNil(t, captured)
+	require.NotNil(t, captured.Keys)
+	assert.Empty(t, captured.Keys)
+}
+
 func TestProviderManager_DeleteProvider(t *testing.T) {
 	ctx := context.Background()
 
@@ -588,6 +679,24 @@ func TestValidateProviderParam(t *testing.T) {
 		p := validProviderParam()
 		p.Keys = []ProviderKey{{Name: "k", Key: "a"}, {Name: "k", Key: "b"}}
 		require.Error(t, ValidateProviderParam(p))
+	})
+
+	t.Run("invalid time zone", func(t *testing.T) {
+		p := validProviderParam()
+		p.TimeZone = lib.PString("Not/AZone")
+		require.Error(t, ValidateProviderParam(p))
+	})
+
+	t.Run("valid time zone", func(t *testing.T) {
+		p := validProviderParam()
+		p.TimeZone = lib.PString("UTC")
+		require.NoError(t, ValidateProviderParam(p))
+	})
+
+	t.Run("nil time zone kept optional", func(t *testing.T) {
+		p := validProviderParam()
+		p.TimeZone = nil
+		require.NoError(t, ValidateProviderParam(p))
 	})
 }
 

--- a/storage/rdb/provider/provider.go
+++ b/storage/rdb/provider/provider.go
@@ -17,6 +17,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 
 	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
 	"github.com/rainway-ai-gateway/ai-gateway-api/model/iprovider"
@@ -57,7 +58,7 @@ func (s *RDBProviderStorager) UpdateProvider(ctx context.Context, name string, p
 		return err
 	}
 
-	data, err := toDAOParam(param)
+	data, err := toDAOParamForUpdate(param)
 	if err != nil {
 		return err
 	}
@@ -241,6 +242,71 @@ func fromDAO(one *dao.TProvider) *iprovider.Provider {
 		CreateTime:     createTime,
 		UpdateTime:     updateTime,
 	}
+}
+
+func toDAOParamForUpdate(param *iprovider.ProviderParam) (*dao.TProviderParam, error) {
+	if param == nil {
+		return nil, nil
+	}
+
+	modelEndpoint, err := marshalJSONPtr(param.ModelEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	models, err := marshalJSONPtr(param.Models)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := marshalJSONPtr(param.Keys)
+	if err != nil {
+		return nil, err
+	}
+	instancePool, err := marshalJSONPtr(param.InstancePool)
+	if err != nil {
+		return nil, err
+	}
+	modelProtocols, err := marshalJSONPtr(param.ModelProtocols)
+	if err != nil {
+		return nil, err
+	}
+	tiers, err := marshalJSONPtr(param.Tiers)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dao.TProviderParam{
+		Name:           param.Name,
+		Description:    param.Description,
+		ModelEndpoint:  modelEndpoint,
+		Models:         models,
+		Keys:           keys,
+		InstancePool:   instancePool,
+		ModelProtocols: modelProtocols,
+		TimeZone:       param.TimeZone,
+		Tiers:          tiers,
+	}, nil
+}
+
+// marshalJSONPtr returns nil for a nil interface, nil pointer, or nil slice,
+// so that the DAO layer's nil-skip keeps the existing column value on partial
+// updates. Explicitly provided values (including empty slices) are marshaled
+// normally.
+func marshalJSONPtr(v interface{}) (*string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface:
+		if rv.IsNil() {
+			return nil, nil
+		}
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return lib.PString(string(data)), nil
 }
 
 func marshalJSON(v interface{}) (*string, error) {

--- a/storage/rdb/provider/provider_test.go
+++ b/storage/rdb/provider/provider_test.go
@@ -1,0 +1,270 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/rainway-ai-gateway/ai-gateway-api/lib"
+	"github.com/rainway-ai-gateway/ai-gateway-api/model/iprovider"
+	"github.com/rainway-ai-gateway/ai-gateway-api/stateful"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestStorager(t *testing.T) *RDBProviderStorager {
+	// The DAO layer consults stateful.DefaultConfig when recording SQL.
+	if stateful.DefaultConfig == nil {
+		stateful.DefaultConfig = &stateful.Config{}
+	}
+
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+CREATE TABLE providers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  model_endpoint TEXT,
+  models TEXT,
+  api_keys TEXT,
+  instance_pool TEXT NOT NULL,
+  model_protocols TEXT NOT NULL,
+  time_zone TEXT NOT NULL DEFAULT 'Asia/Shanghai',
+  tiers TEXT,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (name)
+);`)
+	require.NoError(t, err)
+
+	factory := lib.DBContextFactory(func(ctx context.Context, ops ...*lib.Op) (*lib.DBContext, error) {
+		return lib.NewDBContext(ctx, db), nil
+	})
+
+	return NewRDBProviderStorager(factory)
+}
+
+func TestToDAOParamForUpdate_OmittedFieldsStayNil(t *testing.T) {
+	desc := "new description"
+	param := &iprovider.ProviderParam{
+		Name:        lib.PString("p1"),
+		Description: &desc,
+	}
+
+	data, err := toDAOParamForUpdate(param)
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	assert.Equal(t, "p1", *data.Name)
+	assert.Equal(t, desc, *data.Description)
+	// Omitted fields must stay nil so the DAO layer skips them and the
+	// existing column values are preserved (partial update semantics).
+	assert.Nil(t, data.ModelEndpoint)
+	assert.Nil(t, data.Models)
+	assert.Nil(t, data.Keys)
+	assert.Nil(t, data.InstancePool)
+	assert.Nil(t, data.ModelProtocols)
+	assert.Nil(t, data.TimeZone)
+	assert.Nil(t, data.Tiers)
+}
+
+func TestToDAOParamForUpdate_ExplicitEmptySlicesAreMarshaled(t *testing.T) {
+	tz := "UTC"
+	param := &iprovider.ProviderParam{
+		Name:           lib.PString("p1"),
+		Models:         []string{},
+		Keys:           []iprovider.ProviderKey{},
+		Tiers:          []iprovider.PricingTier{},
+		InstancePool:   []iprovider.ProviderInstance{{Addr: "10.0.0.1", Port: 9002, Weight: 100}},
+		ModelProtocols: []string{"openai"},
+		TimeZone:       &tz,
+	}
+
+	data, err := toDAOParamForUpdate(param)
+	require.NoError(t, err)
+
+	// Explicitly provided values (including empty slices) must be written,
+	// so callers can still clear a field by passing an empty array.
+	require.NotNil(t, data.Models)
+	assert.Equal(t, "[]", *data.Models)
+	require.NotNil(t, data.Keys)
+	assert.Equal(t, "[]", *data.Keys)
+	require.NotNil(t, data.Tiers)
+	assert.Equal(t, "[]", *data.Tiers)
+	require.NotNil(t, data.InstancePool)
+	require.NotNil(t, data.ModelProtocols)
+	require.NotNil(t, data.TimeZone)
+	assert.Equal(t, tz, *data.TimeZone)
+}
+
+func TestToDAOParam_CreatePathDefaultsUnchanged(t *testing.T) {
+	param := &iprovider.ProviderParam{
+		Name:           lib.PString("p1"),
+		InstancePool:   []iprovider.ProviderInstance{{Addr: "10.0.0.1", Port: 9002, Weight: 100}},
+		ModelProtocols: []string{"openai"},
+	}
+
+	data, err := toDAOParam(param)
+	require.NoError(t, err)
+
+	// Create path keeps filling defaults for omitted fields.
+	require.NotNil(t, data.ModelEndpoint)
+	assert.Contains(t, *data.ModelEndpoint, "/v1/models")
+	require.NotNil(t, data.Models)
+	assert.Equal(t, "[]", *data.Models)
+	require.NotNil(t, data.Keys)
+	assert.Equal(t, "[]", *data.Keys)
+	require.NotNil(t, data.TimeZone)
+	assert.Equal(t, "Asia/Shanghai", *data.TimeZone)
+	require.NotNil(t, data.Tiers)
+}
+
+func TestMarshalJSONPtr(t *testing.T) {
+	// nil interface
+	p, err := marshalJSONPtr(nil)
+	require.NoError(t, err)
+	assert.Nil(t, p)
+
+	// nil slice
+	p, err = marshalJSONPtr([]string(nil))
+	require.NoError(t, err)
+	assert.Nil(t, p)
+
+	// empty slice
+	p, err = marshalJSONPtr([]string{})
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, "[]", *p)
+
+	// non-empty slice
+	p, err = marshalJSONPtr([]string{"a"})
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, `["a"]`, *p)
+
+	// nil pointer
+	p, err = marshalJSONPtr((*iprovider.ProviderEndpoint)(nil))
+	require.NoError(t, err)
+	assert.Nil(t, p)
+
+	// non-nil pointer
+	p, err = marshalJSONPtr(&iprovider.ProviderEndpoint{Schema: "https", URI: "/v1/models"})
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Contains(t, *p, "/v1/models")
+}
+
+func TestRDBProviderStorager_UpdateProviderPartialUpdate(t *testing.T) {
+	ctx := context.Background()
+	s := setupTestStorager(t)
+
+	customTZ := "UTC"
+	_, err := s.CreateProvider(ctx, &iprovider.ProviderParam{
+		Name:           lib.PString("p1"),
+		Description:    lib.PString("original"),
+		ModelEndpoint:  &iprovider.ProviderEndpoint{Schema: "http", URI: "/custom/models"},
+		Models:         []string{"deepseek-chat"},
+		Keys:           []iprovider.ProviderKey{{Name: "k1", Key: "sk-abc"}},
+		InstancePool:   []iprovider.ProviderInstance{{Addr: "10.0.0.1", Port: 9002, Weight: 100}},
+		ModelProtocols: []string{"openai"},
+		TimeZone:       &customTZ,
+		Tiers: []iprovider.PricingTier{
+			{
+				Name:       "peak",
+				TimeRanges: []iprovider.TimeRange{{Weekdays: []int{1, 2, 3, 4, 5}, Start: "09:00", End: "18:00"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// PATCH with only description: every other field must keep its value.
+	require.NoError(t, s.UpdateProvider(ctx, "p1", &iprovider.ProviderParam{
+		Name:        lib.PString("p1"),
+		Description: lib.PString("updated"),
+	}))
+
+	one, err := s.FetchProvider(ctx, &iprovider.ProviderFilter{Name: lib.PString("p1")})
+	require.NoError(t, err)
+	require.NotNil(t, one)
+	assert.Equal(t, "updated", one.Description)
+	assert.Equal(t, "UTC", one.TimeZone)
+	assert.Equal(t, "http", one.ModelEndpoint.Schema)
+	assert.Equal(t, "/custom/models", one.ModelEndpoint.URI)
+	assert.Equal(t, []string{"deepseek-chat"}, one.Models)
+	require.Len(t, one.Keys, 1)
+	assert.Equal(t, "k1", one.Keys[0].Name)
+	require.Len(t, one.Tiers, 1)
+	assert.Equal(t, "peak", one.Tiers[0].Name)
+
+	// PATCH changing only time_zone: tiers and models keep their values.
+	london := "Europe/London"
+	require.NoError(t, s.UpdateProvider(ctx, "p1", &iprovider.ProviderParam{
+		Name:     lib.PString("p1"),
+		TimeZone: &london,
+	}))
+	one, err = s.FetchProvider(ctx, &iprovider.ProviderFilter{Name: lib.PString("p1")})
+	require.NoError(t, err)
+	assert.Equal(t, "Europe/London", one.TimeZone)
+	require.Len(t, one.Tiers, 1)
+	assert.Equal(t, []string{"deepseek-chat"}, one.Models)
+
+	// PATCH explicitly passing empty slices clears those fields.
+	require.NoError(t, s.UpdateProvider(ctx, "p1", &iprovider.ProviderParam{
+		Name:           lib.PString("p1"),
+		Models:         []string{},
+		Keys:           []iprovider.ProviderKey{},
+		Tiers:          []iprovider.PricingTier{},
+		InstancePool:   []iprovider.ProviderInstance{{Addr: "10.0.0.1", Port: 9002, Weight: 100}},
+		ModelProtocols: []string{"openai"},
+	}))
+	one, err = s.FetchProvider(ctx, &iprovider.ProviderFilter{Name: lib.PString("p1")})
+	require.NoError(t, err)
+	assert.Empty(t, one.Models)
+	assert.Empty(t, one.Keys)
+	assert.Empty(t, one.Tiers)
+	// Omitted fields keep their previous values.
+	assert.Equal(t, "Europe/London", one.TimeZone)
+	assert.Equal(t, "http", one.ModelEndpoint.Schema)
+}
+
+func TestRDBProviderStorager_CreateProviderDefaults(t *testing.T) {
+	ctx := context.Background()
+	s := setupTestStorager(t)
+
+	// Create without time_zone/models/keys: defaults must be applied.
+	_, err := s.CreateProvider(ctx, &iprovider.ProviderParam{
+		Name:           lib.PString("p1"),
+		InstancePool:   []iprovider.ProviderInstance{{Addr: "10.0.0.1", Port: 9002, Weight: 100}},
+		ModelProtocols: []string{"openai"},
+	})
+	require.NoError(t, err)
+
+	one, err := s.FetchProvider(ctx, &iprovider.ProviderFilter{Name: lib.PString("p1")})
+	require.NoError(t, err)
+	require.NotNil(t, one)
+	assert.Equal(t, "Asia/Shanghai", one.TimeZone)
+	assert.NotNil(t, one.ModelEndpoint)
+	assert.Equal(t, "https", one.ModelEndpoint.Schema)
+	assert.Empty(t, one.Models)
+	assert.Empty(t, one.Keys)
+	assert.Empty(t, one.Tiers)
+}

--- a/test/integration/tests/provider/design.md
+++ b/test/integration/tests/provider/design.md
@@ -18,7 +18,7 @@ Provider 与 Cluster 概念分离后：
 | PV-1 | 创建 Provider | POST | `/open-api/v1/providers` | 创建模型提供商 |
 | PV-2 | 查询 Provider 列表 | GET | `/open-api/v1/providers` | 未携带 `page`/`page_size` 时返回全部；携带时按分页返回；支持 `model_protocol` 过滤 |
 | PV-3 | 查询 Provider 详情 | GET | `/open-api/v1/providers/{provider_name}` | - |
-| PV-4 | 更新 Provider | PATCH | `/open-api/v1/providers/{provider_name}` | 全量替换 `keys`、`models` 等数组字段 |
+| PV-4 | 更新 Provider | PATCH | `/open-api/v1/providers/{provider_name}` | 部分更新：未提供的字段保留原值；显式提供的 `keys`、`models` 等数组字段按全量替换处理 |
 | PV-5 | 删除 Provider | DELETE | `/open-api/v1/providers/{provider_name}` | 删除前检查 cluster/model-price 引用 |
 | PV-6 | 触发模型发现 | POST | `/open-api/v1/providers/tools/discover-models` | 无状态工具接口，不绑定 Provider |
 | PV-7 | 获取所有 Provider 名称 | GET | `/open-api/v1/providers/actions/get-provider-names` | 返回全量 provider 名称列表 |
@@ -558,7 +558,7 @@ provider/
 | 接口名称 | 更新 Provider |
 | 方法 | PATCH |
 | 路径 | `/open-api/v1/providers/{provider_name}` |
-| 说明 | `keys`、`models` 等数组字段按全量替换处理 |
+| 说明 | 部分更新语义：请求体未提供的字段（`description`、`model_endpoint`、`models`、`keys`、`time_zone`、`tiers` 等）保留原值；显式提供的数组字段按全量替换处理 |
 
 ### 9.2 请求参数
 
@@ -575,6 +575,10 @@ provider/
 | PV-4-005 | 请求体不包含 `name` | 200，返回的 `name` 与 URI 一致 |
 | PV-4-005a | 更新时 instance_pool 不再包含 name 字段 | 200，返回的 instance 中无 `name` 字段 |
 | PV-4-006 | 请求体包含 `name` | 422 |
+| PV-4-007 | 省略字段保留原值（issue #147） | 200，`description` 更新成功，未提供的 `time_zone`/`tiers`/`models`/`keys`/`model_endpoint` 全部保留原值 |
+| PV-4-008 | 只更新 `time_zone` | 200，`time_zone` 更新成功，其余字段（含 `tiers`）保留原值 |
+| PV-4-009 | 显式空数组清空字段 | 200，显式传入的 `models`/`keys`/`tiers` 被清空，未提供的 `time_zone`/`description`/`model_endpoint` 保留原值 |
+| PV-4-010 | 非法 `time_zone` | 422，且已存储的 `time_zone` 不被修改 |
 
 ### 9.4 测试场景详细设计
 
@@ -688,6 +692,30 @@ provider/
 ##### 预期返回结果
 
 **ErrNum**：422
+
+#### 9.4.5 PV-4-007 ~ PV-4-010：部分更新语义（issue #147）
+
+##### 设计思路
+
+验证 PATCH 为部分更新语义：请求体未提供的字段保留原值，显式提供的字段（含空数组）正常更新。回归 issue #147——修复前省略 `time_zone`/`tiers`/`models`/`keys`/`model_endpoint` 会被静默覆盖为默认值或清空。
+
+测试前置：创建 Provider 时设置自定义 `time_zone=UTC`、`model_endpoint={http, /custom/models}`、`models=["deepseek-chat","deepseek-coder"]`，并通过 `PUT /providers/{name}/pricing-tiers` 设置 peak 时段模板；`keys` 使用创建时的默认两个 Key。
+
+##### 执行步骤
+
+1. **PV-4-007**：PATCH 请求体只含 `description`（另附校验必填的 `instance_pool`、`model_protocols`），随后 GET 详情，断言 `time_zone`/`tiers`/`models`/`keys`/`model_endpoint` 与前置值一致。
+2. **PV-4-008**：PATCH 请求体只含 `time_zone=Europe/London`，断言更新成功且 `description`、`tiers`、`keys`、`model_endpoint` 保留。
+3. **PV-4-009**：PATCH 请求体显式传 `models=[]`、`keys=[]`、`tiers=[]`，断言三者被清空，而省略的 `time_zone`/`description`/`model_endpoint` 保留。
+4. **PV-4-010**：PATCH 请求体传非法 `time_zone=Not/AZone`，断言返回 422，且 GET 详情确认存储值未被修改。
+
+##### 预期返回结果
+
+| 用例 | 预期 |
+|------|------|
+| PV-4-007 | 200，未提供的五项字段全部保留原值 |
+| PV-4-008 | 200，`time_zone` 更新为 `Europe/London`，其余字段保留 |
+| PV-4-009 | 200，显式空数组字段被清空，省略字段保留 |
+| PV-4-010 | 422，存储的 `time_zone` 不被修改 |
 
 
 ## 10. Provider instance_pool 同步到 Inner API

--- a/test/integration/tests/provider/partial_update/partial_update_test.go
+++ b/test/integration/tests/provider/partial_update/partial_update_test.go
@@ -1,0 +1,174 @@
+// Copyright(c) 2026 The Rainway AI Gateway (壬远AI网关) Authors.
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package partial_update_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/rainway-ai-gateway/ai-gateway-api/integration/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var sm *testutil.ServerManager
+
+func TestMain(m *testing.M) {
+	var err error
+	sm, err = testutil.StartServer()
+	if err != nil {
+		panic("failed to start server: " + err.Error())
+	}
+	code := m.Run()
+	sm.Shutdown()
+	os.Exit(code)
+}
+
+// requiredPatchBody carries the fields that PATCH validation requires on
+// every request; individual cases add the fields under test on top of it.
+func requiredPatchBody() map[string]interface{} {
+	return map[string]interface{}{
+		"instance_pool":   []interface{}{map[string]interface{}{"addr": "10.0.0.1", "weight": 100, "port": 8080}},
+		"model_protocols": []string{"openai"},
+	}
+}
+
+func fetchProviderData(t *testing.T, providerName string) map[string]interface{} {
+	t.Helper()
+	resp, err := testutil.GetClient().Get("/open-api/v1/providers/" + providerName)
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, resp)
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(resp.Data, &data))
+	return data
+}
+
+func TestProvider_PartialUpdate(t *testing.T) {
+	providerName := testutil.UniqueProviderName()
+	// Create with customized values for every field that PATCH must preserve
+	// when omitted: time_zone / tiers / models / keys / model_endpoint.
+	_, err := testutil.CreateProvider(providerName, map[string]interface{}{
+		"description": "partial-update baseline",
+		"model_endpoint": map[string]interface{}{
+			"schema": "http",
+			"uri":    "/custom/models",
+		},
+		"models":   []string{"deepseek-chat", "deepseek-coder"},
+		"time_zone": "UTC",
+	})
+	if err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+	t.Cleanup(func() {
+		testutil.DeleteProvider(providerName)
+	})
+
+	// Set peak pricing tiers via the dedicated endpoint (issue #147 repro path).
+	resp, err := testutil.UpdatePricingTiers(providerName, map[string]interface{}{
+		"time_zone": "UTC",
+		"tiers": []interface{}{
+			map[string]interface{}{
+				"name": "peak",
+				"time_ranges": []interface{}{
+					map[string]interface{}{
+						"weekdays": []int{1, 2, 3, 4, 5},
+						"start":    "09:00",
+						"end":      "18:00",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	testutil.AssertSuccess(t, resp)
+
+	t.Run("PV-4-007 省略字段保留原值", func(t *testing.T) {
+		body := requiredPatchBody()
+		body["description"] = "只改 description"
+		resp, err := testutil.GetClient().Patch("/open-api/v1/providers/"+providerName, body)
+		require.NoError(t, err)
+		testutil.AssertSuccess(t, resp)
+		testutil.AssertDataFieldEquals(t, resp, "description", "只改 description")
+
+		// The five fields omitted from the PATCH body must keep their values.
+		data := fetchProviderData(t, providerName)
+		assert.Equal(t, "UTC", data["time_zone"])
+		tiers, _ := data["tiers"].([]interface{})
+		require.Len(t, tiers, 1)
+		tier, _ := tiers[0].(map[string]interface{})
+		assert.Equal(t, "peak", tier["name"])
+		models, _ := data["models"].([]interface{})
+		assert.Equal(t, []interface{}{"deepseek-chat", "deepseek-coder"}, models)
+		keys, _ := data["keys"].([]interface{})
+		require.Len(t, keys, 2)
+		endpoint, _ := data["model_endpoint"].(map[string]interface{})
+		assert.Equal(t, "http", endpoint["schema"])
+		assert.Equal(t, "/custom/models", endpoint["uri"])
+	})
+
+	t.Run("PV-4-008 只更新 time_zone 其余字段保留", func(t *testing.T) {
+		body := requiredPatchBody()
+		body["time_zone"] = "Europe/London"
+		resp, err := testutil.GetClient().Patch("/open-api/v1/providers/"+providerName, body)
+		require.NoError(t, err)
+		testutil.AssertSuccess(t, resp)
+		testutil.AssertDataFieldEquals(t, resp, "time_zone", "Europe/London")
+
+		data := fetchProviderData(t, providerName)
+		assert.Equal(t, "只改 description", data["description"])
+		tiers, _ := data["tiers"].([]interface{})
+		require.Len(t, tiers, 1)
+		keys, _ := data["keys"].([]interface{})
+		assert.Len(t, keys, 2)
+		endpoint, _ := data["model_endpoint"].(map[string]interface{})
+		assert.Equal(t, "/custom/models", endpoint["uri"])
+	})
+
+	t.Run("PV-4-009 显式空数组清空字段", func(t *testing.T) {
+		body := requiredPatchBody()
+		body["models"] = []string{}
+		body["keys"] = []interface{}{}
+		body["tiers"] = []interface{}{}
+		resp, err := testutil.GetClient().Patch("/open-api/v1/providers/"+providerName, body)
+		require.NoError(t, err)
+		testutil.AssertSuccess(t, resp)
+
+		data := fetchProviderData(t, providerName)
+		models, _ := data["models"].([]interface{})
+		assert.Empty(t, models)
+		keys, _ := data["keys"].([]interface{})
+		assert.Empty(t, keys)
+		tiers, _ := data["tiers"].([]interface{})
+		assert.Empty(t, tiers)
+		// Fields omitted from this PATCH keep their previous values.
+		assert.Equal(t, "Europe/London", data["time_zone"])
+		assert.Equal(t, "只改 description", data["description"])
+		endpoint, _ := data["model_endpoint"].(map[string]interface{})
+		assert.Equal(t, "/custom/models", endpoint["uri"])
+	})
+
+	t.Run("PV-4-010 非法 time_zone", func(t *testing.T) {
+		body := requiredPatchBody()
+		body["time_zone"] = "Not/AZone"
+		resp, err := testutil.GetClient().Patch("/open-api/v1/providers/"+providerName, body)
+		require.NoError(t, err)
+		testutil.AssertErrCode(t, resp, 422)
+
+		// The rejected update must not have changed the stored value.
+		data := fetchProviderData(t, providerName)
+		assert.Equal(t, "Europe/London", data["time_zone"])
+	})
+}


### PR DESCRIPTION
Fixes rainway-ai-gateway/ai-gateway-api#147

PATCH /providers/{provider_name} 省略 time_zone/tiers/models/keys/ model_endpoint 时，这些字段会被 toDAOParam 内的 FillDefaults 与 marshalJSON 抹平为非 nil 默认值，绕过 DAO 层 nil-skip，导致原值被
静默覆盖。

- storage 层拆分 create/update 转换路径：新增 toDAOParamForUpdate （不调用 FillDefaults）与 marshalJSONPtr（nil 指针/切片返回 nil）， 省略字段不进 SET 子句，保留列原值；Create 默认值语义不变
- ValidateProviderParam 补充 time_zone 合法性校验（省略仍放行）
- storager/manager 单测 + test/ 集成测试 PV-4-007~PV-4-010
- providers.md §2.4 与 provider/design.md 明确部分更新语义